### PR TITLE
feat: enrich runner health diagnostics

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -5,7 +5,9 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 
 ## Interfaces
 - **HTTP**
-  - `GET /health` — returns `{status, runner_id, camoufox_path}` for readiness probes.
+  - `GET /health` — возвращает `{status, runner_id, camoufox_path, slots, vnc, proxy, prewarm}`;
+    `slots.total` считывается из `RunnerSettings.slot_limit`, `slots.active` — количество
+    не-`DEAD` сессий; `prewarm` включает счётчик и последнюю ошибку прогрева.
   - `POST /sessions` — accepts `SessionCreatePayload`, returns created `core.Session` snapshot.
   - `PATCH /sessions/{id}` — accepts `SessionUpdatePayload`, merges labels/metadata, returns updated `core.Session`.
   - `DELETE /sessions/{id}` — marks session as `DEAD`, returns terminal snapshot.
@@ -16,11 +18,15 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 - Uses `core.Session`, `SessionEvent`, `SessionProxySettings`, `SessionVncDetails`, and related enums.
 - Local payload models (`SessionCreatePayload`, `SessionUpdatePayload`) act as request DTOs before conversion into immutable core models.
 - Sessions are keyed by UUID and persisted in-memory; timestamps sourced from an injectable clock (UTC aware).
+- `SessionManagerMetrics` агрегирует счётчик активных сессий и историю ошибок прогрева (bounded deque по
+  `RunnerSettings.prewarm_failure_history_size`).
 
 ## Decisions
 - **In-memory publisher stub**: We expose a `SessionEventPublisher` protocol with an in-memory default to unblock tests until a real transport (HTTP/SSE) is integrated.
-- **Automatic VNC stubs**: When sessions are non-headless and no explicit VNC payload is provided, the manager synthesises `SessionVncDetails` using configurable base URLs and bounded TTL (<=300s) to respect `SessionVncDetails` invariants.
-- **Environment-driven settings**: `RunnerSettings.from_env` centralises configuration parsing without extra dependencies, easing future extension.
+- **Automatic VNC stubs**: When sessions are non-headless and no explicit VNC payload is provided, the manager synthesises `SessionVncDetails` using configurable base URLs and bounded TTL (<=300s) to respect `SessionVncDetails` invariants. Глобальный флаг `RunnerSettings.vnc_enabled` отключает генерацию stub-значений.
+- **Environment-driven settings**: `RunnerSettings.from_env` centralises configuration parsing without extra dependencies, easing future extension. Дополнительные параметры: `slot_limit`, базовые VNC URL, глобальный флаг прокси и ёмкость истории ошибок прогрева.
+- **Bounded prewarm history**: менеджер хранит ошибки прогрева в `deque` с ограничением размера, что позволяет health-эндпоинту
+  показывать последние сбои без риска утечки памяти.
 
 ## Constraints & Invariants
 - `RunnerSettings.vnc_token_ttl_seconds` capped at 300 seconds to align with `SessionVncDetails` validation.
@@ -30,7 +36,6 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 
 ## Known Gaps / TODO
 - [ ] Replace in-memory publisher with HTTP/SSE integration towards Gateway when endpoint contract is defined.
-- [ ] Enrich `/health` with slot/VNC diagnostics once browser integration lands.
 
 ## How to Test
 - `poetry install --no-root`
@@ -38,4 +43,4 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 - `poetry run ruff check .`
 
 ## Changelog (for agents)
-- 2024-09-21 · OpenAI ChatGPT · Initial FastAPI skeleton, in-memory session manager with event publishing, unit tests, and documentation update.
+- 2024-09-22 · OpenAI ChatGPT · Расширен `/health`, добавлены метрики/история prewarm, новые настройки и модульные тесты.

--- a/services/runner/README-TASK.md
+++ b/services/runner/README-TASK.md
@@ -12,3 +12,33 @@
 ## Качество
 - Docstring/inline-комментарии; тесты на создание/удаление сессии (без реального браузера — заглушки).
 - Обновить `AGENT_NOTES.md` (Interfaces/Decisions/TODO/How to Test).
