### PR TITLE
Add SSE query token auth and update session events

### DIFF
--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -5,11 +5,11 @@
 
 ## Interfaces
 - **REST**: `/sessions` (GET/POST/DELETE) через `api/client.ts`.
-- **SSE**: `/sessions/stream` — автообновление списка сессий, перезапуск с экспоненциальной задержкой.
+- **SSE**: `/events` — автообновление списка сессий, перезапуск с экспоненциальной задержкой; авторизация через query `access_token` для `EventSource`.
 - **VNC**: встраивание внешнего URL `session.vncUrl` в `iframe`.
 
 ## Data & Models
-- `Session`/`SessionEvent` описаны в `types/session.ts` (Zod схемы).
+- `Session`/`SessionEvent` описаны в `types/session.ts` (Zod схемы, события `session.created|updated|ended`).
 - Состояние фильтров в `store/sessionFilters.ts` (Zustand).
 
 ## Decisions
@@ -37,3 +37,4 @@
 
 ## Changelog (for agents)
 - 2024-09-08 · gpt-5-codex · Начальная реализация консоли: авторизация, список/детали сессий, создание/удаление, SSE, темы, базовые тесты.
+- 2025-10-01 · gpt-5-codex · Переключение SSE на `/events`, поддержка `access_token` в query, реальные типы событий и юнит-тесты перезаподключения.

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -7,6 +7,8 @@ const sessionCollectionSchema = z.array(SessionSchema);
 
 /**
  * Declares the shape of the API client configuration.
+ *
+ * @property baseUrl - Gateway origin used as the prefix for every request.
  */
 export interface ApiClientConfig {
   /** Base URL of the Ghost Browsers gateway service. */
@@ -15,6 +17,8 @@ export interface ApiClientConfig {
 
 /**
  * Describes the headers required for authenticated requests.
+ *
+ * @property token - Optional bearer token to attach to outgoing requests.
  */
 export interface AuthHeaders {
   /** Bearer access token. */
@@ -23,6 +27,14 @@ export interface AuthHeaders {
 
 /**
  * Small fetch wrapper tailored to the Ghost Browsers API surface.
+ *
+ * @example
+ * ```ts
+ * const client = new ApiClient({ baseUrl: 'https://gateway.example' });
+ * const sessions = await client.get('/sessions', sessionCollectionSchema, {
+ *   token: 'bearer-token',
+ * });
+ * ```
  */
 export class ApiClient {
   private readonly baseUrl: string;
@@ -33,6 +45,12 @@ export class ApiClient {
 
   /**
    * Performs a GET request and decodes the JSON response through the provided Zod schema.
+   *
+   * @param path - Relative endpoint path (e.g. ``/sessions``).
+   * @param schema - Zod schema used to validate and parse the response.
+   * @param headers - Optional authentication context for the request.
+   * @returns The parsed payload typed by the supplied schema.
+   * @throws Error when the HTTP response is not successful or the payload fails validation.
    */
   public async get<T>(path: string, schema: z.ZodSchema<T>, headers?: AuthHeaders): Promise<T> {
     const response = await fetch(createUrl(this.baseUrl, path), {
@@ -50,6 +68,13 @@ export class ApiClient {
 
   /**
    * Performs a POST request with JSON body and returns the decoded payload.
+   *
+   * @param path - Relative endpoint path to call.
+   * @param schema - Zod schema used for decoding the JSON response body.
+   * @param body - Request payload encoded as JSON.
+   * @param headers - Optional authentication context for the request.
+   * @returns Parsed response body typed by ``schema``.
+   * @throws Error when the response is unsuccessful or the payload fails validation.
    */
   public async post<T>(
     path: string,
@@ -76,6 +101,10 @@ export class ApiClient {
 
   /**
    * Performs a DELETE request.
+   *
+   * @param path - Endpoint path identifying the resource to remove.
+   * @param headers - Optional authentication context for the request.
+   * @throws Error when the response is unsuccessful.
    */
   public async delete(path: string, headers?: AuthHeaders): Promise<void> {
     const response = await fetch(createUrl(this.baseUrl, path), {
@@ -108,12 +137,19 @@ export const apiClient = new ApiClient({ baseUrl: gatewayUrl });
 
 /**
  * Fetches the session collection.
+ *
+ * @param headers - Optional authentication context containing the bearer token.
+ * @returns Promise resolving to the typed session list.
  */
 export const fetchSessions = async (headers?: AuthHeaders) =>
   apiClient.get('/sessions', sessionCollectionSchema, headers);
 
 /**
  * Creates a new session.
+ *
+ * @param payload - Request body conforming to the session creation contract.
+ * @param headers - Optional authentication context containing the bearer token.
+ * @returns Promise resolving to the newly created session instance.
  */
 export const createSession = async (
   payload: Record<string, unknown>,
@@ -123,6 +159,10 @@ export const createSession = async (
 
 /**
  * Deletes an existing session.
+ *
+ * @param sessionId - Identifier of the session to remove.
+ * @param headers - Optional authentication context containing the bearer token.
+ * @returns Promise that resolves once the deletion succeeds.
  */
 export const deleteSession = (sessionId: string, headers?: AuthHeaders) =>
   apiClient.delete(`/sessions/${sessionId}`, headers);
@@ -134,6 +174,17 @@ export const deleteSession = (sessionId: string, headers?: AuthHeaders) =>
  * token either through the ``Authorization`` header or the ``access_token``
  * query parameter.  We rely on the latter to authenticate native
  * ``EventSource`` instances.
+ *
+ * @param headers - Optional authentication context containing the bearer token.
+ * @returns ``EventSource`` handle and a parser that converts raw messages into ``SessionEvent``.
+ * @example
+ * ```ts
+ * const { eventSource, parseEvent } = openSessionEventStream({ token: 'abc' });
+ * eventSource.onmessage = (message) => {
+ *   const event = parseEvent(message);
+ *   console.log(event.type);
+ * };
+ * ```
  */
 export const openSessionEventStream = (headers?: AuthHeaders) => {
   const url = new URL(createUrl(gatewayUrl, '/events'));

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -1,10 +1,9 @@
 import { z } from 'zod';
 import { SessionSchema, SessionEventSchema } from '../types/session';
+import type { SessionEvent } from '../types/session';
 import { createUrl } from '../utils/url';
 
-const sessionCollectionSchema = z.object({
-  sessions: z.array(SessionSchema),
-});
+const sessionCollectionSchema = z.array(SessionSchema);
 
 /**
  * Declares the shape of the API client configuration.
@@ -130,17 +129,22 @@ export const deleteSession = (sessionId: string, headers?: AuthHeaders) =>
 
 /**
  * Opens a typed EventSource connection for session updates.
+ *
+ * The gateway exposes session events via ``/events`` and accepts the bearer
+ * token either through the ``Authorization`` header or the ``access_token``
+ * query parameter.  We rely on the latter to authenticate native
+ * ``EventSource`` instances.
  */
 export const openSessionEventStream = (headers?: AuthHeaders) => {
-  const url = new URL(createUrl(gatewayUrl, '/sessions/stream'));
+  const url = new URL(createUrl(gatewayUrl, '/events'));
   if (headers?.token) {
     url.searchParams.set('access_token', headers.token);
   }
 
-  const eventSource = new EventSource(url);
+  const eventSource = new EventSource(url.toString());
   return {
     eventSource,
-    parseEvent: (event: MessageEvent<string>) => {
+    parseEvent: (event: MessageEvent<string>): SessionEvent => {
       const payload: unknown = JSON.parse(event.data);
       return SessionEventSchema.parse(payload);
     },

--- a/apps/ui/src/hooks/useSessionEvents.test.tsx
+++ b/apps/ui/src/hooks/useSessionEvents.test.tsx
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+import { useSessionEvents } from './useSessionEvents';
+import { queryKeys } from '../utils/queryKeys';
+import type { Session, SessionEvent } from '../types/session';
+
+interface CapturedEventSource {
+  onmessage: ((event: MessageEvent<string>) => void) | null;
+  onerror: ((event: Event) => void) | null;
+  onopen: ((event: Event) => void) | null;
+  close: ReturnType<typeof vi.fn>;
+  url: string;
+}
+
+const createdStreams: CapturedEventSource[] = [];
+
+class MockEventSource {
+  public onmessage: ((event: MessageEvent<string>) => void) | null = null;
+  public onerror: ((event: Event) => void) | null = null;
+  public onopen: ((event: Event) => void) | null = null;
+  public readonly close = vi.fn();
+  public readonly url: string;
+
+  public constructor(url: string | URL) {
+    this.url = url instanceof URL ? url.toString() : url;
+    createdStreams.push(this);
+  }
+}
+
+const originalEventSource = globalThis.EventSource;
+
+let sessionCounter = 0;
+
+const createSession = (overrides: Partial<Session> = {}): Session => ({
+  id: overrides.id ?? `session-${sessionCounter++}`,
+  status: overrides.status ?? 'active',
+  createdAt: overrides.createdAt ?? '2025-10-01T00:00:00.000Z',
+  updatedAt: overrides.updatedAt ?? '2025-10-01T00:00:00.000Z',
+  region: overrides.region ?? 'eu-central',
+  proxy: overrides.proxy ?? null,
+  browser: overrides.browser ?? { name: 'camoufox', version: '1.0.0' },
+  snapshotUrl: overrides.snapshotUrl ?? null,
+  vncUrl: overrides.vncUrl ?? null,
+  metadata: overrides.metadata ?? {},
+});
+
+const renderWithClient = (client: QueryClient, token?: string) =>
+  renderHook(() => useSessionEvents({ enabled: true, token }), {
+    wrapper: ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    ),
+  });
+
+describe('useSessionEvents', () => {
+  beforeEach(() => {
+    createdStreams.length = 0;
+    sessionCounter = 0;
+    globalThis.EventSource = MockEventSource as unknown as typeof EventSource;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalEventSource) {
+      globalThis.EventSource = originalEventSource;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete -- test cleanup
+      delete (globalThis as Record<string, unknown>).EventSource;
+    }
+  });
+
+  it('prepends new sessions on session.created events', () => {
+    const queryClient = new QueryClient();
+    const existing = createSession({ id: 'existing' });
+    queryClient.setQueryData<Session[]>(queryKeys.sessions, [existing]);
+
+    const hook = renderWithClient(queryClient, 'token-1');
+
+    const stream = createdStreams.at(-1);
+    expect(stream).toBeDefined();
+    expect(stream?.url).toContain('access_token=token-1');
+
+    const created = createSession({ id: 'new-session', status: 'pending' });
+    const event: SessionEvent = {
+      id: '00000000-0000-0000-0000-000000000001',
+      type: 'session.created',
+      occurredAt: '2025-10-01T00:00:01.000Z',
+      reason: null,
+      session: created,
+    };
+
+    act(() => {
+      stream?.onmessage?.({ data: JSON.stringify(event) } as MessageEvent<string>);
+    });
+
+    const sessions = queryClient.getQueryData<Session[]>(queryKeys.sessions);
+    expect(sessions).toHaveLength(2);
+    expect(sessions?.[0].id).toBe('new-session');
+    expect(sessions?.[1].id).toBe('existing');
+
+    hook.unmount();
+    queryClient.clear();
+  });
+
+  it('updates existing sessions on session.updated events', () => {
+    const queryClient = new QueryClient();
+    const existing = createSession({ id: 'session-1', status: 'pending' });
+    queryClient.setQueryData<Session[]>(queryKeys.sessions, [existing]);
+
+    const hook = renderWithClient(queryClient);
+    const stream = createdStreams.at(-1);
+    expect(stream).toBeDefined();
+
+    const updated = { ...existing, status: 'active', updatedAt: '2025-10-01T00:10:00.000Z' } as Session;
+    const event: SessionEvent = {
+      id: '00000000-0000-0000-0000-000000000002',
+      type: 'session.updated',
+      occurredAt: '2025-10-01T00:10:00.000Z',
+      reason: null,
+      session: updated,
+    };
+
+    act(() => {
+      stream?.onmessage?.({ data: JSON.stringify(event) } as MessageEvent<string>);
+    });
+
+    const sessions = queryClient.getQueryData<Session[]>(queryKeys.sessions);
+    expect(sessions).toHaveLength(1);
+    expect(sessions?.[0].status).toBe('active');
+    expect(sessions?.[0].updatedAt).toBe('2025-10-01T00:10:00.000Z');
+
+    hook.unmount();
+    queryClient.clear();
+  });
+
+  it('removes sessions on session.ended events', () => {
+    const queryClient = new QueryClient();
+    const first = createSession({ id: 'session-a' });
+    const second = createSession({ id: 'session-b' });
+    queryClient.setQueryData<Session[]>(queryKeys.sessions, [first, second]);
+
+    const hook = renderWithClient(queryClient);
+    const stream = createdStreams.at(-1);
+    expect(stream).toBeDefined();
+
+    const event: SessionEvent = {
+      id: '00000000-0000-0000-0000-000000000003',
+      type: 'session.ended',
+      occurredAt: '2025-10-01T00:15:00.000Z',
+      reason: 'completed',
+      session: first,
+    };
+
+    act(() => {
+      stream?.onmessage?.({ data: JSON.stringify(event) } as MessageEvent<string>);
+    });
+
+    const sessions = queryClient.getQueryData<Session[]>(queryKeys.sessions);
+    expect(sessions).toHaveLength(1);
+    expect(sessions?.[0].id).toBe('session-b');
+
+    hook.unmount();
+    queryClient.clear();
+  });
+
+  it('reconnects with exponential backoff on failures', () => {
+    vi.useFakeTimers();
+    const timeoutSpy = vi.spyOn(window, 'setTimeout');
+    const queryClient = new QueryClient();
+    queryClient.setQueryData<Session[]>(queryKeys.sessions, []);
+
+    const hook = renderWithClient(queryClient, 'token-2');
+    const first = createdStreams.at(-1);
+    expect(first).toBeDefined();
+
+    act(() => {
+      first?.onerror?.(new Event('error'));
+    });
+
+    expect(first?.close).toHaveBeenCalledTimes(1);
+    const initialTimerCalls = timeoutSpy.mock.calls.length;
+    expect(initialTimerCalls).toBeGreaterThan(0);
+    const firstDelay = timeoutSpy.mock.calls[initialTimerCalls - 1]?.[1] as number;
+    expect(firstDelay).toBe(2_000);
+
+    vi.advanceTimersByTime(2_000);
+    expect(createdStreams).toHaveLength(2);
+
+    const second = createdStreams.at(-1);
+    act(() => {
+      second?.onerror?.(new Event('error'));
+    });
+
+    const secondTimerCalls = timeoutSpy.mock.calls.length;
+    expect(secondTimerCalls).toBeGreaterThan(initialTimerCalls);
+    const secondDelay = timeoutSpy.mock.calls[secondTimerCalls - 1]?.[1] as number;
+    expect(secondDelay).toBe(firstDelay * 2);
+
+    hook.unmount();
+    queryClient.clear();
+    timeoutSpy.mockRestore();
+  });
+});

--- a/apps/ui/src/hooks/useSessionEvents.ts
+++ b/apps/ui/src/hooks/useSessionEvents.ts
@@ -7,6 +7,12 @@ import { queryKeys } from '../utils/queryKeys';
 const MAX_RETRIES = 5;
 const INITIAL_DELAY = 2_000;
 
+/**
+ * Configuration object accepted by {@link useSessionEvents}.
+ *
+ * @property enabled - Toggles subscription side effects. When ``false`` the hook disconnects.
+ * @property token - Optional bearer token forwarded to the SSE endpoint.
+ */
 export interface UseSessionEventsOptions {
   readonly enabled: boolean;
   readonly token?: string;
@@ -28,6 +34,12 @@ const removeSession = (sessions: Session[], sessionId: string): Session[] =>
 
 /**
  * Subscribes to the session SSE stream and keeps the local cache in sync.
+ *
+ * @param options - Hook options controlling connectivity and authentication.
+ * @example
+ * ```tsx
+ * useSessionEvents({ enabled: isAuthenticated, token: keycloakToken });
+ * ```
  */
 export const useSessionEvents = ({ enabled, token }: UseSessionEventsOptions) => {
   const queryClient = useQueryClient();

--- a/apps/ui/src/hooks/useSessionEvents.ts
+++ b/apps/ui/src/hooks/useSessionEvents.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { openSessionEventStream } from '../api/client';
-import { Session } from '../types/session';
+import type { Session, SessionEvent } from '../types/session';
 import { queryKeys } from '../utils/queryKeys';
 
 const MAX_RETRIES = 5;
@@ -22,6 +22,9 @@ const mergeSession = (sessions: Session[], incoming: Session): Session[] => {
   next[index] = { ...next[index], ...incoming };
   return next;
 };
+
+const removeSession = (sessions: Session[], sessionId: string): Session[] =>
+  sessions.filter((session) => session.id !== sessionId);
 
 /**
  * Subscribes to the session SSE stream and keeps the local cache in sync.
@@ -44,25 +47,26 @@ export const useSessionEvents = ({ enabled, token }: UseSessionEventsOptions) =>
       eventSourceRef.current = eventSource;
 
       eventSource.onmessage = (event: MessageEvent<string>) => {
-        const data = parseEvent(event);
-        queryClient.setQueryData<{ sessions: Session[] }>(queryKeys.sessions, (current) => {
+        const data = parseEvent(event) as SessionEvent;
+        queryClient.setQueryData<Session[]>(queryKeys.sessions, (current) => {
           if (!current) {
             return current;
           }
 
-          if (data.type === 'deleted') {
-            return {
-              sessions: current.sessions.filter((session) => session.id !== data.sessionId),
-            };
+          if (!data.session) {
+            return current;
           }
 
-          if (data.session) {
-            return {
-              sessions: mergeSession(current.sessions, data.session as Session),
-            };
+          const sessionId = data.session.id;
+          switch (data.type) {
+            case 'session.ended':
+              return removeSession(current, sessionId);
+            case 'session.created':
+            case 'session.updated':
+              return mergeSession(current, data.session);
+            default:
+              return current;
           }
-
-          return current;
         });
       };
 

--- a/apps/ui/src/pages/DashboardPage.tsx
+++ b/apps/ui/src/pages/DashboardPage.tsx
@@ -64,7 +64,7 @@ export function DashboardPage(): JSX.Element {
     refetchInterval: 15_000,
   });
 
-  const sessions = data?.sessions ?? EMPTY_SESSIONS;
+  const sessions = data ?? EMPTY_SESSIONS;
 
   const filteredSessions = useMemo(
     () => filterSessions(sessions, search, status, region, proxyId),

--- a/apps/ui/src/types/session.ts
+++ b/apps/ui/src/types/session.ts
@@ -37,9 +37,11 @@ export const SessionSchema = z.object({
  * Session event schema used by the SSE stream.
  */
 export const SessionEventSchema = z.object({
-  type: z.enum(['created', 'updated', 'deleted', 'snapshot']),
-  session: SessionSchema.partial(),
-  sessionId: z.string(),
+  id: z.string().uuid(),
+  type: z.enum(['session.created', 'session.updated', 'session.ended']),
+  occurredAt: z.string(),
+  reason: z.string().nullable().optional(),
+  session: SessionSchema,
 });
 
 /**

--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -17,7 +17,7 @@
 - Streaming:
   - `GET /events` — SSE-канал, ретранслирующий `SessionEvent` (кеш последнего события на подписчика).
   - `WS /events/ws` — WebSocket с тем же потоком событий.
-- Аутентификация: Bearer JWT (Keycloak). Для WebSocket токен передаётся в заголовке `Authorization: Bearer` или параметре `token`.
+- Аутентификация: Bearer JWT (Keycloak). Для WebSocket токен передаётся в заголовке `Authorization: Bearer` или параметре `token`; для SSE (`GET /events`) также поддерживается query `access_token` для нативного `EventSource`.
 
 ## Data & Models
 - Переиспользуются модели из `packages/core`: `Session`, `SessionEvent`, `Runner`, `SessionProxySettings`, `SessionVncDetails` и др.
@@ -57,3 +57,4 @@
 - 2025-10-02 · OpenAI ChatGPT · Добавлены публичные VNC-шаблоны для раннеров и переписывание URL при создании сессий по образцу beta-control-plane.
 - 2025-10-03 · gpt-5-codex · Вынесен VNC JWT секрет в конфигурацию и синхронизирован с VNC Gateway.
 - 2025-10-05 · gpt-5-codex · Уточнена логика выдачи VNC токенов при пустых значениях от Runner и добавлены покрывающие тесты.
+- 2025-10-01 · gpt-5-codex · Добавлен разбор `access_token` в HTTP-зависимости и покрывающий тест для SSE аутентификации.

--- a/services/gateway/app/deps/security.py
+++ b/services/gateway/app/deps/security.py
@@ -12,6 +12,36 @@ from ..security import AuthenticatedUser, AuthenticationError, KeycloakAuthentic
 _bearer_scheme = HTTPBearer(auto_error=False)
 
 
+def _extract_bearer_token(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials | None,
+) -> str | None:
+    """Return a bearer token from headers or ``access_token`` query parameter.
+
+    Args:
+        request: Incoming HTTP request used to access query parameters.
+        credentials: Parsed ``Authorization`` header produced by ``HTTPBearer``.
+
+    Returns:
+        Optional token string if found either in the ``Authorization`` header or
+        the ``access_token`` query parameter.
+
+    Example:
+        >>> scope = {"type": "http", "query_string": b"access_token=abc"}
+        >>> request = Request(scope)
+        >>> _extract_bearer_token(request, None)
+        'abc'
+    """
+
+    if credentials is not None:
+        return credentials.credentials
+
+    token = request.query_params.get("access_token")
+    if token:
+        return token
+    return None
+
+
 def get_authenticator(request: Request) -> KeycloakAuthenticator:
     """Return the authenticator stored on the FastAPI application instance."""
 
@@ -19,6 +49,7 @@ def get_authenticator(request: Request) -> KeycloakAuthenticator:
 
 
 async def get_current_user(
+    request: Request,
     credentials: Annotated[
         HTTPAuthorizationCredentials | None, Depends(_bearer_scheme)
     ],
@@ -26,12 +57,19 @@ async def get_current_user(
         KeycloakAuthenticator, Depends(get_authenticator)
     ],
 ) -> AuthenticatedUser:
-    """Validate the incoming bearer token and return the authenticated user."""
+    """Validate a bearer token delivered via headers or query parameters.
 
-    if credentials is None:
+    The HTTP SSE endpoint accepts tokens through the ``access_token`` query
+    parameter to mirror the WebSocket implementation.  This helper inspects
+    both the ``Authorization`` header and query string before delegating to the
+    authenticator.
+    """
+
+    token = _extract_bearer_token(request, credentials)
+    if token is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
     try:
-        return await authenticator.authenticate(credentials.credentials)
+        return await authenticator.authenticate(token)
     except AuthenticationError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/services/gateway/app/deps/security.py
+++ b/services/gateway/app/deps/security.py
@@ -43,7 +43,31 @@ def _extract_bearer_token(
 
 
 def get_authenticator(request: Request) -> KeycloakAuthenticator:
-    """Return the authenticator stored on the FastAPI application instance."""
+    """Return the authenticator registered on the FastAPI application instance.
+
+    Args:
+        request: Incoming FastAPI request exposing the shared ``state`` object.
+
+    Returns:
+        The :class:`~app.security.KeycloakAuthenticator` configured during
+        application startup.
+
+    Raises:
+        AttributeError: If the application ``state`` does not carry an
+            ``authenticator`` attribute.  The gateway initialiser always sets
+            the attribute, therefore an error here signals a misconfigured test
+            harness.
+
+    Example:
+        A FastAPI dependency can reuse this helper to access the shared
+        authenticator::
+
+            @router.get("/sessions")
+            async def list_sessions(
+                authenticator: KeycloakAuthenticator = Depends(get_authenticator),
+            ) -> list[dict[str, object]]:
+                ...
+    """
 
     return request.app.state.authenticator  # type: ignore[attr-defined]
 
@@ -59,10 +83,33 @@ async def get_current_user(
 ) -> AuthenticatedUser:
     """Validate a bearer token delivered via headers or query parameters.
 
-    The HTTP SSE endpoint accepts tokens through the ``access_token`` query
-    parameter to mirror the WebSocket implementation.  This helper inspects
-    both the ``Authorization`` header and query string before delegating to the
-    authenticator.
+    Args:
+        request: Incoming HTTP request that may transport the token either via
+            headers or the ``access_token`` query string parameter.
+        credentials: Parsed bearer credentials produced by
+            :class:`fastapi.security.HTTPBearer`.  The dependency returns
+            ``None`` when the ``Authorization`` header is absent, allowing us to
+            inspect query parameters instead.
+        authenticator: Component responsible for verifying and decoding the
+            access token into an :class:`~app.security.AuthenticatedUser`.
+
+    Returns:
+        The authenticated user represented by the supplied bearer token.
+
+    Raises:
+        HTTPException: If the token is missing or rejected by the authenticator
+            implementation.
+
+    Example:
+        >>> scope = {"type": "http", "query_string": b"access_token=test", "headers": []}
+        >>> request = Request(scope)
+        >>> class DummyAuthenticator:
+        ...     async def authenticate(self, token: str) -> AuthenticatedUser:
+        ...         assert token == "test"
+        ...         return AuthenticatedUser(subject="demo", email=None)
+        >>> import anyio
+        >>> anyio.run(get_current_user, request, None, DummyAuthenticator())
+        AuthenticatedUser(subject='demo', email=None)
     """
 
     token = _extract_bearer_token(request, credentials)
@@ -81,7 +128,31 @@ async def authenticate_websocket(
     websocket: WebSocket,
     authenticator: KeycloakAuthenticator,
 ) -> AuthenticatedUser:
-    """Perform bearer token authentication for WebSocket connections."""
+    """Perform bearer token authentication for WebSocket connections.
+
+    Args:
+        websocket: Active WebSocket connection requiring authentication.
+        authenticator: Component capable of validating bearer tokens.
+
+    Returns:
+        The :class:`~app.security.AuthenticatedUser` associated with the
+        provided token.
+
+    Raises:
+        AuthenticationError: If the token cannot be located or fails
+            validation.  The helper closes the WebSocket using code ``1008``
+            before propagating the error to the caller.
+
+    Example:
+        Within a FastAPI WebSocket route the helper is invoked before accepting
+        the connection::
+
+            @app.websocket("/events/ws")
+            async def session_events(endpoint: WebSocket) -> None:
+                user = await authenticate_websocket(endpoint, authenticator)
+                await endpoint.accept()
+                ...
+    """
 
     authorization = websocket.headers.get("Authorization")
     token: str | None = None

--- a/services/gateway/app/routers/events.py
+++ b/services/gateway/app/routers/events.py
@@ -20,7 +20,12 @@ async def stream_events(
     bridge: Annotated[AbstractSessionEventBridge, Depends(get_event_bridge)],
     user: Annotated[AuthenticatedUser, Depends(get_current_user)],
 ) -> StreamingResponse:
-    """Provide a Server-Sent Events stream for session events."""
+    """Provide a Server-Sent Events stream for session events.
+
+    Clients may authenticate with a bearer token supplied either via the
+    ``Authorization`` header or the ``access_token`` query parameter to mirror
+    WebSocket semantics.
+    """
 
     async def iterator() -> str:
         subscription = await bridge.subscribe(replay_latest=True)

--- a/services/gateway/tests/test_gateway.py
+++ b/services/gateway/tests/test_gateway.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 import anyio
 import pytest
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 from jose import jwt
 from starlette.responses import StreamingResponse
@@ -34,6 +34,27 @@ from core import (
     SessionStatus,
     SessionVncDetails,
 )  # noqa: E402
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_current_user_accepts_query_token() -> None:
+    """Authentication falls back to the ``access_token`` query parameter."""
+
+    scope = {"type": "http", "headers": [], "query_string": b"access_token=token-123"}
+    request = Request(scope)
+
+    class _DummyAuthenticator:
+        async def authenticate(self, token: str) -> AuthenticatedUser:
+            assert token == "token-123"
+            return AuthenticatedUser(subject="tester", email="tester@example.com")
+
+    user = await get_current_user(
+        request=request,
+        credentials=None,
+        authenticator=_DummyAuthenticator(),
+    )
+
+    assert user.subject == "tester"
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- allow HTTP dependencies to read bearer tokens from the access_token query parameter and document the behaviour on the /events endpoint, including a unit test
- point the UI SSE client at /events, parse real session.* events, and keep the React Query cache in sync with list responses
- add Vitest coverage for the session event hook, including reconnect/backoff scenarios, and refresh agent notes

## Testing
- poetry run pytest -q
- pnpm -C apps/ui test

## Security
- uses existing token validation paths; no additional sensitive data is logged

------
https://chatgpt.com/codex/tasks/task_e_68dd065ec164832aa6beb8e897edca68