### PR TITLE
Implement gateway service with authentication and streaming

### DIFF
--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -1,2 +1,51 @@
 # AGENT_NOTES — gateway
-(Заполнить после первой реализации: интерфейсы, решения, ограничения, TODO, How to Test, Changelog.)
+
+## Overview
+- FastAPI приложение, реализующее публичный REST/SSE/WebSocket фронт для управления браузерными сессиями и трансляции событий Runner.
+- Хранит состояние (сессии, раннеры) в памяти для локальной разработки и unit-тестов.
+- Проверяет Keycloak JWT через JWKS и дополнительно выпускает короткоживущие VNC-токены для доступа к прокси.
+
+## Interfaces
+- REST:
+  - `POST /sessions` — регистрация сессии; автоматически добавляет VNC-токен при наличии VNC-деталей.
+  - `GET /sessions` — список активных сессий.
+  - `GET /sessions/{id}` — сессия по идентификатору.
+  - `POST /sessions/{id}/proxy` — установка/обновление `SessionProxySettings`.
+  - `POST /sessions/{id}/touch` — обновление `last_seen_at`.
+  - `DELETE /sessions/{id}` — удаление сессии.
+  - `GET /runners` — список зарегистрированных раннеров.
+- Streaming:
+  - `GET /events` — SSE-канал, ретранслирующий `SessionEvent` (кеш последнего события на подписчика).
+  - `WS /events/ws` — WebSocket с тем же потоком событий.
+- Аутентификация: Bearer JWT (Keycloak). Для WebSocket токен передаётся в заголовке `Authorization: Bearer` или параметре `token`.
+
+## Data & Models
+- Переиспользуются модели из `packages/core`: `Session`, `SessionEvent`, `Runner`, `SessionProxySettings`, `SessionVncDetails` и др.
+- `SessionRegistry`/`RunnerRegistry` — простые in-memory контейнеры с `asyncio.Lock` для потокобезопасности.
+- `InMemorySessionEventBridge` (из core) хранит последнее событие и раздаёт подписчикам.
+
+## Decisions
+- JWKS кэшируется в памяти и повторно запрашивается при отсутствии нужного `kid` (устойчивость к ротации ключей).
+- ВNC-токены выдаются как HMAC JWT (`HS256`) через `VncTokenService` с TTL из конфигурации (≤300 сек); секрет по умолчанию генерируется при старте.
+- SSE реализовано через `StreamingResponse`, WebSocket — нативный FastAPI роутер; для обоих каналов используется единый event bridge.
+- Авторизация завершается до открытия WebSocket, при ошибках соединение закрывается кодом `1008`.
+
+## Constraints & Invariants
+- `VNC_TOKEN_TTL_SEC` всегда ≤300; нарушение приводит к `ValueError` на старте.
+- JWT должен содержать `kid` и валидный `exp`; аудит-лог записывает `sub` и `email`/`preferred_username`.
+- In-memory хранилища не предназначены для горизонтального масштабирования; восстановление состояния из Runner discovery пока не реализовано.
+
+## Known Gaps / TODO
+- [ ] Реализовать реальные механизмы discovery и синхронизации раннеров/сессий (сейчас только in-memory конфиг).
+- [ ] Вынести секрет для VNC-токенов в конфигурацию и синхронизировать с VNC Gateway.
+- [ ] Добавить интеграционные тесты с реальной валидацией JWKS (httpx/respx), а не заполнять кэш напрямую.
+
+## How to Test
+- Локально:
+  - `cd services/gateway`
+  - `poetry install --no-root`
+  - `poetry run pytest -q`
+- При необходимости линтинг: `poetry run ruff check .`
+
+## Changelog (for agents)
+- 2025-10-01 · OpenAI ChatGPT · Реализован FastAPI gateway (REST/SSE/WS), Keycloak JWT, VNC-токены и покрывающие unit-тесты.

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -1,0 +1,40 @@
+# Gateway Service
+
+FastAPI-based edge service exposing REST, Server-Sent Events, and WebSocket
+interfaces for managing runner-backed browser sessions. The gateway acts as the
+public API facade and issues short-lived VNC access tokens on top of
+Keycloak-protected endpoints.
+
+## Configuration
+
+| Variable            | Description                                                        |
+| ------------------- | ------------------------------------------------------------------ |
+| `DISCOVERY_MODE`    | Runner discovery strategy (`static` by default).                   |
+| `RUNNERS`           | JSON-массив с объектами `Runner` (см. `packages/core`).            |
+| `JWT_JWKS_URL`      | URL JWKS-документа Keycloak.                                       |
+| `VNC_TOKEN_TTL_SEC` | Время жизни VNC JWT (≤300 секунд).                                 |
+
+## Endpoints
+
+- `POST /sessions` — register a session and enrich VNC details with a short-lived token.
+- `GET /sessions` / `GET /sessions/{id}` — inspect active sessions.
+- `POST /sessions/{id}/proxy` — update proxy configuration (`SessionProxySettings`).
+- `POST /sessions/{id}/touch` — refresh `last_seen_at` heartbeat timestamp.
+- `DELETE /sessions/{id}` — remove a session from the registry.
+- `GET /runners` — list known runners.
+- `GET /events` — Server-Sent Events stream of `SessionEvent` objects.
+- `WS /events/ws` — WebSocket stream with the same event payloads.
+
+All HTTP endpoints require a valid Keycloak bearer token. The WebSocket endpoint
+expects the token either in the `Authorization: Bearer` header or in the
+`token` query parameter.
+
+## Development
+
+```bash
+cd services/gateway
+poetry install --no-root
+poetry run pytest -q
+```
+
+Use `poetry run ruff check .` for linting the service codebase.

