### PR TITLE
feat(runner): add in-memory session manager and FastAPI app

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -1,2 +1,41 @@
 # AGENT_NOTES — runner
-(Заполнить после первой реализации.)
+
+## Overview
+FastAPI-based service that manages browser sessions for Ghost Browsers. Provides in-memory lifecycle management, publishes session events, and exposes minimal HTTP endpoints for orchestration and health checks.
+
+## Interfaces
+- **HTTP**
+  - `GET /health` — returns `{status, runner_id, camoufox_path}` for readiness probes.
+  - `POST /sessions` — accepts `SessionCreatePayload`, returns created `core.Session` snapshot.
+  - `PATCH /sessions/{id}` — accepts `SessionUpdatePayload`, merges labels/metadata, returns updated `core.Session`.
+  - `DELETE /sessions/{id}` — marks session as `DEAD`, returns terminal snapshot.
+- **Event transport**
+  - `SessionEventPublisher.publish(SessionEvent)` — protocol for pushing lifecycle events downstream. Default implementation stores events in memory (`InMemorySessionEventPublisher`) but can be swapped for HTTP/SSE bridges via `CallbackSessionEventPublisher`.
+
+## Data & Models
+- Uses `core.Session`, `SessionEvent`, `SessionProxySettings`, `SessionVncDetails`, and related enums.
+- Local payload models (`SessionCreatePayload`, `SessionUpdatePayload`) act as request DTOs before conversion into immutable core models.
+- Sessions are keyed by UUID and persisted in-memory; timestamps sourced from an injectable clock (UTC aware).
+
+## Decisions
+- **In-memory publisher stub**: We expose a `SessionEventPublisher` protocol with an in-memory default to unblock tests until a real transport (HTTP/SSE) is integrated.
+- **Automatic VNC stubs**: When sessions are non-headless and no explicit VNC payload is provided, the manager synthesises `SessionVncDetails` using configurable base URLs and bounded TTL (<=300s) to respect `SessionVncDetails` invariants.
+- **Environment-driven settings**: `RunnerSettings.from_env` centralises configuration parsing without extra dependencies, easing future extension.
+
+## Constraints & Invariants
+- `RunnerSettings.vnc_token_ttl_seconds` capped at 300 seconds to align with `SessionVncDetails` validation.
+- `SessionManager` always updates `last_seen_at` on mutations to ensure monotonic timestamps.
+- `SessionEvent` timestamps are UTC and emitted for every state change; terminal events require `SessionStatus.DEAD`.
+- Session mutations occur under an `anyio.Lock` to avoid race conditions in async contexts.
+
+## Known Gaps / TODO
+- [ ] Replace in-memory publisher with HTTP/SSE integration towards Gateway when endpoint contract is defined.
+- [ ] Enrich `/health` with slot/VNC diagnostics once browser integration lands.
+
+## How to Test
+- `poetry install --no-root`
+- `poetry run pytest -q` (anyio-powered unit tests)
+- `poetry run ruff check .`
+
+## Changelog (for agents)
+- 2024-09-21 · OpenAI ChatGPT · Initial FastAPI skeleton, in-memory session manager with event publishing, unit tests, and documentation update.

--- a/services/runner/app/__init__.py
+++ b/services/runner/app/__init__.py
@@ -1,0 +1,3 @@
+"""Application package for the Runner service."""
+
+__all__ = []