+
+## Контракт `/health`
+
+Эндпоинт `GET /health` должен возвращать JSON-структуру:
+
+```json
+{
+  "status": "ok",
+  "runner_id": "runner-name",
+  "camoufox_path": "/usr/bin/camoufox",
+  "slots": {"total": 3, "active": 1, "available": 2},
+  "vnc": {
+    "http_base_url": "http://localhost:9000/vnc",
+    "ws_base_url": "ws://localhost:9000/vnc",
+    "enabled": true
+  },
+  "proxy": {
+    "enabled": false,
+    "http_base_url": null,
+    "https_base_url": null,
+    "socks_base_url": null
+  },
+  "prewarm": {
+    "failures": 0,
+    "last_error": null
+  }
+}
+```
+
+Слоты рассчитываются из лимита настроек и текущего количества активных сессий. Раздел `prewarm` отражает последние ошибки предварительного прогрева браузера.

--- a/services/runner/app/config/settings.py
+++ b/services/runner/app/config/settings.py
@@ -13,18 +13,31 @@ class RunnerSettings(BaseModel):
     """Typed view over environment-driven runner configuration.
 
     The settings object captures values that influence how the runner allocates
-    sessions and emits events. ``from_env`` reads recognised environment
-    variables and applies type validation, making it safe to inject into
-    FastAPI dependencies and background components.
+    sessions, exposes diagnostics, and emits events. ``from_env`` reads
+    recognised environment variables and applies type validation, making it
+    safe to inject into FastAPI dependencies and background components.
 
     Attributes:
         runner_id: Identifier advertised to the gateway/UI for every session.
         camoufox_path: Absolute path to the Camoufox binary.
         event_endpoint: Optional HTTP(S) endpoint used by the event publisher
             stub. When absent, events are kept in-memory.
+        slot_limit: Maximum number of concurrently active sessions.
+        vnc_enabled: Controls whether VNC URLs should be generated for new
+            sessions.
         vnc_http_base_url: Base URL for generating human-facing VNC previews.
         vnc_ws_base_url: Base URL for generating WebSocket control endpoints.
         vnc_token_ttl_seconds: Time-to-live applied to generated VNC tokens.
+        proxy_enabled: Signals whether proxy support is globally available for
+            sessions provisioned by this runner.
+        proxy_http_base_url: Optional base URL for HTTP proxies issued during
+            session creation.
+        proxy_https_base_url: Optional base URL for HTTPS proxies issued during
+            session creation.
+        proxy_socks_base_url: Optional base URL for SOCKS proxies issued during
+            session creation.
+        prewarm_failure_history_size: Number of most recent prewarm failures to
+            retain for diagnostics.
 
     Example:
         >>> settings = RunnerSettings.from_env({"RUNNER_ID": "runner-1"})
@@ -37,9 +50,16 @@ class RunnerSettings(BaseModel):
     runner_id: str = Field(default="runner-local", min_length=1)
     camoufox_path: Path = Field(default=Path("/usr/bin/camoufox"))
     event_endpoint: AnyUrl | None = Field(default=None)
+    slot_limit: PositiveInt = Field(default=4, ge=1)
+    vnc_enabled: bool = Field(default=True)
     vnc_http_base_url: AnyUrl = Field(default="http://127.0.0.1:8060/vnc")
     vnc_ws_base_url: AnyUrl = Field(default="ws://127.0.0.1:8060/vnc")
     vnc_token_ttl_seconds: PositiveInt = Field(default=120, le=300)
+    proxy_enabled: bool = Field(default=False)
+    proxy_http_base_url: AnyUrl | None = Field(default=None)
+    proxy_https_base_url: AnyUrl | None = Field(default=None)
+    proxy_socks_base_url: AnyUrl | None = Field(default=None)
+    prewarm_failure_history_size: PositiveInt = Field(default=5, ge=1, le=50)
 
     @classmethod
     def from_env(cls, environ: dict[str, str] | None = None) -> "RunnerSettings":
@@ -61,12 +81,26 @@ class RunnerSettings(BaseModel):
             source["camoufox_path"] = Path(env["CAMOUFOX_PATH"])
         if "EVENT_ENDPOINT" in env:
             source["event_endpoint"] = env["EVENT_ENDPOINT"]
+        if "SLOT_LIMIT" in env:
+            source["slot_limit"] = int(env["SLOT_LIMIT"])
+        if "VNC_ENABLED" in env:
+            source["vnc_enabled"] = env["VNC_ENABLED"].lower() in {"1", "true", "yes"}
         if "VNC_HTTP_BASE_URL" in env:
             source["vnc_http_base_url"] = env["VNC_HTTP_BASE_URL"]
         if "VNC_WS_BASE_URL" in env:
             source["vnc_ws_base_url"] = env["VNC_WS_BASE_URL"]
         if "VNC_TOKEN_TTL_SECONDS" in env:
             source["vnc_token_ttl_seconds"] = int(env["VNC_TOKEN_TTL_SECONDS"])
+        if "PROXY_ENABLED" in env:
+            source["proxy_enabled"] = env["PROXY_ENABLED"].lower() in {"1", "true", "yes"}
+        if "PROXY_HTTP_BASE_URL" in env:
+            source["proxy_http_base_url"] = env["PROXY_HTTP_BASE_URL"]
+        if "PROXY_HTTPS_BASE_URL" in env:
+            source["proxy_https_base_url"] = env["PROXY_HTTPS_BASE_URL"]
+        if "PROXY_SOCKS_BASE_URL" in env:
+            source["proxy_socks_base_url"] = env["PROXY_SOCKS_BASE_URL"]
+        if "PREWARM_FAILURE_HISTORY_SIZE" in env:
+            source["prewarm_failure_history_size"] = int(env["PREWARM_FAILURE_HISTORY_SIZE"])
         return cls.model_validate(source)
 
 

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 from uuid import UUID
 
 from core.models import Session
@@ -24,13 +24,51 @@ SessionManagerDep = Annotated[SessionManager, Depends(get_session_manager)]
 
 
 @app.get("/health", summary="Runner health probe")
-async def health(settings: RunnerSettingsDep) -> dict[str, str]:
-    """Return a minimal health payload consumed by gateways and tests."""
+async def health(
+    settings: RunnerSettingsDep, manager: SessionManagerDep
+) -> dict[str, Any]:
+    """Return a structured health payload consumed by gateways and tests."""
 
+    metrics = await manager.get_metrics()
+    active_slots = metrics.active_sessions
+    total_slots = settings.slot_limit
+    available_slots = max(total_slots - active_slots, 0)
     return {
         "status": "ok",
         "runner_id": settings.runner_id,
         "camoufox_path": str(settings.camoufox_path),
+        "slots": {
+            "total": total_slots,
+            "active": active_slots,
+            "available": available_slots,
+        },
+        "vnc": {
+            "http_base_url": str(settings.vnc_http_base_url),
+            "ws_base_url": str(settings.vnc_ws_base_url),
+            "enabled": settings.vnc_enabled,
+        },
+        "proxy": {
+            "enabled": settings.proxy_enabled,
+            "http_base_url": (
+                str(settings.proxy_http_base_url)
+                if settings.proxy_http_base_url is not None
+                else None
+            ),
+            "https_base_url": (
+                str(settings.proxy_https_base_url)
+                if settings.proxy_https_base_url is not None
+                else None
+            ),
+            "socks_base_url": (
+                str(settings.proxy_socks_base_url)
+                if settings.proxy_socks_base_url is not None
+                else None
+            ),
+        },
+        "prewarm": {
+            "failures": metrics.prewarm_failure_count,
+            "last_error": metrics.last_prewarm_error,
+        },
     }
 
 

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any
@@ -74,6 +75,36 @@ class SessionNotFoundError(KeyError):
     """Raised when attempting to operate on an unknown session identifier."""
 
 
+class SessionManagerMetrics(BaseModel):
+    """Snapshot of operational counters maintained by :class:`SessionManager`.
+
+    Attributes:
+        active_sessions: Number of sessions that are not in the ``DEAD`` state.
+        prewarm_failures: Ordered list of recorded prewarm failure messages.
+        last_prewarm_error: Most recent prewarm failure message, if any.
+
+    Example:
+        >>> SessionManagerMetrics(
+        ...     active_sessions=1,
+        ...     prewarm_failures=["boom"],
+        ...     last_prewarm_error="boom",
+        ... )
+        SessionManagerMetrics(active_sessions=1, prewarm_failures=['boom'], last_prewarm_error='boom')
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    active_sessions: int = Field(default=0, ge=0)
+    prewarm_failures: list[str] = Field(default_factory=list)
+    last_prewarm_error: str | None = Field(default=None)
+
+    @property
+    def prewarm_failure_count(self) -> int:
+        """Return the number of recorded prewarm failures."""
+
+        return len(self.prewarm_failures)
+
+
 class SessionManager:
     """Manage session lifecycle and publish events for downstream consumers."""
 