--- a/services/gateway/app/__init__.py
+++ b/services/gateway/app/__init__.py
@@ -1,0 +1,5 @@
+"""Gateway FastAPI application package."""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/services/gateway/app/config.py
+++ b/services/gateway/app/config.py
@@ -1,0 +1,97 @@
+"""Configuration helpers for the Gateway service."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping
+
+from core import Runner
+
+
+@dataclass(slots=True)
+class GatewaySettings:
+    """Configuration object used to bootstrap the FastAPI application.
+
+    Attributes:
+        discovery_mode: Strategy for runner discovery (``static`` or ``dynamic``).
+        runners: Initial list of runners that should be registered on startup.
+        jwt_jwks_url: HTTP URL pointing to the Keycloak JWKS document.
+        vnc_token_ttl_seconds: Lifetime of the issued VNC tokens in seconds.
+
+    Example:
+        >>> settings = GatewaySettings.from_env({
+        ...     "RUNNERS": (
+        ...         '[{"id": "r-1", "base_url": "http://runner", "total_slots": 1}]'
+        ...     ),
+        ...     "JWT_JWKS_URL": "http://idp.local/jwks",
+        ...     "VNC_TOKEN_TTL_SEC": "120",
+        ... })
+        >>> settings.discovery_mode
+        'static'
+    """
+
+    discovery_mode: str = "static"
+    runners: list[Runner] = field(default_factory=list)
+    jwt_jwks_url: str = "http://localhost/.well-known/jwks.json"
+    vnc_token_ttl_seconds: int = 300
+
+    @classmethod
+    def from_env(cls, env: Mapping[str, str] | None = None) -> "GatewaySettings":
+        """Create settings by reading the expected environment variables.
+
+        Args:
+            env: Optional mapping used during testing; defaults to :mod:`os.environ`.
+
+        Returns:
+            GatewaySettings: Populated settings instance.
+
+        Raises:
+            ValueError: If ``VNC_TOKEN_TTL_SEC`` exceeds 300 seconds or a runner
+                definition cannot be parsed.
+        """
+
+        env_map = env or os.environ
+        discovery_mode = env_map.get("DISCOVERY_MODE", cls.discovery_mode)
+        jwt_jwks_url = env_map.get("JWT_JWKS_URL", cls.jwt_jwks_url)
+        ttl_raw = env_map.get("VNC_TOKEN_TTL_SEC", str(cls.vnc_token_ttl_seconds))
+        ttl = int(ttl_raw)
+        if ttl > 300:
+            raise ValueError("VNC_TOKEN_TTL_SEC must be <= 300 seconds")
+        runners = list(_parse_runners(env_map.get("RUNNERS")))
+        return cls(
+            discovery_mode=discovery_mode,
+            runners=runners,
+            jwt_jwks_url=jwt_jwks_url,
+            vnc_token_ttl_seconds=ttl,
+        )
+
+
+def _parse_runners(raw: str | None) -> Iterable[Runner]:
+    """Parse the ``RUNNERS`` environment variable into :class:`Runner` models.
+
+    Args:
+        raw: JSON string encoding a list of runner definitions. Each definition
+            must match the :class:`Runner` schema from :mod:`core`.
+
+    Yields:
+        Runner: Validated runner instances ready to be registered.
+
+    Raises:
+        ValueError: If the payload cannot be parsed as JSON or does not contain a
+            list of mapping objects.
+    """
+
+    if not raw:
+        return []
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+        raise ValueError("RUNNERS must contain valid JSON") from exc
+    if not isinstance(payload, list):
+        raise ValueError("RUNNERS must be a JSON array of runner objects")
+    for item in payload:
+        if not isinstance(item, Mapping):
+            raise ValueError("Runner definitions must be JSON objects")
+        yield Runner.model_validate(item)

--- a/services/gateway/app/deps/__init__.py
+++ b/services/gateway/app/deps/__init__.py
@@ -1,0 +1,34 @@
+"""Dependency providers for the FastAPI routers."""
+
+from __future__ import annotations
+
+from core import AbstractSessionEventBridge
+from fastapi import Request
+
+from ..security import VncTokenService
+from ..services.runner_registry import RunnerRegistry
+from ..services.session_registry import SessionRegistry
+
+
+def get_session_registry(request: Request) -> SessionRegistry:
+    """Return the session registry stored in the application state."""
+
+    return request.app.state.session_registry  # type: ignore[attr-defined]
+
+
+def get_runner_registry(request: Request) -> RunnerRegistry:
+    """Return the runner registry stored in the application state."""
+
+    return request.app.state.runner_registry  # type: ignore[attr-defined]
+
+
+def get_event_bridge(request: Request) -> AbstractSessionEventBridge:
+    """Return the event bridge shared across routers."""
+
+    return request.app.state.event_bridge  # type: ignore[attr-defined]
+
+
+def get_vnc_token_service(request: Request) -> VncTokenService:
+    """Return the VNC token service stored on the application."""
+
+    return request.app.state.vnc_tokens  # type: ignore[attr-defined]

--- a/services/gateway/app/deps/security.py
+++ b/services/gateway/app/deps/security.py
@@ -1,0 +1,61 @@
+"""Security-related FastAPI dependencies."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, Request, WebSocket, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from ..security import AuthenticatedUser, AuthenticationError, KeycloakAuthenticator
+
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def get_authenticator(request: Request) -> KeycloakAuthenticator:
+    """Return the authenticator stored on the FastAPI application instance."""
+
+    return request.app.state.authenticator  # type: ignore[attr-defined]
+
+
+async def get_current_user(
+    credentials: Annotated[
+        HTTPAuthorizationCredentials | None, Depends(_bearer_scheme)
+    ],
+    authenticator: Annotated[
+        KeycloakAuthenticator, Depends(get_authenticator)
+    ],
+) -> AuthenticatedUser:
+    """Validate the incoming bearer token and return the authenticated user."""
+
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
+    try:
+        return await authenticator.authenticate(credentials.credentials)
+    except AuthenticationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token",
+        ) from exc
+
+
+async def authenticate_websocket(
+    websocket: WebSocket,
+    authenticator: KeycloakAuthenticator,
+) -> AuthenticatedUser:
+    """Perform bearer token authentication for WebSocket connections."""
+
+    authorization = websocket.headers.get("Authorization")
+    token: str | None = None
+    if authorization and authorization.lower().startswith("bearer "):
+        token = authorization.split(" ", 1)[1]
+    else:
+        token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        raise AuthenticationError("Missing bearer token for WebSocket connection")
+    try:
+        return await authenticator.authenticate(token)
+    except AuthenticationError as exc:
+        await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+        raise exc

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -1,0 +1,39 @@
+"""Application factory for the Camou Gateway service."""
+
+from __future__ import annotations
+
+import logging
+
+from core import InMemorySessionEventBridge
+from fastapi import FastAPI
+
+from .config import GatewaySettings
+from .routers import events_router, runners_router, sessions_router
+from .security import KeycloakAuthenticator, VncTokenService
+from .services.runner_registry import RunnerRegistry
+from .services.session_registry import SessionRegistry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def create_app(settings: GatewaySettings | None = None) -> FastAPI:
+    """Create and configure the FastAPI application instance."""
+
+    config = settings or GatewaySettings.from_env()
+    app = FastAPI(title="Camou Gateway", version="0.1.0")
+    app.state.settings = config
+    app.state.session_registry = SessionRegistry()
+    app.state.runner_registry = RunnerRegistry(config.runners)
+    app.state.event_bridge = InMemorySessionEventBridge()
+    app.state.vnc_tokens = VncTokenService(ttl_seconds=config.vnc_token_ttl_seconds)
+    app.state.authenticator = KeycloakAuthenticator(config.jwt_jwks_url)
+
+    app.include_router(sessions_router)
+    app.include_router(runners_router)
+    app.include_router(events_router)
+
+    _LOGGER.debug(
+        "Gateway application initialised",
+        extra={"discovery_mode": config.discovery_mode},
+    )
+    return app

