### PR TITLE
Fix camoufox stub packaging for editable installs

### DIFF
--- a/packages/camoufox/AGENT_NOTES.md
+++ b/packages/camoufox/AGENT_NOTES.md
@@ -22,6 +22,9 @@ configuration validation.
   succeed offline and commands like `python -m camoufox path` remain
   functional for smoke tests; the module lives at the repo root while
   Poetry consumes it via a path dependency.
+  Путь зависимости фиксируется на корне репозитория (`from = "../.."`),
+  чтобы editable-сборки корректно подключали модуль из каталога
+  `camoufox/`.
 
 ## Constraints & Invariants
 - The reported path is `/usr/bin/camoufox` to match existing fixtures and
@@ -42,3 +45,6 @@ configuration validation.
 ## Changelog (for agents)
 - 2025-10-09 · gpt-5-codex · Создан локальный stub-пакет Camoufox для
   успешного прохождения unit-тестов без доступа к приватному артефакту.
+- 2025-10-12 · gpt-5-codex · Исправлена конфигурация Poetry, чтобы
+  editable-установка подтягивала модуль `camoufox` из корня репозитория
+  и не падала на `poetry install --no-root` в сервисах.

--- a/packages/camoufox/pyproject.toml
+++ b/packages/camoufox/pyproject.toml
@@ -2,7 +2,7 @@
 name = "camoufox"
 version = "0.0.0"
 description = "Stub Camoufox bindings for local development and tests"
-packages = [{include = "camoufox", from = ".."}]
+packages = [{include = "camoufox", from = "../.."}]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.13"

--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -41,6 +41,7 @@
   инициированных самим Gateway.
 - Авторизация завершается до открытия WebSocket, при ошибках соединение закрывается кодом `1008`.
 - Командные эндпоинты используют `RunnerCommandClient` (httpx + MockTransport в тестах) и на стороне Gateway трансформируют упрощённый DTO (`browser_name`, `region`, `proxy_id`) в Runner API. При отсутствии `runner_id` выбирается первый доступный раннер из регистра.
+- Для предотвращения рассинхронизации контрактов с Runner добавлены unit-тесты, которые валидируют DTO команд Gateway через `SessionCreatePayload`/`SessionUpdatePayload` из Runner и проверяют поддержку алиаса `updated_at` в `core.Session`.
 - Health-чек раннеров выполняется через `RunnerHealthClient` (httpx) и сохраняет результат в `RunnerRegistry`. Селектор `select_next` использует круговой обход и фильтрует по признаку здоровья и поддержке VNC, чтобы избежать ручного выбора в роутерах.
 
 ## Constraints & Invariants
@@ -64,6 +65,7 @@
   - `poetry run pytest -q`
 - При необходимости линтинг: `poetry run ruff check .`
 - Тест `test_vnc_overrides_apply_runner_templates` проверяет, что VNC-адреса переписываются на публичные шаблоны по аналогии с beta.
+- Тесты `test_contract_synchronization.py` гарантируют, что HTTP-команды Gateway совместимы с моделями Runner и `core.Session`.
 
 ## Changelog (for agents)
 - 2025-10-01 · OpenAI ChatGPT · Реализован FastAPI gateway (REST/SSE/WS), Keycloak JWT, VNC-токены и покрывающие unit-тесты.
@@ -75,3 +77,4 @@
 - 2025-10-08 · gpt-5-codex · Реализован HTTP-приёмник `POST /events`, генерация событий на мутациях сессий и тесты доставки в SSE/WS.
 - 2025-10-09 · gpt-5-codex · Добавлен HTTP-клиент для health-чеков раннеров, круговой селектор с фильтрами VNC и расширенный `/runners` с данными диагностики.
 - 2025-10-10 · gpt-5-codex · Обновление ответов `/sessions` через свежие данные раннеров для пересборки публичных VNC URL и выпуск новых токенов при необходимости; добавлен тест изменения шаблонов.
+- 2025-10-11 · gpt-5-codex · Добавлены перекрёстные тесты синхронизации контрактов Gateway↔Runner↔core, чтобы отслеживать регрессии в DTO команд.

