### PR TITLE
feat(ui): sync session types with core models

### DIFF
--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -9,7 +9,9 @@
 - **VNC**: встраивание внешнего URL `session.vncUrl` в `iframe`.
 
 ## Data & Models
-- `Session`/`SessionEvent` описаны в `types/session.ts` (Zod схемы).
+- `Session`/`SessionEvent` описаны в `types/session.ts` (Zod схемы) и адаптеры `adaptSession*`
+  нормализуют snake_case FastAPI payload в camelCase модель UI (добавляют `region`,
+  `proxyId`, `proxyLabel`, `snapshotUrl`).
 - Состояние фильтров в `store/sessionFilters.ts` (Zustand).
 
 ## Decisions
@@ -37,3 +39,6 @@
 
 ## Changelog (for agents)
 - 2024-09-08 · gpt-5-codex · Начальная реализация консоли: авторизация, список/детали сессий, создание/удаление, SSE, темы, базовые тесты.
+- 2024-09-09 · gpt-5-codex · Перешли на модели core.Session/core.SessionEvent: адаптеры в
+  `types/session.ts`, хранение списка сессий напрямую в React Query, обновлены фильтры,
+  компоненты и тесты под статусы `INIT/READY/TERMINATING/DEAD`.

--- a/apps/ui/src/__tests__/sessionAdapter.test.ts
+++ b/apps/ui/src/__tests__/sessionAdapter.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { adaptSession, adaptSessionEvent, type RawSession, type RawSessionEvent } from '../types/session';
+
+describe('session adapters', () => {
+  const baseSession: RawSession = {
+    id: '00000000-0000-0000-0000-000000000001',
+    runner_id: 'runner-1',
+    status: 'READY',
+    created_at: '2024-01-01T00:00:00Z',
+    last_seen_at: '2024-01-01T00:10:00Z',
+    ended_at: null,
+    start_url: null,
+    start_url_wait: 'load',
+    headless: false,
+    idle_ttl_seconds: 300,
+    browser: 'camoufox',
+    labels: {
+      region: 'eu-central',
+      proxy_id: 'proxy-1',
+      proxy_label: 'Proxy One',
+    },
+    ws_endpoint: '/sessions/00000000-0000-0000-0000-000000000001/ws',
+    proxy: {
+      http: 'http://proxy.local:3128',
+      https: null,
+      socks: null,
+    },
+    vnc: {
+      http_url: 'https://vnc.example/view/1',
+      websocket_url: 'wss://vnc.example/ws/1',
+      token: 'opaque-token',
+      token_ttl_seconds: 60,
+    },
+    vnc_enabled: true,
+    metadata: {
+      snapshot_url: 'https://cdn.example/snapshots/1.png',
+    },
+  };
+
+  it('normalises session payloads to camelCase fields', () => {
+    const session = adaptSession(baseSession);
+
+    expect(session).toMatchObject({
+      id: baseSession.id,
+      runnerId: baseSession.runner_id,
+      status: baseSession.status,
+      createdAt: baseSession.created_at,
+      lastSeenAt: baseSession.last_seen_at,
+      region: 'eu-central',
+      proxyId: 'proxy-1',
+      proxyLabel: 'Proxy One',
+      snapshotUrl: 'https://cdn.example/snapshots/1.png',
+    });
+    expect(session.proxy).toEqual({
+      http: 'http://proxy.local:3128',
+      https: null,
+      socks: null,
+    });
+    expect(session.vnc).toEqual({
+      httpUrl: 'https://vnc.example/view/1',
+      websocketUrl: 'wss://vnc.example/ws/1',
+      token: 'opaque-token',
+      tokenTtlSeconds: 60,
+    });
+  });
+
+  it('derives event metadata and terminal flag', () => {
+    const event: RawSessionEvent = {
+      id: '11111111-1111-1111-1111-111111111111',
+      type: 'session.updated',
+      occurred_at: '2024-01-01T00:10:00Z',
+      reason: null,
+      session: baseSession,
+    };
+
+    const adapted = adaptSessionEvent(event);
+    expect(adapted).toMatchObject({
+      id: event.id,
+      type: event.type,
+      occurredAt: event.occurred_at,
+      isTerminal: false,
+    });
+    expect(adapted.session.id).toBe(baseSession.id);
+  });
+});