--- a/services/gateway/app/routers/__init__.py
+++ b/services/gateway/app/routers/__init__.py
@@ -1,0 +1,11 @@
+"""REST and realtime routers exposed by the gateway."""
+
+from .events import router as events_router
+from .runners import router as runners_router
+from .sessions import router as sessions_router
+
+__all__ = [
+    "sessions_router",
+    "runners_router",
+    "events_router",
+]

--- a/services/gateway/app/routers/events.py
+++ b/services/gateway/app/routers/events.py
@@ -1,0 +1,53 @@
+"""Realtime event streaming endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from core import AbstractSessionEventBridge
+from fastapi import APIRouter, Depends, WebSocket, WebSocketDisconnect
+from fastapi.responses import StreamingResponse
+
+from ..deps import get_event_bridge
+from ..deps.security import authenticate_websocket, get_authenticator, get_current_user
+from ..security import AuthenticatedUser, KeycloakAuthenticator
+
+router = APIRouter(prefix="/events", tags=["events"])
+
+
+@router.get("", response_class=StreamingResponse)
+async def stream_events(
+    bridge: Annotated[AbstractSessionEventBridge, Depends(get_event_bridge)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> StreamingResponse:
+    """Provide a Server-Sent Events stream for session events."""
+
+    async def iterator() -> str:
+        subscription = await bridge.subscribe(replay_latest=True)
+        try:
+            async for event in subscription:
+                yield f"data: {event.model_dump_json(by_alias=True)}\n\n"
+        finally:
+            await subscription.aclose()
+
+    return StreamingResponse(iterator(), media_type="text/event-stream")
+
+
+@router.websocket("/ws")
+async def websocket_events(
+    websocket: WebSocket,
+    authenticator: Annotated[KeycloakAuthenticator, Depends(get_authenticator)],
+) -> None:
+    """Relay session events over a WebSocket connection."""
+
+    await authenticate_websocket(websocket, authenticator)
+    await websocket.accept()
+    bridge: AbstractSessionEventBridge = websocket.app.state.event_bridge  # type: ignore[attr-defined]
+    subscription = await bridge.subscribe(replay_latest=True)
+    try:
+        async for event in subscription:
+            await websocket.send_json(event.model_dump(mode="json"))
+    except WebSocketDisconnect:  # pragma: no cover - handshake drop
+        pass
+    finally:
+        await subscription.aclose()

--- a/services/gateway/app/routers/runners.py
+++ b/services/gateway/app/routers/runners.py
@@ -1,0 +1,25 @@
+"""Runner discovery endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from core import Runner
+from fastapi import APIRouter, Depends
+
+from ..deps import get_runner_registry
+from ..deps.security import get_current_user
+from ..security import AuthenticatedUser
+from ..services.runner_registry import RunnerRegistry
+
+router = APIRouter(prefix="/runners", tags=["runners"])
+
+
+@router.get("", response_model=list[Runner])
+async def list_runners(
+    registry: Annotated[RunnerRegistry, Depends(get_runner_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> list[Runner]:
+    """Return all registered runners."""
+
+    return await registry.list()

--- a/services/gateway/app/routers/sessions.py
+++ b/services/gateway/app/routers/sessions.py
@@ -1,0 +1,132 @@
+"""Session management endpoints."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from core import Session, SessionProxySettings
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from pydantic import BaseModel
+
+from ..deps import get_session_registry, get_vnc_token_service
+from ..deps.security import get_current_user
+from ..security import AuthenticatedUser, VncTokenService
+from ..services.session_registry import SessionRegistry
+
+
+class TouchPayload(BaseModel):
+    """Request body used to update the heartbeat timestamp for a session."""
+
+    timestamp: datetime | None = None
+
+
+router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+@router.get("", response_model=list[Session])
+async def list_sessions(
+    registry: Annotated[SessionRegistry, Depends(get_session_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> list[Session]:
+    """Return all sessions currently tracked by the gateway."""
+
+    return await registry.list()
+
+
+@router.post("", response_model=Session, status_code=status.HTTP_201_CREATED)
+async def create_session(
+    session: Session,
+    registry: Annotated[SessionRegistry, Depends(get_session_registry)],
+    token_service: Annotated[VncTokenService, Depends(get_vnc_token_service)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> Session:
+    """Register a new session emitted by a runner."""
+
+    enriched = session
+    if session.vnc is not None and session.vnc.token is None:
+        enriched = session.model_copy(
+            update={
+                "vnc": token_service.enrich_vnc_details(
+                    session.vnc,
+                    session_id=str(session.id),
+                    subject=user.subject,
+                )
+            }
+        )
+    try:
+        return await registry.add(enriched)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+
+
+@router.get("/{session_id}", response_model=Session)
+async def get_session(
+    session_id: UUID,
+    registry: Annotated[SessionRegistry, Depends(get_session_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> Session:
+    """Return a single session by identifier."""
+
+    try:
+        return await registry.get(session_id)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found",
+        ) from exc
+
+
+@router.delete("/{session_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_session(
+    session_id: UUID,
+    registry: Annotated[SessionRegistry, Depends(get_session_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> Response:
+    """Delete a session from the registry."""
+
+    try:
+        await registry.delete(session_id)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found",
+        ) from exc
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/{session_id}/proxy", response_model=Session)
+async def update_proxy(
+    session_id: UUID,
+    payload: SessionProxySettings,
+    registry: Annotated[SessionRegistry, Depends(get_session_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> Session:
+    """Update proxy configuration for a session."""
+
+    try:
+        return await registry.update_proxy(session_id, payload)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found",
+        ) from exc
+
+
+@router.post("/{session_id}/touch", response_model=Session)
+async def touch_session(
+    session_id: UUID,
+    payload: TouchPayload,
+    registry: Annotated[SessionRegistry, Depends(get_session_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> Session:
+    """Update the ``last_seen_at`` timestamp for a session."""
+
+    try:
+        return await registry.touch(session_id, timestamp=payload.timestamp)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found",
+        ) from exc

--- a/services/gateway/app/security/__init__.py
+++ b/services/gateway/app/security/__init__.py
@@ -1,0 +1,11 @@
+"""Security helpers for the Gateway service."""
+
+from .keycloak import AuthenticatedUser, AuthenticationError, KeycloakAuthenticator
+from .vnc import VncTokenService
+
+__all__ = [
+    "AuthenticatedUser",
+    "KeycloakAuthenticator",
+    "AuthenticationError",
+    "VncTokenService",
+]

--- a/services/gateway/app/security/keycloak.py
+++ b/services/gateway/app/security/keycloak.py
@@ -1,0 +1,133 @@
+"""Keycloak JWT validation utilities."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Mapping
+
+import httpx
+from jose import jwk, jwt
+from jose.exceptions import JOSEError
+from jose.utils import base64url_decode
+
+_LOGGER = logging.getLogger("gateway.security")
+
+
+@dataclass(slots=True)
+class AuthenticatedUser:
+    """Represents the authenticated principal extracted from a JWT."""
+
+    subject: str
+    email: str | None = None
+
+
+class AuthenticationError(RuntimeError):
+    """Raised when the supplied JWT cannot be verified."""
+
+
+class KeycloakAuthenticator:
+    """Validate Keycloak-issued JWTs using JWKS metadata."""
+
+    def __init__(self, jwks_url: str, *, audience: str | None = None) -> None:
+        """Initialise the authenticator with JWKS location and optional audience."""
+
+        self._jwks_url = jwks_url
+        self._audience = audience
+        self._jwks_cache: dict[str, Mapping[str, Any]] | None = None
+        self._jwks_lock = asyncio.Lock()
+
+    async def authenticate(self, token: str) -> AuthenticatedUser:
+        """Verify the token signature and extract the principal information.
+
+        Args:
+            token: Bearer token supplied by the caller.
+
+        Returns:
+            AuthenticatedUser: Subject and email extracted from the claims set.
+
+        Raises:
+            AuthenticationError: If the token header or claims are invalid or the
+                signature check fails.
+        """
+
+        try:
+            header = jwt.get_unverified_header(token)
+        except JOSEError as exc:  # pragma: no cover - jose already tested
+            raise AuthenticationError("Invalid token header") from exc
+        kid = header.get("kid")
+        if not kid:
+            raise AuthenticationError("JWT header missing 'kid'")
+        key_dict = await self._get_key(kid)
+        message, encoded_signature = token.rsplit(".", 1)
+        signature = base64url_decode(encoded_signature.encode("utf-8"))
+        try:
+            constructed_key = jwk.construct(key_dict)
+        except JOSEError as exc:  # pragma: no cover - defensive branch
+            raise AuthenticationError("Unable to construct verification key") from exc
+        if not constructed_key.verify(message.encode("utf-8"), signature):
+            raise AuthenticationError("Token signature verification failed")
+        claims = jwt.get_unverified_claims(token)
+        self._validate_claims(claims)
+        subject = str(claims.get("sub"))
+        if not subject:
+            raise AuthenticationError("JWT is missing subject claim")
+        email = claims.get("email") or claims.get("preferred_username")
+        _LOGGER.info("authenticated", extra={"sub": subject, "email": email})
+        return AuthenticatedUser(subject=subject, email=email)
+
+    async def _get_key(self, kid: str) -> Mapping[str, Any]:
+        """Return the JWKS entry for the given key identifier."""
+
+        async with self._jwks_lock:
+            if self._jwks_cache is None:
+                self._jwks_cache = await self._fetch_jwks()
+            key = self._jwks_cache.get(kid)
+            if key is None:
+                # Refresh JWKS in case Keycloak rotated the key set.
+                self._jwks_cache = await self._fetch_jwks()
+                key = self._jwks_cache.get(kid)
+            if key is None:
+                raise AuthenticationError("Signing key not found in JWKS")
+            return key
+
+    async def _fetch_jwks(self) -> dict[str, Mapping[str, Any]]:
+        """Download JWKS metadata and index it by ``kid``."""
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(self._jwks_url, timeout=5.0)
+        response.raise_for_status()
+        data = response.json()
+        keys = data.get("keys", [])
+        if not isinstance(keys, list):
+            raise AuthenticationError("JWKS payload is malformed")
+        indexed: dict[str, Mapping[str, Any]] = {}
+        for item in keys:
+            if not isinstance(item, Mapping) or "kid" not in item:
+                raise AuthenticationError("Invalid key entry in JWKS")
+            indexed[str(item["kid"])] = item
+        if not indexed:
+            raise AuthenticationError("JWKS document does not contain keys")
+        return indexed
+
+    def _validate_claims(self, claims: Mapping[str, Any]) -> None:
+        """Validate expiry and optional audience claims."""
+
+        expires_at = claims.get("exp")
+        if expires_at is not None:
+            expiry = datetime.fromtimestamp(int(expires_at), tz=UTC)
+            if expiry <= datetime.now(tz=UTC):
+                raise AuthenticationError("Token has expired")
+        if self._audience is None:
+            return
+        audience = claims.get("aud")
+        if isinstance(audience, str):
+            audiences = {audience}
+        elif isinstance(audience, list):
+            audiences = {str(item) for item in audience}
+        else:
+            audiences = set()
+        if self._audience not in audiences:
+            raise AuthenticationError("Token audience mismatch")

--- a/services/gateway/app/security/vnc.py
+++ b/services/gateway/app/security/vnc.py
@@ -1,0 +1,87 @@
+"""Short-lived VNC token issuance utilities."""
+
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from core import SessionVncDetails
+from jose import jwt
+
+
+class VncTokenService:
+    """Issue JWT tokens that guard access to the VNC gateway."""
+
+    def __init__(
+        self,
+        *,
+        secret: str | None = None,
+        ttl_seconds: int = 300,
+        issuer: str = "camou-gateway",
+    ) -> None:
+        """Create a new token service.
+
+        Args:
+            secret: Optional HMAC secret used to sign JWT tokens. When omitted a
+                random secret is generated which is suitable for unit tests.
+            ttl_seconds: Lifetime of each token; must not exceed 300 seconds.
+            issuer: Issuer claim embedded into generated tokens.
+
+        Raises:
+            ValueError: If ``ttl_seconds`` exceeds the contractually defined limit.
+        """
+
+        if ttl_seconds > 300:
+            raise ValueError("VNC token TTL must be <= 300 seconds")
+        self._secret = secret or secrets.token_urlsafe(32)
+        self._ttl_seconds = ttl_seconds
+        self._issuer = issuer
+
+    def issue(self, session_id: str, *, subject: str | None = None) -> tuple[str, int]:
+        """Generate a JWT for the given session identifier.
+
+        Args:
+            session_id: Identifier of the session protected by the token.
+            subject: Optional subject propagated from the authenticated user.
+
+        Returns:
+            tuple[str, int]: The encoded JWT token and its TTL in seconds.
+        """
+
+        now = datetime.now(tz=UTC)
+        expires = now + timedelta(seconds=self._ttl_seconds)
+        payload: dict[str, Any] = {
+            "sid": session_id,
+            "iat": int(now.timestamp()),
+            "exp": int(expires.timestamp()),
+            "iss": self._issuer,
+        }
+        if subject is not None:
+            payload["sub"] = subject
+        token = jwt.encode(payload, self._secret, algorithm="HS256")
+        return token, self._ttl_seconds
+
+    def enrich_vnc_details(
+        self,
+        details: SessionVncDetails,
+        *,
+        session_id: str,
+        subject: str | None = None,
+    ) -> SessionVncDetails:
+        """Attach a token to the provided VNC details when missing.
+
+        Args:
+            details: VNC descriptor supplied by the runner.
+            session_id: Identifier of the associated session.
+            subject: Optional authenticated subject for auditing.
+
+        Returns:
+            SessionVncDetails: Updated descriptor including ``token`` and
+            ``token_ttl_seconds`` fields.
+        """
+
+        if details.token is not None:
+            return details
+        token, ttl = self.issue(session_id, subject=subject)
+        return details.model_copy(update={"token": token, "token_ttl_seconds": ttl})

--- a/services/gateway/app/services/runner_registry.py
+++ b/services/gateway/app/services/runner_registry.py
@@ -1,0 +1,34 @@
+"""In-memory representation of runner metadata."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable
+
+from core import Runner
+
+
+class RunnerRegistry:
+    """Track runner information reported by the discovery layer."""
+
+    def __init__(self, runners: Iterable[Runner] | None = None) -> None:
+        """Populate the registry with optional initial runners."""
+
+        self._runners: dict[str, Runner] = {}
+        if runners is not None:
+            for runner in runners:
+                self._runners[runner.id] = runner
+        self._lock = asyncio.Lock()
+
+    async def list(self) -> list[Runner]:
+        """Return a snapshot of all known runners."""
+
+        async with self._lock:
+            return list(self._runners.values())
+
+    async def upsert(self, runner: Runner) -> Runner:
+        """Insert or update a runner entry."""
+
+        async with self._lock:
+            self._runners[runner.id] = runner
+            return runner

--- a/services/gateway/app/services/session_registry.py
+++ b/services/gateway/app/services/session_registry.py
@@ -1,0 +1,90 @@
+"""In-memory session registry used by the gateway routers."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from uuid import UUID
+
+from core import Session, SessionProxySettings
+
+
+class SessionRegistry:
+    """Concurrency-safe container that holds active sessions."""
+
+    def __init__(self) -> None:
+        """Initialise the registry with no sessions tracked."""
+
+        self._sessions: dict[UUID, Session] = {}
+        self._lock = asyncio.Lock()
+
+    async def add(self, session: Session) -> Session:
+        """Register a new session instance.
+
+        Args:
+            session: Session object reported by a runner.
+
+        Returns:
+            Session: The stored session instance (identical to ``session``).
+
+        Raises:
+            ValueError: If a session with the same identifier already exists.
+        """
+
+        async with self._lock:
+            if session.id in self._sessions:
+                raise ValueError("Session already exists")
+            self._sessions[session.id] = session
+            return session
+
+    async def list(self) -> list[Session]:
+        """Return all registered sessions in insertion order."""
+
+        async with self._lock:
+            return list(self._sessions.values())
+
+    async def get(self, session_id: UUID) -> Session:
+        """Retrieve a session by identifier."""
+
+        async with self._lock:
+            try:
+                return self._sessions[session_id]
+            except KeyError as exc:  # pragma: no cover - trivial guard
+                raise KeyError("Session not found") from exc
+
+    async def delete(self, session_id: UUID) -> None:
+        """Remove a session from the registry."""
+
+        async with self._lock:
+            try:
+                del self._sessions[session_id]
+            except KeyError as exc:  # pragma: no cover - trivial guard
+                raise KeyError("Session not found") from exc
+
+    async def update_proxy(self, session_id: UUID, proxy: SessionProxySettings) -> Session:
+        """Attach or replace the proxy configuration for a session."""
+
+        async with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise KeyError("Session not found")
+            updated = session.model_copy(update={"proxy": proxy})
+            self._sessions[session_id] = updated
+            return updated
+
+    async def touch(
+        self,
+        session_id: UUID,
+        *,
+        timestamp: datetime | None = None,
+    ) -> Session:
+        """Update the ``last_seen_at`` timestamp for a session."""
+
+        async with self._lock:
+            session = self._sessions.get(session_id)
+            if session is None:
+                raise KeyError("Session not found")
+            observed_at = timestamp or datetime.now(tz=UTC)
+            updated = session.model_copy(update={"last_seen_at": observed_at})
+            self._sessions[session_id] = updated
+            return updated

--- a/services/gateway/pyproject.toml
+++ b/services/gateway/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "camou-gateway"
 version = "0.1.0"
-description = "Ghost-browsers Gateway (to be implemented)"
-packages = []
+description = "Ghost-browsers Gateway service"
+packages = [{ include = "app" }]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"
@@ -12,6 +12,7 @@ python-jose = "^3.3.0"
 httpx = "^0.27.2"
 pydantic = "^2.8.2"
 anyio = "^4.4.0"
+"camou-core" = { path = "../../packages/core", develop = true }
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/services/gateway/tests/test_gateway.py
+++ b/services/gateway/tests/test_gateway.py
@@ -1,0 +1,240 @@
+"""Unit tests for the gateway service."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import uuid4
+
+import anyio
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from jose import jwt
+from starlette.responses import StreamingResponse
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from app import create_app  # noqa: E402
+from app.config import GatewaySettings  # noqa: E402
+from app.deps import get_vnc_token_service  # noqa: E402
+from app.deps.security import get_authenticator, get_current_user  # noqa: E402
+from app.security import AuthenticatedUser, KeycloakAuthenticator, VncTokenService  # noqa: E402
+from core import Runner, Session, SessionEvent, SessionEventType, SessionStatus  # noqa: E402
+
+
+@pytest.fixture()
+def gateway_app() -> FastAPI:
+    """Return a FastAPI application with testing dependencies configured."""
+
+    settings = GatewaySettings(
+        discovery_mode="static",
+        runners=[
+            Runner(
+                id="runner-1",
+                base_url="http://runner-1",
+                total_slots=1,
+            )
+        ],
+        jwt_jwks_url="http://jwks.local",
+        vnc_token_ttl_seconds=120,
+    )
+    app = create_app(settings)
+
+    user = AuthenticatedUser(subject="tester", email="tester@example.com")
+
+    async def _user_override() -> AuthenticatedUser:
+        return user
+
+    token_service = VncTokenService(
+        secret="unit-test-secret",
+        ttl_seconds=settings.vnc_token_ttl_seconds,
+    )
+
+    class _DummyAuthenticator:
+        async def authenticate(self, token: str) -> AuthenticatedUser:
+            """Return the static authenticated user for tests."""
+
+            return user
+
+    dummy_auth = _DummyAuthenticator()
+
+    app.state.vnc_tokens = token_service
+    app.state.authenticator = dummy_auth
+    app.dependency_overrides[get_current_user] = _user_override
+    app.dependency_overrides[get_authenticator] = lambda: dummy_auth
+    app.dependency_overrides[get_vnc_token_service] = lambda: token_service
+
+    return app
+
+
+@pytest.fixture()
+def gateway_client(gateway_app: FastAPI) -> TestClient:
+    """Return a FastAPI test client with dependencies overridden for testing."""
+
+    client = TestClient(gateway_app)
+    yield client
+    client.close()
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    """Force AnyIO tests to run on asyncio to avoid optional trio dependency."""
+
+    return "asyncio"
+
+
+def test_session_crud(gateway_client: TestClient) -> None:
+    """Sessions can be created, listed, touched, and deleted."""
+
+    now = datetime.now(tz=UTC)
+    session_body = {
+        "id": str(uuid4()),
+        "runner_id": "runner-1",
+        "status": SessionStatus.INIT.value,
+        "created_at": now.isoformat(),
+        "last_seen_at": now.isoformat(),
+        "headless": False,
+        "idle_ttl_seconds": 300,
+    }
+    response = gateway_client.post("/sessions", json=session_body)
+    assert response.status_code == 201
+    session_id = response.json()["id"]
+
+    response = gateway_client.get("/sessions")
+    assert response.status_code == 200
+    assert any(item["id"] == session_id for item in response.json())
+
+    proxy_body = {"http": "http://proxy", "https": None, "socks": None}
+    response = gateway_client.post(f"/sessions/{session_id}/proxy", json=proxy_body)
+    assert response.status_code == 200
+    assert response.json()["proxy"]["http"].startswith("http://proxy")
+
+    updated_at = (now + timedelta(seconds=30)).isoformat()
+    response = gateway_client.post(f"/sessions/{session_id}/touch", json={"timestamp": updated_at})
+    assert response.status_code == 200
+    assert response.json()["last_seen_at"].startswith(updated_at[:19])
+
+    response = gateway_client.delete(f"/sessions/{session_id}")
+    assert response.status_code == 204
+
+    response = gateway_client.get(f"/sessions/{session_id}")
+    assert response.status_code == 404
+
+
+def test_vnc_token_generation(gateway_client: TestClient) -> None:
+    """Sessions containing VNC details receive signed short-lived tokens."""
+
+    now = datetime.now(tz=UTC)
+    session_body = {
+        "id": str(uuid4()),
+        "runner_id": "runner-1",
+        "status": SessionStatus.INIT.value,
+        "created_at": now.isoformat(),
+        "last_seen_at": now.isoformat(),
+        "headless": False,
+        "idle_ttl_seconds": 300,
+        "vnc": {"http_url": "https://vnc.example/view"},
+    }
+    response = gateway_client.post("/sessions", json=session_body)
+    assert response.status_code == 201
+    payload = response.json()["vnc"]
+    assert payload["token_ttl_seconds"] == 120
+    claims = jwt.decode(payload["token"], "unit-test-secret", algorithms=["HS256"])
+    assert claims["sid"] == session_body["id"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_sse_event_forwarding(gateway_app: FastAPI) -> None:
+    """Events published into the bridge appear on the SSE endpoint."""
+
+    from app.routers.events import stream_events
+
+    bridge = gateway_app.state.event_bridge
+    now = datetime.now(tz=UTC)
+    session = Session(
+        id=uuid4(),
+        runner_id="runner-1",
+        status=SessionStatus.READY,
+        created_at=now,
+        last_seen_at=now,
+        headless=False,
+        idle_ttl_seconds=300,
+    )
+    event = SessionEvent(
+        session=session,
+        occurred_at=now,
+        type=SessionEventType.UPDATED,
+    )
+
+    response = await stream_events(
+        bridge=bridge,
+        user=AuthenticatedUser(subject="tester", email="tester@example.com"),
+    )
+    assert isinstance(response, StreamingResponse)
+
+    iterator = response.body_iterator
+    consumer = asyncio.create_task(iterator.__anext__())
+    await asyncio.sleep(0)
+    await bridge.publish(event)
+    chunk = await asyncio.wait_for(consumer, timeout=1)
+    text = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+    payload = json.loads(text.removeprefix("data:").strip())
+    assert payload["session"]["id"] == str(event.session.id)
+    await iterator.aclose()
+
+
+def test_websocket_event_forwarding(gateway_client: TestClient) -> None:
+    """Events are also forwarded to WebSocket subscribers."""
+
+    bridge = gateway_client.app.state.event_bridge
+    now = datetime.now(tz=UTC)
+    session = Session(
+        id=uuid4(),
+        runner_id="runner-1",
+        status=SessionStatus.READY,
+        created_at=now,
+        last_seen_at=now,
+        headless=False,
+        idle_ttl_seconds=300,
+    )
+    event = SessionEvent(
+        session=session,
+        occurred_at=now,
+        type=SessionEventType.UPDATED,
+    )
+    anyio.run(bridge.publish, event)
+    with gateway_client.websocket_connect("/events/ws?token=stub") as websocket:
+        message = websocket.receive_json()
+        assert message["session"]["id"] == str(session.id)
+
+
+@pytest.mark.anyio
+async def test_keycloak_authenticator_logs_subject(caplog: pytest.LogCaptureFixture) -> None:
+    """The authenticator validates a token using JWKS metadata and logs the subject."""
+
+    authenticator = KeycloakAuthenticator("http://jwks")
+    secret = "shared-secret"
+    jwk_entry = {
+        "kty": "oct",
+        "kid": "unit",
+        "k": base64.urlsafe_b64encode(secret.encode("utf-8")).decode("utf-8").rstrip("="),
+        "alg": "HS256",
+    }
+    authenticator._jwks_cache = {"unit": jwk_entry}  # type: ignore[attr-defined]
+    caplog.set_level("INFO", logger="gateway.security")
+    payload = {
+        "sub": "subject-1",
+        "email": "subject@example.com",
+        "exp": int((datetime.now(tz=UTC) + timedelta(minutes=5)).timestamp()),
+    }
+    token = jwt.encode(payload, secret, algorithm="HS256", headers={"kid": "unit"})
+    user = await authenticator.authenticate(token)
+    assert user.subject == "subject-1"
+    assert any(record.sub == "subject-1" for record in caplog.records)


### PR DESCRIPTION
## Summary
- add gateway configuration, application factory, and security dependencies to initialise registries, JWKS validation, and VNC token issuance. 【F:services/gateway/app/main.py†L1-L37】【F:services/gateway/app/config.py†L13-L66】【F:services/gateway/app/deps/security.py†L1-L52】
- expose session and runner REST APIs plus SSE/WebSocket event streaming backed by in-memory registries. 【F:services/gateway/app/routers/sessions.py†L1-L118】【F:services/gateway/app/services/session_registry.py†L1-L90】【F:services/gateway/app/routers/events.py†L17-L52】【F:services/gateway/app/routers/runners.py†L1-L24】
- implement JWKS-based Keycloak authentication, short-lived VNC token generation, documentation, and comprehensive unit tests. 【F:services/gateway/app/security/keycloak.py†L1-L134】【F:services/gateway/app/security/vnc.py†L1-L88】【F:services/gateway/tests/test_gateway.py†L1-L235】【F:services/gateway/README.md†L1-L40】

## Testing
- poetry run pytest -q 【0aae28†L1-L2】

## Security
- JWTs are validated against JWKS with caching and logging of subject/email while VNC tokens remain capped at 300 seconds. 【F:services/gateway/app/security/keycloak.py†L32-L134】【F:services/gateway/app/security/vnc.py†L17-L88】

------
https://chatgpt.com/codex/tasks/task_e_68dcd44dc1c8832a8a34c58b3c502188