@@ -88,6 +119,11 @@ class SessionManager:
         self._clock = clock or (lambda: datetime.now(UTC))
         self._sessions: dict[UUID, Session] = {}
         self._lock = anyio.Lock()
+        self._active_sessions = 0
+        self._prewarm_failures: deque[str] = deque(
+            maxlen=settings.prewarm_failure_history_size
+        )
+        self._last_prewarm_error: str | None = None
 
     async def create_session(self, payload: SessionCreatePayload) -> Session:
         """Create, persist, and broadcast a new session object."""
@@ -120,6 +156,8 @@ class SessionManager:
                 metadata=payload.metadata,
             )
             self._sessions[session_id] = session
+            if session.status is not SessionStatus.DEAD:
+                self._active_sessions += 1
             await self._publish(session, SessionEventType.CREATED, reason=None)
             return session
 
@@ -147,6 +185,7 @@ class SessionManager:
                 update_data["metadata"] = {**existing.metadata, **merged_metadata}
             session = existing.model_copy(update=update_data, deep=True)
             self._sessions[session_id] = session
+            self._recalculate_active_sessions(existing.status, session.status)
             event_type = (
                 SessionEventType.ENDED
                 if session.status is SessionStatus.DEAD
@@ -187,6 +226,33 @@ class SessionManager:
         async with self._lock:
             return list(self._sessions.values())
 
+    async def record_prewarm_failure(self, message: str) -> None:
+        """Append ``message`` to the rolling prewarm failure history."""
+
+        async with self._lock:
+            self._prewarm_failures.append(message)
+            self._last_prewarm_error = message
+
+    async def reset_prewarm_failures(self) -> None:
+        """Clear recorded prewarm failures, typically after a successful run."""
+
+        async with self._lock:
+            self._prewarm_failures.clear()
+            self._last_prewarm_error = None
+
+    async def get_metrics(self) -> SessionManagerMetrics:
+        """Return a metrics snapshot safe to expose via diagnostics endpoints."""
+
+        async with self._lock:
+            active_sessions = self._active_sessions
+            failures = list(self._prewarm_failures)
+            last_error = self._last_prewarm_error
+        return SessionManagerMetrics(
+            active_sessions=active_sessions,
+            prewarm_failures=failures,
+            last_prewarm_error=last_error,
+        )
+
     def _resolve_vnc(
         self,
         payload: SessionCreatePayload,
@@ -194,7 +260,7 @@ class SessionManager:
     ) -> SessionVncDetails | None:
         """Return VNC details honouring payload overrides and settings defaults."""
 
-        if payload.headless:
+        if payload.headless or not self._settings.vnc_enabled:
             return None
         if payload.vnc is not None:
             return payload.vnc
@@ -205,6 +271,18 @@ class SessionManager:
             token=token,
             token_ttl_seconds=self._settings.vnc_token_ttl_seconds,
         )