--- a/services/gateway/tests/test_contract_synchronization.py
+++ b/services/gateway/tests/test_contract_synchronization.py
@@ -1,0 +1,131 @@
+"""Validate that gateway command DTOs remain compatible with runner/core models."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+TEST_ROOT = Path(__file__).resolve()
+SERVICE_ROOT = TEST_ROOT.parents[1]
+REPO_ROOT = SERVICE_ROOT.parents[1]
+RUNNER_ROOT = REPO_ROOT / "services" / "runner"
+RUNNER_APP_PATH = RUNNER_ROOT / "app"
+
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+if str(RUNNER_ROOT) not in sys.path:
+    sys.path.append(str(RUNNER_ROOT))
+
+runner_app_pkg = types.ModuleType("runner_app")
+runner_app_pkg.__path__ = [str(RUNNER_APP_PATH)]
+sys.modules.setdefault("runner_app", runner_app_pkg)
+
+config_settings_spec = importlib.util.spec_from_file_location(
+    "runner_app.config.settings", RUNNER_APP_PATH / "config" / "settings.py"
+)
+config_settings_module = importlib.util.module_from_spec(config_settings_spec)
+sys.modules["runner_app.config.settings"] = config_settings_module
+config_settings_spec.loader.exec_module(config_settings_module)
+
+events_spec = importlib.util.spec_from_file_location(
+    "runner_app.events", RUNNER_APP_PATH / "events.py"
+)
+events_module = importlib.util.module_from_spec(events_spec)
+sys.modules["runner_app.events"] = events_module
+events_spec.loader.exec_module(events_module)
+
+config_spec = importlib.util.spec_from_file_location(
+    "runner_app.config", RUNNER_APP_PATH / "config" / "__init__.py"
+)
+config_module = importlib.util.module_from_spec(config_spec)
+sys.modules["runner_app.config"] = config_module
+config_spec.loader.exec_module(config_module)
+
+session_manager_spec = importlib.util.spec_from_file_location(
+    "runner_app.session_manager", RUNNER_APP_PATH / "session_manager.py"
+)
+session_manager_module = importlib.util.module_from_spec(session_manager_spec)
+sys.modules["runner_app.session_manager"] = session_manager_module
+session_manager_spec.loader.exec_module(session_manager_module)
+
+from app.services.runner_client import SessionCreateCommand, SessionUpdateCommand  # noqa: E402
+from core import Session, SessionStatus  # noqa: E402
+SessionCreatePayload = session_manager_module.SessionCreatePayload
+SessionUpdatePayload = session_manager_module.SessionUpdatePayload
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    """Force the AnyIO plugin to use asyncio for compatibility."""
+
+    return "asyncio"
+
+
+def test_session_create_command_matches_runner_contract() -> None:
+    """Ensure ``SessionCreateCommand`` renders payload accepted by the runner."""
+
+    command = SessionCreateCommand(
+        runner_id="runner-1",
+        browser_name="Chrome",
+        region="eu-central",
+        proxy_id="proxy-9",
+        headless=False,
+        start_url="https://example.test",
+    )
+
+    payload = command.to_runner_payload()
+    validated = SessionCreatePayload.model_validate(payload)
+
+    assert validated.browser == command.browser_name
+    assert validated.headless is command.headless
+    assert validated.labels == {"region": "eu-central", "proxy_id": "proxy-9"}
+    assert str(validated.start_url) == "https://example.test/"
+    assert validated.idle_ttl_seconds == 300
+
+
+def test_session_update_command_matches_runner_contract() -> None:
+    """Ensure ``SessionUpdateCommand`` payload conforms to runner expectations."""
+
+    command = SessionUpdateCommand(
+        status=SessionStatus.READY,
+        headless=True,
+        labels={"tier": "gold"},
+        metadata={"attempt": 1},
+        reason="manual override",
+    )
+
+    payload = command.to_runner_payload()
+    validated = SessionUpdatePayload.model_validate(payload)
+
+    assert validated.status is SessionStatus.READY
+    assert validated.headless is True
+    assert validated.labels == {"tier": "gold"}
+    assert validated.metadata == {"attempt": 1}
+    assert validated.reason == "manual override"
+    assert "last_seen_at" not in payload
+
+
+def test_session_accepts_updated_at_alias() -> None:
+    """Runner responses using the ``updated_at`` alias validate against ``Session``."""
+
+    now = datetime.now(tz=UTC)
+    payload = {
+        "id": str(uuid4()),
+        "runner_id": "runner-1",
+        "status": SessionStatus.READY.value,
+        "created_at": now.isoformat(),
+        "updated_at": now.isoformat(),
+        "idle_ttl_seconds": 300,
+        "headless": False,
+    }
+
+    session = Session.model_validate(payload)
+
+    assert session.last_seen_at == now
+    assert session.updated_at == now


### PR DESCRIPTION
## Summary
- point the camoufox stub package include path at the repository root so editable installs locate the module
- document the packaging constraint in the camoufox agent notes and record the change in the changelog

## Testing
- poetry install --no-root (services/runner)

## Security
- no changes


------
https://chatgpt.com/codex/tasks/task_e_68dd539e4fdc832a9637e55c2567b392