--- a/services/runner/app/config/__init__.py
+++ b/services/runner/app/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuration helpers for the Runner service."""
+
+from .settings import RunnerSettings
+
+__all__ = ["RunnerSettings"]

--- a/services/runner/app/config/settings.py
+++ b/services/runner/app/config/settings.py
@@ -1,0 +1,73 @@
+"""Runtime configuration model for the Runner service."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PositiveInt
+
+
+class RunnerSettings(BaseModel):
+    """Typed view over environment-driven runner configuration.
+
+    The settings object captures values that influence how the runner allocates
+    sessions and emits events. ``from_env`` reads recognised environment
+    variables and applies type validation, making it safe to inject into
+    FastAPI dependencies and background components.
+
+    Attributes:
+        runner_id: Identifier advertised to the gateway/UI for every session.
+        camoufox_path: Absolute path to the Camoufox binary.
+        event_endpoint: Optional HTTP(S) endpoint used by the event publisher
+            stub. When absent, events are kept in-memory.
+        vnc_http_base_url: Base URL for generating human-facing VNC previews.
+        vnc_ws_base_url: Base URL for generating WebSocket control endpoints.
+        vnc_token_ttl_seconds: Time-to-live applied to generated VNC tokens.
+
+    Example:
+        >>> settings = RunnerSettings.from_env({"RUNNER_ID": "runner-1"})
+        >>> settings.runner_id
+        'runner-1'
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    runner_id: str = Field(default="runner-local", min_length=1)
+    camoufox_path: Path = Field(default=Path("/usr/bin/camoufox"))
+    event_endpoint: AnyUrl | None = Field(default=None)
+    vnc_http_base_url: AnyUrl = Field(default="http://127.0.0.1:8060/vnc")
+    vnc_ws_base_url: AnyUrl = Field(default="ws://127.0.0.1:8060/vnc")
+    vnc_token_ttl_seconds: PositiveInt = Field(default=120, le=300)
+
+    @classmethod
+    def from_env(cls, environ: dict[str, str] | None = None) -> "RunnerSettings":
+        """Load settings from the provided environment mapping.
+
+        Args:
+            environ: Mapping resembling :data:`os.environ`. When ``None`` the
+                real process environment is used.
+
+        Returns:
+            RunnerSettings: Parsed and validated settings instance.
+        """
+
+        source: dict[str, Any] = {}
+        env = os.environ if environ is None else environ
+        if "RUNNER_ID" in env:
+            source["runner_id"] = env["RUNNER_ID"]
+        if "CAMOUFOX_PATH" in env:
+            source["camoufox_path"] = Path(env["CAMOUFOX_PATH"])
+        if "EVENT_ENDPOINT" in env:
+            source["event_endpoint"] = env["EVENT_ENDPOINT"]
+        if "VNC_HTTP_BASE_URL" in env:
+            source["vnc_http_base_url"] = env["VNC_HTTP_BASE_URL"]
+        if "VNC_WS_BASE_URL" in env:
+            source["vnc_ws_base_url"] = env["VNC_WS_BASE_URL"]
+        if "VNC_TOKEN_TTL_SECONDS" in env:
+            source["vnc_token_ttl_seconds"] = int(env["VNC_TOKEN_TTL_SECONDS"])
+        return cls.model_validate(source)
+
+
+__all__ = ["RunnerSettings"]

--- a/services/runner/app/dependencies/__init__.py
+++ b/services/runner/app/dependencies/__init__.py
@@ -1,0 +1,13 @@
+"""Dependency providers for FastAPI endpoints."""
+
+from .session_manager import (
+    get_event_publisher,
+    get_runner_settings,
+    get_session_manager,
+)
+
+__all__ = [
+    "get_event_publisher",
+    "get_runner_settings",
+    "get_session_manager",
+]

--- a/services/runner/app/dependencies/session_manager.py
+++ b/services/runner/app/dependencies/session_manager.py
@@ -1,0 +1,37 @@
+"""Dependency wiring for the session manager and publishers."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from ..config import RunnerSettings
+from ..events import InMemorySessionEventPublisher, SessionEventPublisher
+from ..session_manager import SessionManager
+
+
+@lru_cache
+def get_runner_settings() -> RunnerSettings:
+    """Return cached :class:`RunnerSettings` parsed from the environment."""
+
+    return RunnerSettings.from_env()
+
+
+@lru_cache
+def get_event_publisher() -> SessionEventPublisher:
+    """Return the default in-memory session event publisher."""
+
+    return InMemorySessionEventPublisher()
+
+
+@lru_cache
+def get_session_manager() -> SessionManager:
+    """Return a singleton :class:`SessionManager` wired with default dependencies."""
+
+    return SessionManager(get_runner_settings(), get_event_publisher())
+
+
+__all__ = [
+    "get_event_publisher",
+    "get_runner_settings",
+    "get_session_manager",
+]