+
+    def _recalculate_active_sessions(
+        self, previous_status: SessionStatus, current_status: SessionStatus
+    ) -> None:
+        """Update the active session counter based on a status transition."""
+
+        was_active = previous_status is not SessionStatus.DEAD
+        is_active = current_status is not SessionStatus.DEAD
+        if was_active and not is_active:
+            self._active_sessions = max(0, self._active_sessions - 1)
+        elif not was_active and is_active:
+            self._active_sessions += 1
 
     async def _publish(
         self,
@@ -228,5 +306,6 @@ __all__ = [
     "SessionCreatePayload",
     "SessionManager",
     "SessionNotFoundError",
+    "SessionManagerMetrics",
     "SessionUpdatePayload",
 ]

--- a/services/runner/tests/test_main.py
+++ b/services/runner/tests/test_main.py
@@ -1,0 +1,79 @@
+"""Unit tests for FastAPI endpoints exposed by the runner application."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+from app.config import RunnerSettings
+from app.dependencies.session_manager import (
+    get_event_publisher,
+    get_runner_settings,
+    get_session_manager,
+)
+from app.events import InMemorySessionEventPublisher
+from app.main import app
+from app.session_manager import SessionCreatePayload, SessionManager
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Force the anyio plugin to use the asyncio backend."""
+
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_health_endpoint_reports_extended_metrics() -> None:
+    """``GET /health`` should expose slots, proxy, VNC, and prewarm diagnostics."""
+
+    settings = RunnerSettings(
+        runner_id="runner-health",
+        camoufox_path="/usr/bin/camoufox",
+        slot_limit=3,
+        vnc_enabled=True,
+        vnc_http_base_url="http://localhost:9000/vnc",
+        vnc_ws_base_url="ws://localhost:9000/vnc",
+        proxy_enabled=True,
+        proxy_http_base_url="http://proxy.example:3128",
+        prewarm_failure_history_size=5,
+    )
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(settings, publisher)
+
+    await manager.create_session(SessionCreatePayload())
+    await manager.create_session(SessionCreatePayload())
+    await manager.record_prewarm_failure("prewarm timeout")
+    await manager.record_prewarm_failure("prewarm retry failed")
+
+    app.dependency_overrides[get_runner_settings] = lambda: settings
+    app.dependency_overrides[get_event_publisher] = lambda: publisher
+    app.dependency_overrides[get_session_manager] = lambda: manager
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.get("/health")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["runner_id"] == "runner-health"
+    assert payload["camoufox_path"].endswith("camoufox")
+    assert payload["slots"] == {"total": 3, "active": 2, "available": 1}
+    assert payload["vnc"] == {
+        "http_base_url": "http://localhost:9000/vnc",
+        "ws_base_url": "ws://localhost:9000/vnc",
+        "enabled": True,
+    }
+    assert payload["proxy"] == {
+        "enabled": True,
+        "http_base_url": "http://proxy.example:3128",
+        "https_base_url": None,
+        "socks_base_url": None,
+    }
+    assert payload["prewarm"] == {
+        "failures": 2,
+        "last_error": "prewarm retry failed",
+    }

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -103,3 +103,38 @@ async def test_end_session_sets_terminal_state_and_event() -> None:
     events = await publisher.drain()
     assert [event.type for event in events] == [SessionEventType.CREATED, SessionEventType.ENDED]
     assert events[-1].reason == "completed"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_metrics_track_active_sessions_and_prewarm_failures() -> None:
+    """Metrics should reflect active sessions and retain bounded prewarm errors."""
+
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(
+        RunnerSettings(
+            runner_id="runner-metrics",
+            camoufox_path="/usr/bin/camoufox",
+            slot_limit=3,
+            prewarm_failure_history_size=2,
+        ),
+        publisher,
+    )
+
+    first = await manager.create_session(SessionCreatePayload())
+    await manager.create_session(SessionCreatePayload())
+    await manager.record_prewarm_failure("warmup-1")
+    await manager.record_prewarm_failure("warmup-2")
+    metrics = await manager.get_metrics()
+
+    assert metrics.active_sessions == 2
+    assert metrics.prewarm_failure_count == 2
+    assert metrics.prewarm_failures == ["warmup-1", "warmup-2"]
+    assert metrics.last_prewarm_error == "warmup-2"
+
+    await manager.record_prewarm_failure("warmup-3")
+    metrics = await manager.get_metrics()
+    assert metrics.prewarm_failures == ["warmup-2", "warmup-3"]
+
+    await manager.end_session(first.id)
+    metrics = await manager.get_metrics()
+    assert metrics.active_sessions == 1


### PR DESCRIPTION
## Summary
- extend RunnerSettings with slot, proxy, VNC, and prewarm configuration knobs and expose new session metrics
- update /health endpoint to surface slot usage, proxy/VNC configuration, and prewarm diagnostics sourced from the session manager
- add unit tests covering the expanded health payload and SessionManager metrics tracking, plus refresh docs/notes for the new contract

## Testing
- poetry run pytest -q *(fails: missing optional dependencies camoufox/httpx prevent environment bootstrap)*

## Security
- no security-relevant changes


------
https://chatgpt.com/codex/tasks/task_e_68dcf1f3d5d4832a8e53ea2e700a50dc