### PR TITLE
Improve core package documentation and tests

### DIFF
--- a/packages/core/AGENT_NOTES.md
+++ b/packages/core/AGENT_NOTES.md
@@ -56,6 +56,9 @@
 - Тесты: `poetry run pytest -q`
 
 ## Changelog (for agents)
+- 2025-02-15 · ChatGPT — Добавлен README пакета, исправлен модульный docstring
+  моста событий, расширены тестовые docstring'и и обновлено описание в
+  `pyproject.toml`.
 - 2025-02-14 · ChatGPT — Уточнены docstring’и валидаторов, добавлен модульный
   docstring для тестов; функциональное поведение не изменено.
 - 2025-10-02 · ChatGPT — Согласованы поля с beta-веткой: статусы `INIT→DEAD`, `StartUrlWait`,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,77 @@
+# camou-core
+
+Shared contract models and developer utilities for the Ghost Browsers stack.
+The package is consumed by the Runner, Gateway, VNC Gateway, and operator UI
+services to guarantee a consistent representation of runner metadata, session
+state, and lifecycle events.
+
+## Contents
+- **Pydantic models**: immutable schemas covering runner metadata, session
+  lifecycle, and session events with strong validation rules (see
+  [`core/models.py`](core/models.py)).
+- **Event bridge abstractions**: an abstract interface for broadcasting session
+  events and a local in-memory implementation for tests and development (see
+  [`core/websocket_bridge.py`](core/websocket_bridge.py)).
+
+## Key invariants
+- `Session.last_seen_at >= Session.created_at`, `Session.ended_at` may only
+  increase.
+- VNC tokens expire in ≤ 300 seconds and must be supplied together with a TTL.
+- Runner availability is capped by `total_slots` and OFFLINE runners cannot be
+  reported as healthy.
+- Proxy definitions require at least one URL; VNC descriptors require a HTTP or
+  WebSocket endpoint.
+
+The wider architectural context and token lifetime guarantees are described in
+[`docs/architecture.md`](../docs/architecture.md) and
+[`docs/configuration.md`](../docs/configuration.md).
+
+## Installation
+```bash
+cd packages/core
+poetry install --no-root
+```
+
+## Usage
+```python
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from core import (
+    InMemorySessionEventBridge,
+    Runner,
+    Session,
+    SessionEvent,
+    SessionStatus,
+)
+
+runner = Runner(id="runner-1", base_url="http://runner:8080", total_slots=4)
+bridge = InMemorySessionEventBridge()
+session = Session(
+    id=uuid4(),
+    runner_id=runner.id,
+    status=SessionStatus.INIT,
+    created_at=datetime.now(tz=timezone.utc),
+    last_seen_at=datetime.now(tz=timezone.utc),
+    headless=False,
+    idle_ttl_seconds=300,
+)
+
+async def consume() -> None:
+    async for event in await bridge.subscribe(replay_latest=True):
+        ...
+
+async def produce() -> None:
+    await bridge.publish(
+        SessionEvent(session=session, occurred_at=datetime.now(tz=timezone.utc))
+    )
+```
+
+## Testing
+```bash
+poetry run ruff check .
+poetry run pytest -q
+```
+
+See [`AGENT_NOTES.md`](AGENT_NOTES.md) for additional constraints, decisions,
+and known gaps.

--- a/packages/core/core/websocket_bridge.py
+++ b/packages/core/core/websocket_bridge.py
@@ -1,9 +1,17 @@
-"""Asynchronous utilities for propagating session events via WebSockets.
+"""Bridging asynchronous session events between runners and UI clients.
 
-The real gateway will bridge events from runners to UI subscribers using
-Redis streams or another broker. This module defines the abstract API
-and provides an in-memory implementation that is suitable for unit tests
-and local development.
+The production gateway persists events published by runners to a durable
+transport (Redis or Kafka) and fans them out to UI subscribers.  The
+abstractions in this module capture that contract while keeping the core
+package independent from infrastructure choices.  An in-memory
+implementation is shipped for unit tests and local development.
+
+Example:
+    >>> bridge = InMemorySessionEventBridge()
+    >>> async def consumer() -> None:
+    ...     async for event in await bridge.subscribe(replay_latest=True):
+    ...         print(event.session.id)
+    >>> # Producers publish events that are delivered to all subscribers.
 """
 
 from __future__ import annotations

--- a/packages/core/pyproject.toml
+++ b/packages/core/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "camou-core"
 version = "0.1.0"
-description = "Shared models and utilities (to be implemented)"
+description = "Shared Camoufox contract models and developer utilities"
 packages = [{ include = "core" }]
 
 [tool.poetry.dependencies]

--- a/packages/core/tests/test_models.py
+++ b/packages/core/tests/test_models.py
@@ -3,7 +3,9 @@
 The suite validates structural invariants, serialisation behaviour and
 the in-memory WebSocket bridge used for local development. Each test
 focuses on a specific contract to surface regressions quickly for
-services that depend on the core package.
+services that depend on the core package. The docstrings describe
+expected semantics so that failing tests act as executable documentation
+for downstream services.
 """
 
 from __future__ import annotations
@@ -29,7 +31,20 @@ from pydantic import ValidationError
 
 
 def build_session(**overrides) -> Session:
-    """Helper to build a session with sensible defaults for tests."""
+    """Construct a :class:`Session` instance with predictable defaults.
+
+    Args:
+        **overrides: Optional field overrides to apply to the default
+            payload.  Most tests supply timestamps or lifecycle states.
+
+    Returns:
+        Session: Fully-populated session object ready for assertions.
+
+    Example:
+        >>> session = build_session(status=SessionStatus.READY)
+        >>> session.status is SessionStatus.READY
+        True
+    """
 
     defaults = dict(overrides)
     now = datetime.now(tz=timezone.utc)


### PR DESCRIPTION
## Summary
- document the core package with a README and refreshed agent notes
- tighten websocket bridge documentation to describe the replay contract
- enrich test helpers with structured docstrings and align packaging metadata

## Testing
- poetry run pytest -q

## Security
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dccdb8dafc832a9d21020c3c40f978