### PR TITLE
Refactor VNC gateway proxy for target port handling

### DIFF
--- a/services/vnc-gateway/AGENT_NOTES.md
+++ b/services/vnc-gateway/AGENT_NOTES.md
@@ -14,9 +14,10 @@ FastAPI service that validates short-lived VNC access tokens and proxies HTTP/WS
 ## Decisions
 - Токены — стандартные HS256 JWT; валидация выполняется через `python-jose` с проверкой `iss`, `exp` и `sid`.
 - Connection metrics backed by in-memory `ConnectionRegistry` with async context manager; logs `connection.started/finished` events.
-- WebSocket proxy implemented via `websockets` library using two relay tasks; HTTP proxy uses `httpx.AsyncClient` streaming API.
+- WebSocket proxy implemented via `websockets` library using two relay tasks; HTTP proxy leverages a shared `httpx.AsyncClient` for outbound requests.
 - Dependency wiring relies on `typing.Annotated` wrappers to avoid Ruff `B008` violations while keeping FastAPI semantics.
 - Tests inject stubbed `RunnerProxy` via dependency overrides; `tests/conftest.py` adjusts `sys.path` instead of installing the package.
+- Runner proxy keeps a singleton `httpx.AsyncClient` and resolves `target_port` from query/referer/cookie (persisting it via `vnc-target-port` cookie) to build Runner URLs with configurable prefixes, mirroring the upstream beta implementation. WebSocket relaying now mirrors the production gateway behaviour with `FIRST_EXCEPTION` waiting semantics and graceful close codes (1008/1011).
 
 ## Constraints & Invariants
 - Tokens must include the matching session identifier; mismatches immediately rejected.
@@ -39,3 +40,4 @@ poetry run pytest -q
 ## Changelog (for agents)
 - 2025-02-14 · gpt-5-codex · Initial FastAPI service implementation with token validator, proxy wiring, and unit tests.
 - 2025-10-03 · gpt-5-codex · Переведён валидатор на HS256 JWT и синхронизирован с Gateway `VncTokenService`.
+- 2025-10-06 · gpt-5-codex · Синхронизирован HTTP/WS-прокси с beta-референсом: общий `httpx.AsyncClient`, выбор `target_port` из query/referer/cookie с cookie-фолбэком, обновлённая двунаправленная WebSocket-переадресация и unit-тесты на таргет-порт хелперы.

--- a/services/vnc-gateway/app/camou_vnc_gateway/dependencies.py
+++ b/services/vnc-gateway/app/camou_vnc_gateway/dependencies.py
@@ -23,7 +23,9 @@ def get_token_validator(settings: SettingsDependency) -> TokenValidator:
 def get_runner_proxy(settings: SettingsDependency) -> RunnerProxy:
     """Instantiate a :class:`RunnerProxy` for forwarding traffic to Runner."""
 
-    return RunnerProxy(settings=settings)
+    if not hasattr(get_runner_proxy, "_instance"):
+        get_runner_proxy._instance = RunnerProxy(settings=settings)  # type: ignore[attr-defined]
+    return get_runner_proxy._instance  # type: ignore[attr-defined]
 
 
 def get_connection_registry() -> ConnectionRegistry:

--- a/services/vnc-gateway/app/camou_vnc_gateway/main.py
+++ b/services/vnc-gateway/app/camou_vnc_gateway/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from .config import Settings, get_settings
+from .dependencies import get_runner_proxy
 from .routes import router
 
 
@@ -17,6 +18,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         app.dependency_overrides[get_settings] = lambda: settings
 
     app.include_router(router)
+
+    @app.on_event("shutdown")
+    async def _shutdown_runner_proxy() -> None:  # pragma: no cover - FastAPI lifecycle hook
+        proxy = getattr(get_runner_proxy, "_instance", None)
+        if proxy is not None:
+            await proxy.aclose()
+
     return app
 
 