--- a/apps/ui/src/__tests__/sessionFilters.test.ts
+++ b/apps/ui/src/__tests__/sessionFilters.test.ts
@@ -16,7 +16,7 @@ describe('useSessionFilters', () => {
 
   it('resets to initial values', () => {
     const { setStatus, setRegion, setProxyId, reset } = getState();
-    setStatus('active');
+    setStatus('READY');
     setRegion('eu');
     setProxyId('proxy-1');
     reset();

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod';
-import { SessionSchema, SessionEventSchema } from '../types/session';
+import {
+  SessionSchema,
+  SessionEventSchema,
+  adaptSession,
+  adaptSessionEvent,
+  type Session,
+  type SessionEvent,
+} from '../types/session';
 import { createUrl } from '../utils/url';
-
-const sessionCollectionSchema = z.object({
-  sessions: z.array(SessionSchema),
-});
 
 /**
  * Declares the shape of the API client configuration.
@@ -108,10 +111,12 @@ const gatewayUrl = import.meta.env.VITE_GATEWAY_URL ?? 'http://localhost:8000';
 export const apiClient = new ApiClient({ baseUrl: gatewayUrl });
 
 /**
- * Fetches the session collection.
+ * Fetches the session collection and normalises the payload for the UI.
  */
-export const fetchSessions = async (headers?: AuthHeaders) =>
-  apiClient.get('/sessions', sessionCollectionSchema, headers);
+export const fetchSessions = async (headers?: AuthHeaders): Promise<Session[]> => {
+  const payload = await apiClient.get('/sessions', z.array(SessionSchema), headers);
+  return payload.map(adaptSession);
+};
 
 /**
  * Creates a new session.
@@ -119,8 +124,7 @@ export const fetchSessions = async (headers?: AuthHeaders) =>
 export const createSession = async (
   payload: Record<string, unknown>,
   headers?: AuthHeaders,
-) =>
-  apiClient.post('/sessions', SessionSchema, payload, headers);
+): Promise<Session> => apiClient.post('/sessions', SessionSchema, payload, headers).then(adaptSession);
 
 /**
  * Deletes an existing session.
@@ -140,9 +144,10 @@ export const openSessionEventStream = (headers?: AuthHeaders) => {
   const eventSource = new EventSource(url);
   return {
     eventSource,
-    parseEvent: (event: MessageEvent<string>) => {
+    parseEvent: (event: MessageEvent<string>): SessionEvent => {
       const payload: unknown = JSON.parse(event.data);
-      return SessionEventSchema.parse(payload);
+      const parsed = SessionEventSchema.parse(payload);
+      return adaptSessionEvent(parsed);
     },
   };
 };

--- a/apps/ui/src/components/SessionDetailsPanel.tsx
+++ b/apps/ui/src/components/SessionDetailsPanel.tsx
@@ -29,11 +29,17 @@ export function SessionDetailsPanel({ session }: SessionDetailsPanelProps): JSX.
     );
   }
 
+  const regionLabel = session.region ?? '—';
+  const proxyLabel =
+    session.proxyLabel ?? session.proxy?.http ?? session.proxy?.https ?? session.proxy?.socks ?? '—';
+  const snapshotUrl = session.snapshotUrl;
+  const vncUrl = session.vnc?.httpUrl ?? session.vnc?.websocketUrl ?? null;
+
   return (
     <aside className="session-details">
       <header>
-        <h2>{session.browser.name}</h2>
-        <span className="session-details__subtitle">{session.browser.version}</span>
+        <h2>{session.browser}</h2>
+        <span className="session-details__subtitle">{session.runnerId}</span>
       </header>
       <section>
         <dl className="session-details__grid">
@@ -43,11 +49,11 @@ export function SessionDetailsPanel({ session }: SessionDetailsPanelProps): JSX.
           </div>
           <div>
             <dt>Регион</dt>
-            <dd>{session.region}</dd>
+            <dd>{regionLabel}</dd>
           </div>
           <div>
             <dt>Прокси</dt>
-            <dd>{session.proxy?.label ?? '—'}</dd>
+            <dd>{proxyLabel}</dd>
           </div>
           <div>
             <dt>Создана</dt>
@@ -55,7 +61,7 @@ export function SessionDetailsPanel({ session }: SessionDetailsPanelProps): JSX.
           </div>
           <div>
             <dt>Обновлена</dt>
-            <dd>{formatTimestamp(session.updatedAt)}</dd>
+            <dd>{formatTimestamp(session.lastSeenAt)}</dd>
           </div>
         </dl>
       </section>
@@ -71,18 +77,18 @@ export function SessionDetailsPanel({ session }: SessionDetailsPanelProps): JSX.
           </ul>
         </section>
       )}
-      {session.snapshotUrl && (
+      {snapshotUrl && (
         <section>
           <h3>Снимок</h3>
-          <img src={session.snapshotUrl} alt="Снимок экрана" className="session-details__snapshot" />
+          <img src={snapshotUrl} alt="Снимок экрана" className="session-details__snapshot" />
         </section>
       )}
-      {session.vncUrl && (
+      {vncUrl && (
         <section>
           <h3>Онлайн доступ</h3>
           <iframe
             title="VNC"
-            src={session.vncUrl}
+            src={vncUrl}
             className="session-details__vnc"
             allow="clipboard-read; clipboard-write"
           />

--- a/apps/ui/src/components/SessionListItem.tsx
+++ b/apps/ui/src/components/SessionListItem.tsx
@@ -12,6 +12,10 @@ interface SessionListItemProps {
  * Individual card in the session grid.
  */
 export function SessionListItem({ session, isActive, onSelect }: SessionListItemProps): JSX.Element {
+  const regionLabel = session.region ?? '—';
+  const proxyLabel =
+    session.proxyLabel ?? session.proxy?.http ?? session.proxy?.https ?? session.proxy?.socks ?? '—';
+
   return (
     <li>
       <button
@@ -22,8 +26,8 @@ export function SessionListItem({ session, isActive, onSelect }: SessionListItem
       >
         <div className="session-card__header">
           <div>
-            <h3>{session.browser.name}</h3>
-            <span className="session-card__subtitle">{session.browser.version}</span>
+            <h3>{session.browser}</h3>
+            <span className="session-card__subtitle">{session.runnerId}</span>
           </div>
           <StatusBadge status={session.status} />
         </div>
@@ -35,15 +39,15 @@ export function SessionListItem({ session, isActive, onSelect }: SessionListItem
             </div>
             <div>
               <dt>Регион</dt>
-              <dd>{session.region}</dd>
+              <dd>{regionLabel}</dd>
             </div>
             <div>
               <dt>Прокси</dt>
-              <dd>{session.proxy?.label ?? '—'}</dd>
+              <dd>{proxyLabel}</dd>
             </div>
             <div>
               <dt>Обновлено</dt>
-              <dd>{formatTimestamp(session.updatedAt)}</dd>
+              <dd>{formatTimestamp(session.lastSeenAt)}</dd>
             </div>
           </dl>
         </div>

--- a/apps/ui/src/components/SessionToolbar.tsx
+++ b/apps/ui/src/components/SessionToolbar.tsx
@@ -9,10 +9,10 @@ interface SessionToolbarProps {
 
 const statusOptions: { readonly value: SessionStatusFilter; readonly label: string }[] = [
   { value: 'all', label: 'Все' },
-  { value: 'pending', label: 'Ожидают' },
-  { value: 'active', label: 'Активные' },
-  { value: 'failed', label: 'Ошибка' },
-  { value: 'completed', label: 'Готовые' },
+  { value: 'INIT', label: 'Инициализация' },
+  { value: 'READY', label: 'Готовы' },
+  { value: 'TERMINATING', label: 'Завершаются' },
+  { value: 'DEAD', label: 'Завершены' },
 ];
 
 /**
@@ -24,15 +24,19 @@ export function SessionToolbar({ sessions, onCreate }: SessionToolbarProps): JSX
 
   const regionOptions = useMemo(() => {
     const unique = new Set<string>();
-    sessions.forEach((session) => unique.add(session.region));
+    sessions.forEach((session) => {
+      if (session.region) {
+        unique.add(session.region);
+      }
+    });
     return Array.from(unique.values());
   }, [sessions]);
 
   const proxyOptions = useMemo(() => {
     const unique = new Map<string, string>();
     sessions.forEach((session) => {
-      if (session.proxy) {
-        unique.set(session.proxy.id, session.proxy.label);
+      if (session.proxyId) {
+        unique.set(session.proxyId, session.proxyLabel ?? session.proxyId);
       }
     });
     return Array.from(unique.entries());

--- a/apps/ui/src/components/StatusBadge.tsx
+++ b/apps/ui/src/components/StatusBadge.tsx
@@ -1,21 +1,21 @@
-import { Session } from '../types/session';
+import type { SessionStatus } from '../types/session';
 
-const statusColors: Record<Session['status'], string> = {
-  pending: '#facc15',
-  active: '#34d399',
-  failed: '#f87171',
-  completed: '#60a5fa',
+const statusColors: Record<SessionStatus, string> = {
+  INIT: '#facc15',
+  READY: '#34d399',
+  TERMINATING: '#fb923c',
+  DEAD: '#9ca3af',
 };
 
-const statusLabels: Record<Session['status'], string> = {
-  pending: 'Ожидание',
-  active: 'Активна',
-  failed: 'Ошибка',
-  completed: 'Завершена',
+const statusLabels: Record<SessionStatus, string> = {
+  INIT: 'Инициализация',
+  READY: 'Готова',
+  TERMINATING: 'Завершается',
+  DEAD: 'Завершена',
 };
 
 interface StatusBadgeProps {
-  readonly status: Session['status'];
+  readonly status: SessionStatus;
 }
 
 /**

--- a/apps/ui/src/hooks/useSessionEvents.ts
+++ b/apps/ui/src/hooks/useSessionEvents.ts
@@ -45,24 +45,9 @@ export const useSessionEvents = ({ enabled, token }: UseSessionEventsOptions) =>
 
       eventSource.onmessage = (event: MessageEvent<string>) => {
         const data = parseEvent(event);
-        queryClient.setQueryData<{ sessions: Session[] }>(queryKeys.sessions, (current) => {
-          if (!current) {
-            return current;
-          }
-
-          if (data.type === 'deleted') {
-            return {
-              sessions: current.sessions.filter((session) => session.id !== data.sessionId),
-            };
-          }
-
-          if (data.session) {
-            return {
-              sessions: mergeSession(current.sessions, data.session as Session),
-            };
-          }
-
-          return current;
+        queryClient.setQueryData<Session[]>(queryKeys.sessions, (current) => {
+          const baseline = current ?? [];
+          return mergeSession(baseline, data.session);
         });
       };
 

--- a/apps/ui/src/pages/DashboardPage.tsx
+++ b/apps/ui/src/pages/DashboardPage.tsx
@@ -12,8 +12,6 @@ import { queryKeys } from '../utils/queryKeys';
 import { useSessionFilters, type SessionStatusFilter } from '../store/sessionFilters';
 import { Session } from '../types/session';
 
-const EMPTY_SESSIONS: Session[] = [];
-
 const filterSessions = (
   sessions: Session[],
   search: string,
@@ -31,7 +29,7 @@ const filterSessions = (
       return false;
     }
 
-    if (proxyId && session.proxy?.id !== proxyId) {
+    if (proxyId && session.proxyId !== proxyId) {
       return false;
     }
 
@@ -39,10 +37,12 @@ const filterSessions = (
       return true;
     }
 
-    const proxyLabel = session.proxy?.label?.toLowerCase() ?? '';
+    const regionLabel = session.region?.toLowerCase() ?? '';
+    const proxyLabel = session.proxyLabel?.toLowerCase() ?? '';
     return (
       session.id.toLowerCase().includes(normalized) ||
-      session.region.toLowerCase().includes(normalized) ||
+      session.runnerId.toLowerCase().includes(normalized) ||
+      regionLabel.includes(normalized) ||
       proxyLabel.includes(normalized)
     );
   });
@@ -64,7 +64,7 @@ export function DashboardPage(): JSX.Element {
     refetchInterval: 15_000,
   });
 
-  const sessions = data?.sessions ?? EMPTY_SESSIONS;
+  const sessions = data ?? [];
 
   const filteredSessions = useMemo(
     () => filterSessions(sessions, search, status, region, proxyId),

--- a/apps/ui/src/store/sessionFilters.ts
+++ b/apps/ui/src/store/sessionFilters.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
+import type { SessionStatus } from '../types/session';
 
-export type SessionStatusFilter = 'all' | 'pending' | 'active' | 'failed' | 'completed';
+export type SessionStatusFilter = 'all' | SessionStatus;
 
 interface SessionFiltersState {
   readonly search: string;

--- a/apps/ui/src/types/session.ts
+++ b/apps/ui/src/types/session.ts
@@ -1,53 +1,208 @@
 import { z } from 'zod';
 
 /**
- * Zod schema describing the proxy metadata attached to a session.
+ * Enumerates lifecycle statuses reported by the backend for a session.
  */
-export const ProxySchema = z.object({
-  id: z.string(),
-  label: z.string(),
-  latencyMs: z.number().nullable(),
+export const SessionStatusSchema = z.enum(['INIT', 'READY', 'TERMINATING', 'DEAD']);
+
+/**
+ * Enumerates the event types emitted through the session event stream.
+ */
+export const SessionEventTypeSchema = z.enum([
+  'session.created',
+  'session.updated',
+  'session.ended',
+]);
+
+/**
+ * Zod schema describing the proxy configuration attached to a session payload.
+ */
+export const SessionProxySchema = z.object({
+  http: z.string().url().nullable(),
+  https: z.string().url().nullable(),
+  socks: z.string().url().nullable(),
 });
 
 /**
- * Zod schema describing the browser metadata associated with a session.
+ * Zod schema describing the VNC connection parameters for a session.
  */
-export const BrowserSchema = z.object({
-  name: z.string(),
-  version: z.string(),
+export const SessionVncSchema = z.object({
+  http_url: z.string().url().nullable(),
+  websocket_url: z.string().url().nullable(),
+  token: z.string().nullable(),
+  token_ttl_seconds: z.number().int().positive().nullable(),
 });
 
 /**
- * Zod schema for an individual browser session.
+ * Zod schema for the raw session representation returned by FastAPI.
  */
 export const SessionSchema = z.object({
-  id: z.string(),
-  status: z.enum(['pending', 'active', 'failed', 'completed']),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  region: z.string(),
-  proxy: ProxySchema.nullable(),
-  browser: BrowserSchema,
-  snapshotUrl: z.string().url().nullable(),
-  vncUrl: z.string().url().nullable(),
-  metadata: z.record(z.string()).default({}),
+  id: z.string().uuid(),
+  runner_id: z.string(),
+  status: SessionStatusSchema,
+  created_at: z.string(),
+  last_seen_at: z.string(),
+  ended_at: z.string().nullable(),
+  start_url: z.string().url().nullable(),
+  start_url_wait: z.enum(['none', 'domcontentloaded', 'load']),
+  headless: z.boolean(),
+  idle_ttl_seconds: z.number(),
+  browser: z.string(),
+  labels: z.record(z.string()).default({}),
+  ws_endpoint: z.string().nullable(),
+  proxy: SessionProxySchema.nullable(),
+  vnc: SessionVncSchema.nullable(),
+  vnc_enabled: z.boolean().nullable(),
+  metadata: z.record(z.unknown()).default({}),
 });
 
 /**
- * Session event schema used by the SSE stream.
+ * Zod schema for the raw session event representation streamed by FastAPI.
  */
 export const SessionEventSchema = z.object({
-  type: z.enum(['created', 'updated', 'deleted', 'snapshot']),
-  session: SessionSchema.partial(),
-  sessionId: z.string(),
+  id: z.string().uuid(),
+  type: SessionEventTypeSchema,
+  session: SessionSchema,
+  occurred_at: z.string(),
+  reason: z.string().nullable(),
 });
 
-/**
- * TypeScript representation of a session.
- */
-export type Session = z.infer<typeof SessionSchema>;
+export type SessionStatus = z.infer<typeof SessionStatusSchema>;
+export type SessionEventType = z.infer<typeof SessionEventTypeSchema>;
+export type RawSession = z.infer<typeof SessionSchema>;
+export type RawSessionEvent = z.infer<typeof SessionEventSchema>;
+export type StartUrlWait = RawSession['start_url_wait'];
 
 /**
- * TypeScript representation of a session event.
+ * UI-friendly proxy descriptor with camelCase keys.
  */
-export type SessionEvent = z.infer<typeof SessionEventSchema>;
+export interface SessionProxy {
+  readonly http: string | null;
+  readonly https: string | null;
+  readonly socks: string | null;
+}
+
+/**
+ * UI-friendly VNC descriptor with camelCase keys.
+ */
+export interface SessionVnc {
+  readonly httpUrl: string | null;
+  readonly websocketUrl: string | null;
+  readonly token: string | null;
+  readonly tokenTtlSeconds: number | null;
+}
+
+/**
+ * Normalised session object consumed by the React UI.
+ */
+export interface Session {
+  readonly id: string;
+  readonly runnerId: string;
+  readonly status: SessionStatus;
+  readonly createdAt: string;
+  readonly lastSeenAt: string;
+  readonly endedAt: string | null;
+  readonly startUrl: string | null;
+  readonly startUrlWait: StartUrlWait;
+  readonly headless: boolean;
+  readonly idleTtlSeconds: number;
+  readonly browser: string;
+  readonly wsEndpoint: string | null;
+  readonly proxy: SessionProxy | null;
+  readonly vnc: SessionVnc | null;
+  readonly vncEnabled: boolean | null;
+  readonly labels: Record<string, string>;
+  readonly metadata: Record<string, unknown>;
+  readonly region: string | null;
+  readonly proxyId: string | null;
+  readonly proxyLabel: string | null;
+  readonly snapshotUrl: string | null;
+}
+
+/**
+ * Normalised session event consumed by the React UI.
+ */
+export interface SessionEvent {
+  readonly id: string;
+  readonly type: SessionEventType;
+  readonly occurredAt: string;
+  readonly reason: string | null;
+  readonly session: Session;
+  readonly isTerminal: boolean;
+}
+
+/**
+ * Converts a raw proxy payload into the UI representation.
+ */
+export const adaptProxy = (proxy: RawSession['proxy']): SessionProxy | null => {
+  if (!proxy) {
+    return null;
+  }
+
+  return {
+    http: proxy.http ?? null,
+    https: proxy.https ?? null,
+    socks: proxy.socks ?? null,
+  };
+};
+
+/**
+ * Converts raw VNC data into the UI representation.
+ */
+export const adaptVnc = (vnc: RawSession['vnc']): SessionVnc | null => {
+  if (!vnc) {
+    return null;
+  }
+
+  return {
+    httpUrl: vnc.http_url ?? null,
+    websocketUrl: vnc.websocket_url ?? null,
+    token: vnc.token ?? null,
+    tokenTtlSeconds: vnc.token_ttl_seconds ?? null,
+  };
+};
+
+/**
+ * Converts the snake_case FastAPI session payload into the camelCase UI variant.
+ */
+export const adaptSession = (session: RawSession): Session => {
+  const labels = session.labels ?? {};
+  const metadata = session.metadata ?? {};
+  const snapshotValue = metadata['snapshot_url'];
+
+  return {
+    id: session.id,
+    runnerId: session.runner_id,
+    status: session.status,
+    createdAt: session.created_at,
+    lastSeenAt: session.last_seen_at,
+    endedAt: session.ended_at ?? null,
+    startUrl: session.start_url ?? null,
+    startUrlWait: session.start_url_wait,
+    headless: session.headless,
+    idleTtlSeconds: session.idle_ttl_seconds,
+    browser: session.browser,
+    wsEndpoint: session.ws_endpoint ?? null,
+    proxy: adaptProxy(session.proxy),
+    vnc: adaptVnc(session.vnc),
+    vncEnabled: session.vnc_enabled ?? null,
+    labels,
+    metadata,
+    region: labels.region ?? null,
+    proxyId: labels.proxy_id ?? null,
+    proxyLabel: labels.proxy_label ?? labels.proxy_id ?? null,
+    snapshotUrl: typeof snapshotValue === 'string' ? snapshotValue : null,
+  };
+};
+
+/**
+ * Converts the raw FastAPI session event into the UI representation.
+ */
+export const adaptSessionEvent = (event: RawSessionEvent): SessionEvent => ({
+  id: event.id,
+  type: event.type,
+  occurredAt: event.occurred_at,
+  reason: event.reason ?? null,
+  session: adaptSession(event.session),
+  isTerminal: event.session.status === 'DEAD',
+});


### PR DESCRIPTION
## Summary
- align session Zod schemas with core.Session/core.SessionEvent and provide adapters that emit camelCase UI models with derived metadata
- return a flat, normalised session list from the API client and update dashboard, toolbar, details and status badge to use INIT/READY lifecycle states
- refresh React Query SSE merging and unit coverage (new adapter tests) plus document the data model shift in AGENT_NOTES

## Testing
- ⚠️ `pnpm -C apps/ui test` *(fails: vitest binary missing until dependencies are installed)*

## Security
- no security-impacting changes

------
https://chatgpt.com/codex/tasks/task_e_68dd065b570c832a9d73d70d670ca11e