--- a/services/runner/app/events.py
+++ b/services/runner/app/events.py
@@ -1,0 +1,70 @@
+"""Session event transport abstraction for the runner service."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+import anyio
+from core.models import SessionEvent
+
+
+class SessionEventPublisher(Protocol):
+    """Protocol implemented by session event transports."""
+
+    async def publish(self, event: SessionEvent) -> None:
+        """Persist or forward a session lifecycle event."""
+
+
+class InMemorySessionEventPublisher:
+    """Store session events in memory for inspection during tests.
+
+    The publisher acts as the default transport for local development and unit
+    tests. Events are appended to an internal list protected by an
+    :class:`anyio.Lock`, ensuring deterministic order even under concurrent
+    access. Consumers can call :meth:`drain` to atomically snapshot the stored
+    events.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[SessionEvent] = []
+        self._lock = anyio.Lock()
+
+    async def publish(self, event: SessionEvent) -> None:
+        """Append ``event`` to the in-memory buffer."""
+
+        async with self._lock:
+            self._events.append(event)
+
+    async def drain(self) -> list[SessionEvent]:
+        """Return and clear the buffered events in FIFO order."""
+
+        async with self._lock:
+            drained = list(self._events)
+            self._events.clear()
+            return drained
+
+
+class CallbackSessionEventPublisher:
+    """Proxy session events to an arbitrary asynchronous callback.
+
+    The helper is used by higher layers (for example SSE broadcasters or HTTP
+    webhooks) to bridge the runner-facing event interface with existing
+    infrastructure. The callback is awaited for each event, propagating
+    exceptions back to the caller so that failures surface in tests.
+    """
+
+    def __init__(self, callback: Callable[[SessionEvent], Awaitable[None]]) -> None:
+        self._callback = callback
+
+    async def publish(self, event: SessionEvent) -> None:
+        """Forward ``event`` to the configured callback."""
+
+        await self._callback(event)
+
+
+__all__ = [
+    "CallbackSessionEventPublisher",
+    "InMemorySessionEventPublisher",
+    "SessionEventPublisher",
+]

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -1,0 +1,85 @@
+"""FastAPI entrypoint for the Runner service."""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+
+from core.models import Session
+from fastapi import Depends, FastAPI, HTTPException, status
+
+from .config import RunnerSettings
+from .dependencies import get_runner_settings, get_session_manager
+from .session_manager import (
+    SessionCreatePayload,
+    SessionManager,
+    SessionNotFoundError,
+    SessionUpdatePayload,
+)
+
+app = FastAPI(title="Ghost Browsers Runner", version="0.1.0")
+
+RunnerSettingsDep = Annotated[RunnerSettings, Depends(get_runner_settings)]
+SessionManagerDep = Annotated[SessionManager, Depends(get_session_manager)]
+
+
+@app.get("/health", summary="Runner health probe")
+async def health(settings: RunnerSettingsDep) -> dict[str, str]:
+    """Return a minimal health payload consumed by gateways and tests."""
+
+    return {
+        "status": "ok",
+        "runner_id": settings.runner_id,
+        "camoufox_path": str(settings.camoufox_path),
+    }
+
+
+@app.post(
+    "/sessions",
+    response_model=Session,
+    status_code=status.HTTP_201_CREATED,
+    summary="Create a session",
+)
+async def create_session(
+    payload: SessionCreatePayload,
+    manager: SessionManagerDep,
+) -> Session:
+    """Create a session and emit a ``session.created`` event."""
+
+    return await manager.create_session(payload)
+
+
+@app.patch("/sessions/{session_id}", response_model=Session, summary="Update a session")
+async def update_session(
+    session_id: UUID,
+    payload: SessionUpdatePayload,
+    manager: SessionManagerDep,
+) -> Session:
+    """Apply a partial update to an existing session."""
+
+    try:
+        return await manager.update_session(session_id, payload)
+    except SessionNotFoundError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="session not found",
+        ) from exc
+
+
+@app.delete("/sessions/{session_id}", response_model=Session, summary="Terminate a session")
+async def delete_session(
+    session_id: UUID,
+    manager: SessionManagerDep,
+) -> Session:
+    """Terminate the target session and emit a ``session.ended`` event."""
+
+    try:
+        return await manager.end_session(session_id)
+    except SessionNotFoundError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="session not found",
+        ) from exc
+
+
+__all__ = ["app"]

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -1,0 +1,232 @@
+"""In-memory session lifecycle manager for the runner service."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+import anyio
+from core.models import (
+    Session,
+    SessionEvent,
+    SessionEventType,
+    SessionProxySettings,
+    SessionStatus,
+    SessionVncDetails,
+    StartUrlWait,
+)
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PositiveInt
+
+from .config import RunnerSettings
+from .events import SessionEventPublisher
+
+
+class SessionCreatePayload(BaseModel):
+    """Input payload accepted by :class:`SessionManager.create_session`.
+
+    Attributes mirror :class:`core.models.Session` fields except for ``id`` and
+    ``runner_id`` which are derived by the manager. Providing a ``vnc`` payload
+    is optional; when omitted the manager constructs a stub value based on
+    :class:`RunnerSettings`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: SessionStatus = Field(default=SessionStatus.INIT)
+    headless: bool = Field(default=False)
+    idle_ttl_seconds: PositiveInt = Field(default=300, ge=30, le=3600)
+    start_url: AnyUrl | None = Field(default=None)
+    start_url_wait: StartUrlWait = Field(default=StartUrlWait.LOAD)
+    browser: str = Field(default="camoufox", min_length=1)
+    labels: dict[str, str] = Field(default_factory=dict)
+    ws_endpoint: str | None = Field(default=None)
+    proxy: SessionProxySettings | None = Field(default=None)
+    vnc: SessionVncDetails | None = Field(default=None)
+    vnc_enabled: bool | None = Field(default=None)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class SessionUpdatePayload(BaseModel):
+    """Partial update applied to an existing session."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    status: SessionStatus | None = Field(default=None)
+    last_seen_at: datetime | None = Field(default=None)
+    ended_at: datetime | None = Field(default=None)
+    headless: bool | None = Field(default=None)
+    idle_ttl_seconds: PositiveInt | None = Field(default=None, ge=30, le=3600)
+    start_url: AnyUrl | None = Field(default=None)
+    start_url_wait: StartUrlWait | None = Field(default=None)
+    browser: str | None = Field(default=None, min_length=1)
+    labels: dict[str, str] | None = Field(default=None)
+    ws_endpoint: str | None = Field(default=None)
+    proxy: SessionProxySettings | None = Field(default=None)
+    vnc: SessionVncDetails | None = Field(default=None)
+    vnc_enabled: bool | None = Field(default=None)
+    metadata: dict[str, Any] | None = Field(default=None)
+    reason: str | None = Field(default=None)
+
+
+class SessionNotFoundError(KeyError):
+    """Raised when attempting to operate on an unknown session identifier."""
+
+
+class SessionManager:
+    """Manage session lifecycle and publish events for downstream consumers."""
+
+    def __init__(
+        self,
+        settings: RunnerSettings,
+        event_publisher: SessionEventPublisher,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._settings = settings
+        self._publisher = event_publisher
+        self._clock = clock or (lambda: datetime.now(UTC))
+        self._sessions: dict[UUID, Session] = {}
+        self._lock = anyio.Lock()
+
+    async def create_session(self, payload: SessionCreatePayload) -> Session:
+        """Create, persist, and broadcast a new session object."""
+
+        async with self._lock:
+            session_id = uuid4()
+            now = self._clock()
+            vnc_details = self._resolve_vnc(payload, session_id)
+            vnc_enabled = (
+                payload.vnc_enabled
+                if payload.vnc_enabled is not None
+                else (vnc_details is not None and not payload.headless)
+            )
+            session = Session(
+                id=session_id,
+                runner_id=self._settings.runner_id,
+                status=payload.status,
+                created_at=now,
+                last_seen_at=now,
+                headless=payload.headless,
+                idle_ttl_seconds=payload.idle_ttl_seconds,
+                start_url=payload.start_url,
+                start_url_wait=payload.start_url_wait,
+                browser=payload.browser,
+                labels=payload.labels,
+                ws_endpoint=payload.ws_endpoint,
+                proxy=payload.proxy,
+                vnc=vnc_details,
+                vnc_enabled=vnc_enabled,
+                metadata=payload.metadata,
+            )
+            self._sessions[session_id] = session
+            await self._publish(session, SessionEventType.CREATED, reason=None)
+            return session
+
+    async def update_session(self, session_id: UUID, payload: SessionUpdatePayload) -> Session:
+        """Apply a partial update to a stored session and broadcast the change."""
+
+        async with self._lock:
+            if session_id not in self._sessions:
+                raise SessionNotFoundError(session_id)
+            existing = self._sessions[session_id]
+            update_data = payload.model_dump(exclude_unset=True)
+            reason = update_data.pop("reason", None)
+            merged_labels = update_data.pop("labels", None)
+            merged_metadata = update_data.pop("metadata", None)
+            if "last_seen_at" not in update_data:
+                update_data["last_seen_at"] = self._clock()
+            if (
+                update_data.get("status") is SessionStatus.DEAD
+                and update_data.get("ended_at") is None
+            ):
+                update_data["ended_at"] = self._clock()
+            if merged_labels is not None:
+                update_data["labels"] = {**existing.labels, **merged_labels}
+            if merged_metadata is not None:
+                update_data["metadata"] = {**existing.metadata, **merged_metadata}
+            session = existing.model_copy(update=update_data, deep=True)
+            self._sessions[session_id] = session
+            event_type = (
+                SessionEventType.ENDED
+                if session.status is SessionStatus.DEAD
+                else SessionEventType.UPDATED
+            )
+            await self._publish(session, event_type, reason=reason)
+            return session
+
+    async def end_session(
+        self,
+        session_id: UUID,
+        *,
+        reason: str | None = None,
+        ended_at: datetime | None = None,
+    ) -> Session:
+        """Mark a session as terminated and emit a terminal event."""
+
+        payload = SessionUpdatePayload(
+            status=SessionStatus.DEAD,
+            ended_at=ended_at,
+            vnc_enabled=False,
+            reason=reason,
+            vnc=None,
+        )
+        return await self.update_session(session_id, payload)
+
+    async def get_session(self, session_id: UUID) -> Session:
+        """Return the current snapshot for ``session_id``."""
+
+        async with self._lock:
+            if session_id not in self._sessions:
+                raise SessionNotFoundError(session_id)
+            return self._sessions[session_id]
+
+    async def list_sessions(self) -> list[Session]:
+        """Return all tracked sessions ordered by insertion time."""
+
+        async with self._lock:
+            return list(self._sessions.values())
+
+    def _resolve_vnc(
+        self,
+        payload: SessionCreatePayload,
+        session_id: UUID,
+    ) -> SessionVncDetails | None:
+        """Return VNC details honouring payload overrides and settings defaults."""
+
+        if payload.headless:
+            return None
+        if payload.vnc is not None:
+            return payload.vnc
+        token = uuid4().hex
+        return SessionVncDetails(
+            http_url=f"{self._settings.vnc_http_base_url}/{session_id}",
+            websocket_url=f"{self._settings.vnc_ws_base_url}/{session_id}",
+            token=token,
+            token_ttl_seconds=self._settings.vnc_token_ttl_seconds,
+        )
+
+    async def _publish(
+        self,
+        session: Session,
+        event_type: SessionEventType,
+        *,
+        reason: str | None,
+    ) -> None:
+        """Send a :class:`SessionEvent` via the configured publisher."""
+
+        event = SessionEvent(
+            session=session,
+            type=event_type,
+            occurred_at=self._clock(),
+            reason=reason,
+        )
+        await self._publisher.publish(event)
+
+
+__all__ = [
+    "SessionCreatePayload",
+    "SessionManager",
+    "SessionNotFoundError",
+    "SessionUpdatePayload",
+]

--- a/services/runner/pyproject.toml
+++ b/services/runner/pyproject.toml
@@ -2,7 +2,7 @@
 name = "camou-runner"
 version = "0.1.0"
 description = "Ghost-browsers Session Runner (to be implemented)"
-packages = []
+packages = [{include = "app"}]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -1,0 +1,105 @@
+"""Unit tests for :mod:`app.session_manager`."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from app.config import RunnerSettings
+from app.events import InMemorySessionEventPublisher
+from app.session_manager import SessionCreatePayload, SessionManager, SessionUpdatePayload
+from core.models import SessionEventType, SessionProxySettings, SessionStatus
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Force the anyio plugin to use the asyncio backend."""
+
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_session_emits_event_and_vnc_stub() -> None:
+    """``create_session`` should store the session and publish a CREATED event."""
+
+    clock_now = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    settings = RunnerSettings(
+        runner_id="runner-test",
+        camoufox_path="/usr/bin/camoufox",
+        vnc_http_base_url="http://localhost:9000/vnc",
+        vnc_ws_base_url="ws://localhost:9000/vnc",
+        vnc_token_ttl_seconds=60,
+    )
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(settings, publisher, clock=lambda: clock_now)
+
+    payload = SessionCreatePayload(
+        start_url="https://example.test",
+        headless=False,
+        proxy=SessionProxySettings(http="http://proxy.example:3128"),
+        metadata={"flow": "smoke"},
+    )
+
+    session = await manager.create_session(payload)
+
+    assert session.runner_id == "runner-test"
+    assert session.proxy is not None
+    assert session.vnc is not None
+    assert str(session.vnc.http_url).endswith(str(session.id))
+    events = await publisher.drain()
+    assert len(events) == 1
+    assert events[0].type is SessionEventType.CREATED
+    assert events[0].session.id == session.id
+    assert events[0].occurred_at == clock_now
+
+
+@pytest.mark.anyio("asyncio")
+async def test_update_session_merges_labels_and_publishes_update() -> None:
+    """Updates should merge labels and emit ``session.updated`` events."""
+
+    clock_now = datetime(2024, 2, 2, 12, 0, 0, tzinfo=UTC)
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(
+        RunnerSettings(runner_id="runner-test", camoufox_path="/usr/bin/camoufox"),
+        publisher,
+        clock=lambda: clock_now,
+    )
+    session = await manager.create_session(SessionCreatePayload(headless=True))
+
+    updated = await manager.update_session(
+        session.id,
+        SessionUpdatePayload(
+            labels={"env": "test"},
+            metadata={"step": 1},
+            status=SessionStatus.READY,
+        ),
+    )
+
+    assert updated.labels["env"] == "test"
+    assert updated.metadata["step"] == 1
+    events = await publisher.drain()
+    assert [event.type for event in events] == [SessionEventType.CREATED, SessionEventType.UPDATED]
+    assert events[-1].session.status is SessionStatus.READY
+    assert events[-1].occurred_at == clock_now
+
+
+@pytest.mark.anyio("asyncio")
+async def test_end_session_sets_terminal_state_and_event() -> None:
+    """``end_session`` should mark the session as DEAD and send ENDED event."""
+
+    clock_now = datetime(2024, 3, 3, 12, 0, 0, tzinfo=UTC)
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(
+        RunnerSettings(runner_id="runner-test", camoufox_path="/usr/bin/camoufox"),
+        publisher,
+        clock=lambda: clock_now,
+    )
+    session = await manager.create_session(SessionCreatePayload())
+
+    ended = await manager.end_session(session.id, reason="completed")
+
+    assert ended.status is SessionStatus.DEAD
+    assert ended.ended_at == clock_now
+    events = await publisher.drain()
+    assert [event.type for event in events] == [SessionEventType.CREATED, SessionEventType.ENDED]
+    assert events[-1].reason == "completed"


### PR DESCRIPTION
## Summary
- scaffold the runner FastAPI application with health and session lifecycle endpoints
- add configuration, dependency wiring, session manager, and event publisher abstractions driven by core models
- cover the in-memory session manager with async unit tests and document architecture updates in AGENT_NOTES

## Testing
- `ruff check services/runner/app services/runner/tests`
- `PYTHONPATH=services/runner:packages/core pytest services/runner/tests -q`

## Security
- No security-relevant changes


------
https://chatgpt.com/codex/tasks/task_e_68dcd137632c832abe89281796acebb1