--- a/services/vnc-gateway/app/camou_vnc_gateway/proxy.py
+++ b/services/vnc-gateway/app/camou_vnc_gateway/proxy.py
@@ -1,20 +1,49 @@
-"""Utilities to proxy HTTP and WebSocket traffic to the Runner service."""
+"""Utilities to proxy HTTP and WebSocket traffic to the Runner service.
+
+The module centralises all logic related to forwarding browser requests to the
+Runner component that exposes the actual VNC assets.  The implementation keeps
+parity with the production-oriented reference available in the upstream
+``beta`` branch by introducing helpers that:
+
+* reuse a shared :class:`httpx.AsyncClient` instance for HTTP forwarding,
+* derive the ``target_port`` parameter from query string, referer header or
+  persisted cookies, and
+* construct upstream URLs using configurable path prefixes so the gateway can
+  operate behind ingress controllers that rewrite paths.
+
+Additionally WebSocket relaying has been tightened to follow the behaviour of
+the reference gateway: both directions of the tunnel are now awaited together
+with ``FIRST_EXCEPTION`` semantics and any failure results in an orderly close
+with policy (1008) or internal error (1011) codes as appropriate.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Iterable, Mapping
 from contextlib import suppress
-from typing import Iterable
+from http.cookies import SimpleCookie
+from typing import Final
+from urllib.parse import ParseResult, parse_qs, urlencode, urlsplit, urlunsplit
 
 import httpx
 import websockets
 from fastapi import Request, WebSocket
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import Response
+from starlette import status
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 from .config import Settings
 
 LOG = logging.getLogger(__name__)
+
+TARGET_PORT_COOKIE: Final[str] = "vnc-target-port"
+
+
+class TargetPortError(ValueError):
+    """Raised when ``target_port`` cannot be parsed or validated."""
+
 
 
 class RunnerProxy:
@@ -28,6 +57,17 @@ class RunnerProxy:
 
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
+        self._http_base = urlsplit(str(settings.runner_http_base))
+        self._ws_base = urlsplit(str(settings.runner_ws_base))
+        self._client = httpx.AsyncClient(follow_redirects=True)
+        self._http_prefix = (self._http_base.path or "").rstrip("/")
+        self._ws_prefix = (self._ws_base.path or "").rstrip("/")
+        self._cookie_path = _join_paths(self._http_prefix, "/vnc")
+
+    async def aclose(self) -> None:
+        """Release the shared HTTP client resources."""
+
+        await self._client.aclose()
 
     async def forward_http(self, *, session_id: str, request: Request) -> Response:
         """Proxy an HTTP GET request to the Runner.
@@ -43,23 +83,63 @@ class RunnerProxy:
             metadata.
         """
 
-        target_url = f"{self._settings.runner_http_base}/sessions/{session_id}"
-        LOG.debug("Proxying HTTP request", extra={"session_id": session_id, "target": target_url})
+        raw_port, source = _select_target_port(
+            query_value=request.query_params.get("target_port"),
+            referer=request.headers.get("referer"),
+            cookies=request.cookies,
+        )
 
-        async with httpx.AsyncClient(follow_redirects=True) as client:
-            upstream_response = await client.get(
-                target_url,
-                params=request.query_params,
-                headers=self._filter_headers(request.headers.keys(), request.headers),
-            )
+        try:
+            port_override = _parse_port(raw_port)
+        except ValueError as exc:  # pragma: no cover - handled by caller
+            raise TargetPortError(str(exc)) from exc
+
+        query_items = [
+            (key, value)
+            for key, value in request.query_params.multi_items()
+            if key != "target_port"
+        ]
+
+        upstream_url = _build_upstream_url(
+            base=self._http_base,
+            prefix=self._http_prefix,
+            path_suffix=f"/sessions/{session_id}",
+            port_override=port_override,
+            query=query_items,
+        )
+        LOG.debug(
+            "Proxying HTTP request",
+            extra={
+                "session_id": session_id,
+                "target": upstream_url,
+                "port_source": source,
+            },
+        )
+
+        upstream_response = await self._client.request(
+            request.method,
+            upstream_url,
+            headers=self._filter_headers(request.headers.keys(), request.headers),
+            content=(await request.body()) or None,
+        )
 
         filtered_headers = self._filter_response_headers(upstream_response.headers)
-        return StreamingResponse(
-            content=upstream_response.aiter_bytes(),
+        response = Response(
+            content=upstream_response.content,
             status_code=upstream_response.status_code,
             headers=dict(filtered_headers),
             media_type=upstream_response.headers.get("content-type"),
         )
+
+        if source == "query" and port_override is not None:
+            response.set_cookie(
+                TARGET_PORT_COOKIE,
+                str(port_override),
+                path=self._cookie_path,
+                samesite="lax",
+            )
+
+        return response
 
     async def forward_websocket(self, *, session_id: str, websocket: WebSocket) -> None:
         """Proxy a WebSocket connection to the Runner service.
@@ -69,57 +149,115 @@ class RunnerProxy:
         either party disconnects.
         """
 
-        target_url = f"{self._settings.runner_ws_base}/sessions/{session_id}/ws"
-        LOG.debug(
-            "Proxying websocket connection",
-            extra={"session_id": session_id, "target": target_url},
+        raw_port, _ = _select_target_port(
+            query_value=websocket.query_params.get("target_port"),
+            referer=websocket.headers.get("referer"),
+            cookies=_parse_cookie_header(websocket.headers.get("cookie")),
         )
 
-        await websocket.accept()
+        try:
+            port_override = _parse_port(raw_port)
+        except ValueError as exc:
+            LOG.warning("Invalid target_port for websocket", extra={"session_id": session_id})
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION, reason=str(exc))
+            return
 
-        async with websockets.connect(target_url) as runner_ws:
-            async def client_to_runner() -> None:
-                try:
-                    while True:
-                        message = await websocket.receive()
-                        message_type = message.get("type")
-                        if message_type == "websocket.disconnect":
-                            await runner_ws.close()
-                            break
-                        data = message.get("text")
-                        if data is not None:
-                            await runner_ws.send(data)
-                            continue
-                        binary_data = message.get("bytes")
-                        if binary_data is not None:
-                            await runner_ws.send(binary_data)
-                except Exception:  # pragma: no cover - defensive logging aid
-                    LOG.exception("client_to_runner failed", extra={"session_id": session_id})
-                    raise
+        query_items = [
+            (key, value)
+            for key, value in websocket.query_params.multi_items()
+            if key != "target_port"
+        ]
 
-            async def runner_to_client() -> None:
-                try:
-                    async for payload in runner_ws:
-                        if isinstance(payload, str):
-                            await websocket.send_text(payload)
-                        else:
-                            await websocket.send_bytes(payload)
-                except Exception:  # pragma: no cover - defensive logging aid
-                    LOG.exception("runner_to_client failed", extra={"session_id": session_id})
-                    raise
+        upstream_url = _build_upstream_url(
+            base=self._ws_base,
+            prefix=self._ws_prefix,
+            path_suffix=f"/sessions/{session_id}/ws",
+            port_override=port_override,
+            query=query_items,
+        )
+        LOG.debug(
+            "Proxying websocket connection",
+            extra={"session_id": session_id, "target": upstream_url},
+        )
 
-            tasks = {
-                asyncio.create_task(client_to_runner()),
-                asyncio.create_task(runner_to_client()),
-            }
-            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            for task in pending:
-                task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await task
-            for task in done:
-                with suppress(asyncio.CancelledError):
-                    await task
+        subprotocol_header = websocket.headers.get("sec-websocket-protocol")
+        subprotocols = [
+            item.strip()
+            for item in (subprotocol_header.split(",") if subprotocol_header else [])
+            if item.strip()
+        ]
+
+        extra_headers = _select_upstream_headers(websocket.headers.items())
+        connect_kwargs: dict[str, object] = {"ping_interval": None}
+        if subprotocols:
+            connect_kwargs["subprotocols"] = subprotocols
+        if extra_headers:
+            connect_kwargs["extra_headers"] = extra_headers
+
+        try:
+            async with websockets.connect(upstream_url, **connect_kwargs) as runner_ws:
+                await websocket.accept(subprotocol=runner_ws.subprotocol)
+
+                async def client_to_runner() -> None:
+                    try:
+                        while True:
+                            message = await websocket.receive()
+                            message_type = message.get("type")
+                            if message_type == "websocket.disconnect":
+                                await runner_ws.close()
+                                break
+                            text_data = message.get("text")
+                            if text_data is not None:
+                                await runner_ws.send(text_data)
+                                continue
+                            binary_data = message.get("bytes")
+                            if binary_data is not None:
+                                await runner_ws.send(binary_data)
+                    except Exception:  # pragma: no cover - defensive logging aid
+                        LOG.exception(
+                            "client_to_runner failed",
+                            extra={"session_id": session_id},
+                        )
+                        raise
+
+                async def runner_to_client() -> None:
+                    try:
+                        async for payload in runner_ws:
+                            if isinstance(payload, str):
+                                await websocket.send_text(payload)
+                            else:
+                                await websocket.send_bytes(payload)
+                    except Exception:  # pragma: no cover - defensive logging aid
+                        LOG.exception(
+                            "runner_to_client failed",
+                            extra={"session_id": session_id},
+                        )
+                        raise
+
+                tasks = {
+                    asyncio.create_task(client_to_runner()),
+                    asyncio.create_task(runner_to_client()),
+                }
+                done, pending = await asyncio.wait(
+                    tasks,
+                    return_when=asyncio.FIRST_EXCEPTION,
+                )
+                for task in pending:
+                    task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await task
+                for task in done:
+                    with suppress(asyncio.CancelledError):
+                        exc = task.exception()
+                        if exc:
+                            raise exc
+        except (ConnectionClosedError, ConnectionClosedOK):
+            with suppress(RuntimeError):
+                await websocket.close()
+        except Exception as exc:  # pragma: no cover - defensive logging aid
+            LOG.warning("WebSocket proxy failure", exc_info=exc)
+            with suppress(RuntimeError):
+                await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
 
     @staticmethod
     def _filter_headers(keys: Iterable[str], headers: httpx.Headers) -> dict[str, str]:
@@ -150,8 +288,154 @@ class RunnerProxy:
             "trailers",
             "transfer-encoding",
             "upgrade",
-        }
+        } 
         return {k: v for k, v in headers.items() if k.lower() not in hop_by_hop}
 
 
-__all__ = ["RunnerProxy"]
+def _build_upstream_url(
+    *,
+    base: ParseResult,
+    prefix: str,
+    path_suffix: str,
+    port_override: int | None,
+    query: Iterable[tuple[str, str]],
+) -> str:
+    """Construct the full upstream URL for Runner requests.
+
+    Parameters
+    ----------
+    base:
+        Parsed URL object describing the configured Runner base endpoint.
+    prefix:
+        Normalised path prefix extracted from the base URL.
+    path_suffix:
+        Path segment that should be appended for the specific request.
+    port_override:
+        Optional integer port selected via ``target_port``.  When ``None`` the
+        port embedded in ``base`` is used.
+    query:
+        Iterable of query parameter key/value pairs that must be forwarded.
+
+    Returns
+    -------
+    str
+        Fully qualified URL that targets the Runner instance.
+    """
+
+    combined_path = _join_paths(prefix, path_suffix)
+    query_string = urlencode(list(query))
+    port = port_override if port_override is not None else base.port
+
+    host = base.hostname or base.netloc
+    if not host:
+        raise RuntimeError("Runner base URL is missing hostname")
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = host
+    if port:
+        netloc = f"{host}:{port}"
+
+    return urlunsplit((base.scheme, netloc, combined_path, query_string, ""))
+
+
+def _join_paths(prefix: str, suffix: str) -> str:
+    """Join two URL path fragments while handling edge cases."""
+
+    prefix = (prefix or "").rstrip("/")
+    suffix = (suffix or "").lstrip("/")
+
+    if prefix and suffix:
+        return f"{prefix}/{suffix}" if prefix.startswith("/") else f"/{prefix}/{suffix}"
+    if prefix:
+        return prefix if prefix.startswith("/") else f"/{prefix}"
+    if suffix:
+        return f"/{suffix}"
+    return "/"
+
+
+def _parse_port(raw_port: str | None) -> int | None:
+    """Validate and normalise the ``target_port`` value.
+
+    Returns ``None`` when no port override is requested.  Invalid inputs raise a
+    :class:`ValueError` with a human-readable message so callers can translate it
+    to HTTP/WebSocket errors.
+    """
+
+    if raw_port is None:
+        return None
+    try:
+        port = int(raw_port)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("target_port must be an integer") from exc
+    if port <= 0 or port > 65535:
+        raise ValueError("target_port must be between 1 and 65535")
+    return port
+
+
+def _select_target_port(
+    *,
+    query_value: str | None,
+    referer: str | None,
+    cookies: Mapping[str, str] | None,
+) -> tuple[str | None, str | None]:
+    """Select the most appropriate source for ``target_port``.
+
+    Preference order: explicit query parameter, referer query string then cookie
+    fallback.  ``(None, None)`` is returned when no information is available.
+    """
+
+    if query_value:
+        return query_value, "query"
+
+    referer_port = _extract_port_from_referer(referer)
+    if referer_port:
+        return referer_port, "referer"
+
+    if cookies:
+        cookie_port = cookies.get(TARGET_PORT_COOKIE)
+        if cookie_port:
+            return cookie_port, "cookie"
+
+    return None, None
+
+
+def _extract_port_from_referer(referer: str | None) -> str | None:
+    """Parse ``target_port`` from an HTTP referer header if present."""
+
+    if not referer:
+        return None
+
+    parsed = urlsplit(referer)
+    values = parse_qs(parsed.query).get("target_port")
+    if values:
+        return values[0]
+    return None
+
+
+def _parse_cookie_header(header_value: str | None) -> dict[str, str]:
+    """Convert a raw ``Cookie`` header into a dictionary mapping."""
+
+    if not header_value:
+        return {}
+
+    jar = SimpleCookie()
+    try:
+        jar.load(header_value)
+    except Exception:  # pragma: no cover - defensive against malformed headers
+        return {}
+
+    return {key: morsel.value for key, morsel in jar.items()}
+
+
+def _select_upstream_headers(headers: Iterable[tuple[str, str]]) -> list[tuple[str, str]]:
+    """Choose headers that should be forwarded to the upstream websocket."""
+
+    allowed = {"origin", "user-agent", "cookie", "sec-websocket-extensions"}
+    return [(key, value) for key, value in headers if key.lower() in allowed]
+
+
+__all__ = [
+    "RunnerProxy",
+    "TARGET_PORT_COOKIE",
+    "TargetPortError",
+]

--- a/services/vnc-gateway/app/camou_vnc_gateway/routes.py
+++ b/services/vnc-gateway/app/camou_vnc_gateway/routes.py
@@ -10,7 +10,7 @@ from starlette import status
 
 from .dependencies import get_connection_registry, get_runner_proxy, get_token_validator
 from .metrics import ConnectionRegistry
-from .proxy import RunnerProxy
+from .proxy import RunnerProxy, TargetPortError
 from .token import TokenValidationError, TokenValidator
 
 LOG = logging.getLogger(__name__)
@@ -56,7 +56,10 @@ async def proxy_session(
         raise HTTPException(status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
 
     async with registry.track(session_id=session_id, channel="http"):
-        return await proxy.forward_http(session_id=session_id, request=request)
+        try:
+            return await proxy.forward_http(session_id=session_id, request=request)
+        except TargetPortError as exc:
+            raise HTTPException(status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
 @router.websocket("/sessions/{session_id}/ws")

--- a/services/vnc-gateway/tests/test_app.py
+++ b/services/vnc-gateway/tests/test_app.py
@@ -17,14 +17,14 @@ for path in (REPO_ROOT, GATEWAY_APP_ROOT, CORE_PACKAGE_ROOT):
     if str(path) not in sys.path:
         sys.path.insert(0, str(path))
 
-from camou_vnc_gateway.config import Settings
-from camou_vnc_gateway.dependencies import get_runner_proxy, get_token_validator
-from camou_vnc_gateway.main import create_app
-from camou_vnc_gateway.token import TokenValidationError, TokenValidator
-from fastapi import Request
-from fastapi.testclient import TestClient
-from jose import jwt
-from security.vnc import VncTokenService
+from camou_vnc_gateway.config import Settings  # noqa: E402
+from camou_vnc_gateway.dependencies import get_runner_proxy, get_token_validator  # noqa: E402
+from camou_vnc_gateway.main import create_app  # noqa: E402
+from camou_vnc_gateway.token import TokenValidationError, TokenValidator  # noqa: E402
+from fastapi import Request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from jose import jwt  # noqa: E402
+from security.vnc import VncTokenService  # noqa: E402
 
 
 class DummyRunnerProxy:
@@ -86,7 +86,9 @@ def test_token_validator_success(validator: TokenValidator, token_service: VncTo
     validator.validate(session_id, token)
 
 
-def test_token_validator_rejects_invalid_signature(validator: TokenValidator, token_service: VncTokenService) -> None:
+def test_token_validator_rejects_invalid_signature(
+    validator: TokenValidator, token_service: VncTokenService
+) -> None:
     """Validation fails when the signature portion is invalid."""
 
     session_id = "abc"
@@ -96,7 +98,9 @@ def test_token_validator_rejects_invalid_signature(validator: TokenValidator, to
         validator.validate(session_id, token)
 
 
-def test_token_validator_rejects_wrong_session(validator: TokenValidator, token_service: VncTokenService) -> None:
+def test_token_validator_rejects_wrong_session(
+    validator: TokenValidator, token_service: VncTokenService
+) -> None:
     """Tokens scoped to another session are rejected."""
 
     token, _ = token_service.issue("session-a")
@@ -104,7 +108,9 @@ def test_token_validator_rejects_wrong_session(validator: TokenValidator, token_
         validator.validate("session-b", token)
 
 
-def test_token_validator_rejects_expired_token(validator: TokenValidator, settings: Settings) -> None:
+def test_token_validator_rejects_expired_token(
+    validator: TokenValidator, settings: Settings
+) -> None:
     """Expired JWT tokens are rejected."""
 
     expired_at = datetime.now(tz=UTC) - timedelta(seconds=5)

--- a/services/vnc-gateway/tests/test_target_port.py
+++ b/services/vnc-gateway/tests/test_target_port.py
@@ -1,0 +1,90 @@
+"""Tests covering helper functions for target_port resolution."""
+
+import pytest
+from camou_vnc_gateway.proxy import (
+    TARGET_PORT_COOKIE,
+    _extract_port_from_referer,
+    _parse_cookie_header,
+    _parse_port,
+    _select_target_port,
+)
+
+
+def test_select_target_port_prefers_query() -> None:
+    port, source = _select_target_port(
+        query_value="6910",
+        referer="http://localhost/vnc/view.html?target_port=6920",
+        cookies={TARGET_PORT_COOKIE: "6930"},
+    )
+
+    assert port == "6910"
+    assert source == "query"
+
+
+def test_select_target_port_prefers_referer_over_cookie() -> None:
+    port, source = _select_target_port(
+        query_value=None,
+        referer="http://localhost/vnc/view.html?target_port=6920",
+        cookies={TARGET_PORT_COOKIE: "6930"},
+    )
+
+    assert port == "6920"
+    assert source == "referer"
+
+
+def test_select_target_port_uses_cookie_when_needed() -> None:
+    port, source = _select_target_port(
+        query_value=None,
+        referer="http://localhost/vnc/view.html",
+        cookies={TARGET_PORT_COOKIE: "6930"},
+    )
+
+    assert port == "6930"
+    assert source == "cookie"
+
+
+def test_select_target_port_handles_missing_values() -> None:
+    port, source = _select_target_port(query_value=None, referer=None, cookies={})
+
+    assert port is None
+    assert source is None
+
+
+def test_extract_port_from_referer_parses_query() -> None:
+    referer = "http://localhost/vnc/vnc.html?foo=1&target_port=6945"
+
+    assert _extract_port_from_referer(referer) == "6945"
+
+
+def test_extract_port_from_referer_missing_value() -> None:
+    assert _extract_port_from_referer(None) is None
+    assert _extract_port_from_referer("http://localhost/vnc/vnc.html") is None
+
+
+def test_parse_cookie_header_extracts_values() -> None:
+    header = "a=1; vnc-target-port=6950; other=value"
+    cookies = _parse_cookie_header(header)
+
+    assert cookies["a"] == "1"
+    assert cookies[TARGET_PORT_COOKIE] == "6950"
+
+
+def test_parse_cookie_header_handles_invalid_header() -> None:
+    cookies = _parse_cookie_header("invalid-cookie\nvalue")
+
+    assert cookies == {}
+
+
+def test_parse_port_validates_range() -> None:
+    assert _parse_port(None) is None
+    assert _parse_port("7000") == 7000
+
+
+def test_parse_port_rejects_invalid_inputs() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        _parse_port("not-int")
+    assert "integer" in str(excinfo.value)
+
+    with pytest.raises(ValueError) as excinfo:
+        _parse_port("70000")
+    assert "between" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- share a single httpx.AsyncClient across requests and expose helper utilities for composing runner URLs with configurable prefixes
- add target_port resolution from query, referer, or cookie with persistence and improved bidirectional websocket forwarding
- extend FastAPI dependencies/routes to surface the refined proxy and add unit tests covering target port helpers plus updated agent notes

## Testing
- poetry run ruff check .
- poetry run pytest -q

## Security
- No security concerns introduced; existing token validation flow unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68dd421bfc3c832a9032415579a03cad