### PR TITLE
fix: stabilize camoufox native runner

### DIFF
--- a/services/camoufox_worker/AGENT_NOTES.md
+++ b/services/camoufox_worker/AGENT_NOTES.md
@@ -8,9 +8,9 @@ Camoufox worker обеспечивает выполнение короткожи
 * Планируемые интеграции: очередь задач (Redis/AMQP), HTTP API Gateway/Runner для orchestrator-режима.
 
 ## Data & Models
-* `worker.jobs.Job` — Pydantic-модель, описывающая параметры задачи (URL, прокси, таймаут). Модель гарантирует валидацию URL и наличие дефолтного таймаута.
-* `worker.jobs.JobStatus`/`JobResult` — структура результата с флагом `ok`, статусом (`success|failure|aborted`), таймстемпами начала/окончания, метриками (`JobMetrics.duration_ms`) и описанием ошибки (`JobError`).
-* `worker.runner_native.run_job` возвращает `JobResult` вместо словаря и заполняет метрики/ошибки; оркестратор будет использовать тот же контракт.
+* `worker.jobs.Job` — Pydantic-модель, описывающая параметры задачи (URL, прокси, таймаут). Помимо нормализованного `HttpUrl` хранит исходную строку `url_source`, чтобы браузер открывал URL без навязанного завершающего слэша.
+* `worker.jobs.JobStatus`/`JobResult` — структура результата с флагом `ok`, статусом (`success|failure|aborted`), таймстемпами начала/окончания, метриками (`JobMetrics.duration_ms`) и описанием ошибки (`JobError`). Поле `JobMetrics.extra` допускает числовые и строковые значения (например, статусы навигации, тип исключения, длительности).
+* `worker.runner_native.run_job` возвращает `JobResult` вместо словаря, применяет per-job proxy и наполняет `JobMetrics.extra` полями `navigation_status`, `navigation_duration_ms`, `timeout_ms`, `exception_type`.
 
 ## Decisions
 * Выбраны отдельные модули для native и orchestrator режимов, чтобы облегчить параллельную разработку и тестирование.
@@ -21,6 +21,8 @@ Camoufox worker обеспечивает выполнение короткожи
 ## Constraints & Invariants
 * Выполнение под non-root пользователем, без `pip install`/`camoufox fetch` в рантайме.
 * Значение `CAMOUFOX_HEADLESS` по умолчанию — `virtual`; ожидается наличие Xvfb в базовом образе Playwright.
+* Каждый запуск создаёт изолированный Camoufox context с приоритетом прокси SOCKS > HTTPS > HTTP и закрывает страницу/контекст даже при исключениях. Если Camoufox падает до навигации, `navigation_status` принудительно переводится в `context_failed`.
+* Навигация выполняется с таймаутом `job.timeout_sec` (преобразованным в миллисекунды для Camoufox API) и использует исходную строку URL из `Job.url_source`.
 * Код должен содержать docstring у каждого публичного объекта (соответствие корневым инструкциям).
 
 ## Known Gaps / TODO
@@ -29,13 +31,15 @@ Camoufox worker обеспечивает выполнение короткожи
 - [ ] Реализовать управление профилями/«тумблерами» Camoufox для разных сценариев.
 
 ## How to Test
-* `poetry install --no-root` — установка зависимостей.
+* `poetry install` — установка зависимостей и публикация пакета `worker`.
 * `poetry run ruff check .` — статический анализ.
 * `poetry run pytest -q` — запуск юнит-тестов (покрытие моделей и нативного раннера через моки).
-* `python -m camoufox path` и `python -m camoufox version` — валидация окружения Camoufox.
+* `poetry run python -m camoufox path` и `poetry run python -m camoufox version` — валидация окружения Camoufox.
 
 ## Changelog (for agents)
 * 2024-08-29 · gpt-5-codex · Создан каркас camoufox_worker, добавлены инструкции, документация и тестовые заглушки.
 * 2024-08-30 · gpt-5-codex · Обновлён CI workflow: для push-сборок используется fallback-тег с SHA коммита, чтобы избежать пустых Docker tag.
 * 2024-08-30 · gpt-5-codex · Исправлен worker build workflow: владелец репозитория приводится к нижнему регистру при формировании GHCR-тега, что устраняет ошибку `repository name must be lowercase`.
 * 2024-09-03 · gpt-5-codex · Добавлены структурированные модели результата (`JobResult`, `JobMetrics`, `JobError`), обновлены CLI/runner и покрыты юнит-тестами.
+* 2024-09-06 · gpt-5-codex · Реализована поддержка прокси и таймаутов в native-runner, добавлены метрики навигации и регрессионные тесты (proxy/timeout).
+* 2025-02-15 · gpt-5-codex · Зафиксирована версия camoufox 0.4.11, добавлены `Job.url_source` и гибкие `JobMetrics.extra`, обновлены статусы навигации, тесты и гайд по запуску.

--- a/services/camoufox_worker/pyproject.toml
+++ b/services/camoufox_worker/pyproject.toml
@@ -9,7 +9,7 @@ python = ">=3.12,<3.13"
 pydantic = "^2.8.2"
 anyio = "^4.4.0"
 httpx = "^0.27.2"
-camoufox = "^0.9.3"
+camoufox = "^0.4.11"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/services/camoufox_worker/tests/test_runner_native.py
+++ b/services/camoufox_worker/tests/test_runner_native.py
@@ -1,10 +1,10 @@
-"""Tests for the native runner integration wrapper."""
+"""Tests for the native Camoufox runner integration wrapper."""
 
 from __future__ import annotations
 
 import sys
 import types
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 # Provide lightweight stubs for the optional camoufox dependency when running tests.
 if "camoufox" not in sys.modules:
@@ -29,51 +29,99 @@ from worker.jobs import Job, JobStatus
 from worker.runner_native import run_job
 
 
-class _DummyPage:
-    """Minimal page stub mimicking Camoufox Page API."""
+class _RecordingPage:
+    """Page stub that records navigation attempts and cleanup calls."""
 
-    def __init__(self, title: str) -> None:
-        """Store the fake page title for later retrieval."""
+    def __init__(self, title: str = "Example Domain") -> None:
+        """Initialise the stubbed page with a predefined title."""
 
         self._title = title
-        self.last_url: str | None = None
+        self.last_url: Optional[str] = None
+        self.goto_kwargs: Dict[str, Any] | None = None
+        self.closed = False
 
-    def goto(self, url: str) -> None:
-        """Record navigation attempts for assertions."""
+    def goto(self, url: str, **kwargs: Any) -> None:
+        """Store the last navigated URL and keyword arguments."""
 
         self.last_url = url
+        self.goto_kwargs = dict(kwargs)
 
     def title(self) -> str:
-        """Return the stubbed page title."""
+        """Return the configured fake page title."""
 
         return self._title
 
+    def close(self) -> None:
+        """Mark the page as closed for assertions."""
 
-class _DummyCamoufox:
+        self.closed = True
+
+
+class _RecordingContext:
+    """Camoufox context stub capturing options and lifecycle hooks."""
+
+    def __init__(self, options: Dict[str, Any]) -> None:
+        """Store context options and lazily create pages."""
+
+        self.options = dict(options)
+        self.pages: List[_RecordingPage] = []
+        self.closed = False
+
+    def new_page(self) -> _RecordingPage:
+        """Return a new recording page and keep track of it."""
+
+        page = _RecordingPage()
+        self.pages.append(page)
+        return page
+
+    def close(self) -> None:
+        """Record that the context has been closed."""
+
+        self.closed = True
+
+
+class _RecordingCamoufox:
     """Context manager stub reproducing the Camoufox API surface."""
 
+    instances: List["_RecordingCamoufox"] = []
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        """Store configuration arguments (ignored) and prepare a stub page."""
+        """Store configuration arguments and prepare tracking containers."""
 
-        self.page = _DummyPage(title="Example Domain")
+        self.args = args
+        self.kwargs = dict(kwargs)
+        self.contexts: List[_RecordingContext] = []
+        self.pages: List[_RecordingPage] = []
+        self.closed = False
+        _RecordingCamoufox.instances.append(self)
 
-    def __enter__(self) -> "_DummyCamoufox":
+    def __enter__(self) -> "_RecordingCamoufox":
         """Enter the context manager and return self."""
 
         return self
 
     def __exit__(self, exc_type, exc, tb) -> bool:  # type: ignore[override]
-        """Propagate any raised exception to the caller."""
+        """Mark the browser as closed and propagate exceptions."""
 
+        self.closed = True
         return False
 
-    def new_page(self) -> _DummyPage:
-        """Return a preconfigured fake page."""
+    def new_context(self, **kwargs: Any) -> _RecordingContext:
+        """Create a new context recording the provided keyword arguments."""
 
-        return self.page
+        context = _RecordingContext(kwargs)
+        self.contexts.append(context)
+        return context
+
+    def new_page(self, **kwargs: Any) -> _RecordingPage:
+        """Fallback for environments lacking context support."""
+
+        page = _RecordingPage()
+        self.pages.append(page)
+        return page
 
 
-class _FailingCamoufox(_DummyCamoufox):
+class _FailingCamoufox(_RecordingCamoufox):
     """Context manager stub that raises to simulate runtime failures."""
 
     def __enter__(self) -> "_FailingCamoufox":
@@ -82,10 +130,18 @@ class _FailingCamoufox(_DummyCamoufox):
         raise RuntimeError("boom")
 
 
-def test_run_job_returns_success_result(monkeypatch) -> None:
-    """Return JobResult with success status and populated metrics."""
+def _reset_recording_state() -> None:
+    """Clear accumulated stub instances between tests."""
 
-    monkeypatch.setattr("worker.runner_native.Camoufox", _DummyCamoufox)
+    _RecordingCamoufox.instances.clear()
+
+
+def test_run_job_returns_success_result(monkeypatch) -> None:
+    """Return JobResult with success status, metrics and cleaned resources."""
+
+    _reset_recording_state()
+    monkeypatch.setattr("worker.runner_native.Camoufox", _RecordingCamoufox)
+    monkeypatch.delenv("CAMOUFOX_HEADLESS", raising=False)
     job = Job(url="https://example.com")
 
     result = run_job(job)
@@ -93,13 +149,19 @@ def test_run_job_returns_success_result(monkeypatch) -> None:
     assert result.ok is True
     assert result.status is JobStatus.SUCCESS
     assert result.title == "Example Domain"
-    assert result.metrics.duration_ms >= 0
-    assert result.error is None
+    assert result.metrics.extra["navigation_status"] == "success"
+
+    browser = _RecordingCamoufox.instances[-1]
+    assert browser.kwargs.get("headless") == "virtual"
+    assert browser.closed is True
+    assert browser.contexts[0].closed is True
+    assert browser.contexts[0].pages[0].closed is True
 
 
 def test_run_job_captures_errors(monkeypatch) -> None:
     """Translate runtime exceptions into failure JobResult instances."""
 
+    _reset_recording_state()
     monkeypatch.setattr("worker.runner_native.Camoufox", _FailingCamoufox)
     job = Job(url="https://example.com")
 
@@ -109,3 +171,31 @@ def test_run_job_captures_errors(monkeypatch) -> None:
     assert result.status is JobStatus.FAILURE
     assert result.error is not None
     assert result.error.message == "boom"
+    assert result.metrics.extra["navigation_status"] == "context_failed"
+
+
+def test_run_job_wires_proxy_and_timeout(monkeypatch) -> None:
+    """Apply per-job proxy configuration and enforce navigation timeout."""
+
+    _reset_recording_state()
+    monkeypatch.setattr("worker.runner_native.Camoufox", _RecordingCamoufox)
+    job = Job(
+        url="https://example.com",
+        http_proxy="http://user:pwd@localhost:8080",
+        timeout_sec=42,
+    )
+
+    result = run_job(job)
+
+    assert result.ok is True
+
+    browser = _RecordingCamoufox.instances[-1]
+    context = browser.contexts[0]
+    assert context.options["proxy"]["server"] == "http://localhost:8080"
+    assert context.options["proxy"]["username"] == "user"
+    assert context.options["proxy"]["password"] == "pwd"
+
+    page = context.pages[0]
+    assert page.last_url == "https://example.com"
+    assert page.goto_kwargs == {"timeout": 42000}
+    assert result.metrics.extra["timeout_ms"] == 42000.0

--- a/services/camoufox_worker/worker/jobs.py
+++ b/services/camoufox_worker/worker/jobs.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from enum import Enum
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Union
 
 from pydantic import BaseModel, Field, HttpUrl, model_validator
 
@@ -24,6 +24,8 @@ class Job(BaseModel):
         Необязательный SOCKS-прокси (например, `socks5://user:pass@host:port`).
     timeout_sec: int
         Предельное время выполнения задачи в секундах; по умолчанию 60.
+    url_source: str
+        Исходная строка URL, сохранённая для навигации без автоматического добавления слэшей.
 
     Returns
     -------
@@ -41,6 +43,30 @@ class Job(BaseModel):
     https_proxy: Optional[str] = None
     socks_proxy: Optional[str] = None
     timeout_sec: int = 60
+    url_source: str = Field(
+        default="",
+        exclude=True,
+        repr=False,
+        description="Исходная строка URL до нормализации Pydantic.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _capture_original_url(cls, data: Dict[str, Any]) -> Dict[str, Any]:
+        """Сохранить исходную строку URL до валидации HttpUrl."""
+
+        raw_url = data.get("url")
+        if isinstance(raw_url, str) and not data.get("url_source"):
+            data["url_source"] = raw_url
+        return data
+
+    @model_validator(mode="after")
+    def _ensure_original_url(self) -> "Job":
+        """Гарантировать наличие исходной строки URL после нормализации."""
+
+        if not self.url_source:
+            self.url_source = str(self.url)
+        return self
 
 
 class JobStatus(str, Enum):
@@ -69,6 +95,9 @@ class JobError(BaseModel):
     details: Optional[str] = None
 
 
+MetricValue = Union[float, int, str, bool, None]
+
+
 class JobMetrics(BaseModel):
     """Execution metrics captured for a worker job run.
 
@@ -76,14 +105,16 @@ class JobMetrics(BaseModel):
     ----------
     duration_ms: float
         Полное время выполнения задачи, включая прогрев браузера и навигацию.
-    extra: dict[str, float]
-        Дополнительные числовые показатели (сетевые задержки, размер артефактов и т.п.).
+    extra: dict[str, MetricValue]
+        Дополнительные показатели (сетевые задержки, коды статуса, флаги таймаутов и т.п.).
     """
 
-    duration_ms: float = Field(..., ge=0, description="Полное время выполнения задачи в миллисекундах.")
-    extra: Dict[str, float] = Field(
+    duration_ms: float = Field(
+        ..., ge=0, description="Полное время выполнения задачи (мс)."
+    )
+    extra: Dict[str, MetricValue] = Field(
         default_factory=dict,
-        description="Произвольные числовые метрики (например, сетевые задержки).",
+        description="Произвольные метрики (например, задержки, статусы навигации, флаги ошибок).",
     )
 
 

--- a/services/camoufox_worker/worker/main.py
+++ b/services/camoufox_worker/worker/main.py
@@ -40,7 +40,8 @@ def run(url: str, timeout: int, mode: str) -> None:
 
     Side Effects
     ------------
-    Печатает JSON-представление результата в stdout и завершает процесс с кодом 0/1 в зависимости от статуса.
+    Печатает JSON-представление результата в stdout и завершает процесс с
+    кодом 0/1 в зависимости от статуса.
     """
 
     job = Job(url=url, timeout_sec=timeout)

--- a/services/camoufox_worker/worker/runner_native.py
+++ b/services/camoufox_worker/worker/runner_native.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import os
 import time
 from datetime import UTC, datetime
-from typing import Optional
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
 
 from camoufox.errors import CamoufoxError
 from camoufox.sync_api import Camoufox
@@ -13,12 +14,61 @@ from camoufox.sync_api import Camoufox
 from .jobs import Job, JobError, JobMetrics, JobResult, JobStatus
 
 
+def _build_proxy_options(job: Job) -> Dict[str, Any]:
+    """Return Camoufox context options derived from the job proxy settings.
+
+    Parameters
+    ----------
+    job:
+        Задача, содержащая необязательные строки подключения к прокси.
+
+    Returns
+    -------
+    dict[str, Any]
+        Набор аргументов для ``browser.new_context`` или ``browser.new_page``.
+        Если прокси не указан, возвращается пустой словарь.
+
+    Notes
+    -----
+    Приоритет отдается SOCKS, затем HTTPS и HTTP прокси — это соответствует
+    способу, которым Playwright принимает единственный сервер в
+    ``proxy.server``.
+
+    Examples
+    --------
+    >>> job = Job(url="https://example.com", http_proxy="http://user:pwd@localhost:8080")
+    >>> options = _build_proxy_options(job)
+    >>> options["proxy"]["server"]
+    'http://localhost:8080'
+    """
+
+    proxy_url = job.socks_proxy or job.https_proxy or job.http_proxy
+    if not proxy_url:
+        return {}
+
+    parsed = urlparse(proxy_url)
+    if not parsed.scheme or not parsed.hostname:
+        raise ValueError(f"Invalid proxy URL: {proxy_url}")
+
+    server = f"{parsed.scheme}://{parsed.hostname}"
+    if parsed.port:
+        server = f"{server}:{parsed.port}"
+
+    proxy: Dict[str, Any] = {"server": server}
+    if parsed.username:
+        proxy["username"] = parsed.username
+    if parsed.password:
+        proxy["password"] = parsed.password
+
+    return {"proxy": proxy}
+
+
 def run_job(job: Job) -> JobResult:
     """Execute a job inside the current container using Camoufox directly.
 
     Parameters
     ----------
-    job: Job
+    job:
         Экземпляр задачи, описывающий URL, прокси и таймаут.
 
     Returns
@@ -28,37 +78,88 @@ def run_job(job: Job) -> JobResult:
 
     Notes
     -----
-    Прокси-настройки пока не применяются; модуль выступает заглушкой для будущей интеграции
-    с изолированными контекстами и сетевыми профилями.
+    Функция применяет прокси-опции к новому контексту Camoufox и гарантирует,
+    что переход выполняется с таймаутом ``job.timeout_sec``. Контекст и
+    страница закрываются даже при ошибках навигации.
 
     Examples
     --------
     >>> run_job(Job(url="https://example.com"))
     JobResult(ok=True, status=<JobStatus.SUCCESS: 'success'>, ...)
     """
+
     headless = os.getenv("CAMOUFOX_HEADLESS", "virtual")
     started_at = datetime.now(UTC)
     started_perf = time.perf_counter()
     title: Optional[str] = None
     error: Optional[JobError] = None
     status = JobStatus.SUCCESS
+    navigation_status = "not_attempted"
+    navigation_duration_ms: Optional[float] = None
+    exception_type: Optional[str] = None
+    context_obj: Any = None
+    page_obj: Any = None
+    timeout_ms = int(job.timeout_sec * 1000)
 
     try:
         with Camoufox(headless=headless, geoip=True) as browser:
-            page = browser.new_page()
-            # TODO: применить прокси к браузеру/контексту, если указано в job
-            page.goto(str(job.url))
-            title = page.title()
+            proxy_options = _build_proxy_options(job)
+
+            try:
+                if hasattr(browser, "new_context"):
+                    context_obj = browser.new_context(**proxy_options)
+                    page_obj = context_obj.new_page()
+                else:
+                    page_obj = browser.new_page(**proxy_options)
+            except Exception:
+                navigation_status = "context_failed"
+                raise
+
+            try:
+                navigation_started = time.perf_counter()
+                page_obj.goto(job.url_source, timeout=timeout_ms)
+            except Exception:
+                navigation_status = "navigation_failed"
+                raise
+            else:
+                navigation_status = "success"
+                navigation_duration_ms = (time.perf_counter() - navigation_started) * 1000
+                title = page_obj.title()
     except CamoufoxError as exc:  # pragma: no cover - defensive branch for runtime errors
         status = JobStatus.FAILURE
+        if navigation_status == "not_attempted":
+            navigation_status = "context_failed"
         error = JobError(type=exc.__class__.__name__, message=str(exc))
+        exception_type = exc.__class__.__name__
     except Exception as exc:  # pragma: no cover - unexpected runtime failures
         status = JobStatus.FAILURE
+        if navigation_status == "not_attempted":
+            navigation_status = "context_failed"
         error = JobError(type=exc.__class__.__name__, message=str(exc))
+        exception_type = exc.__class__.__name__
+    finally:
+        for closable in (page_obj, context_obj):
+            close = getattr(closable, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # pragma: no cover - defensive close cleanup
+                    pass
 
     finished_at = datetime.now(UTC)
     duration_ms = (time.perf_counter() - started_perf) * 1000
-    metrics = JobMetrics(duration_ms=duration_ms)
+    metrics = JobMetrics(
+        duration_ms=duration_ms,
+        extra={
+            "navigation_status": navigation_status,
+            "navigation_duration_ms": navigation_duration_ms or 0.0,
+            "timeout_ms": float(timeout_ms),
+        },
+    )
+
+    if exception_type:
+        metrics.extra["exception_type"] = exception_type
+
     return JobResult(
         job=job,
         status=status,


### PR DESCRIPTION
## Summary
- pin camoufox to the latest public release and refresh the camoufox_worker notes with the new setup instructions
- extend the Job/JobMetrics models to preserve the original URL string and allow non-numeric metrics consumers require
- route native-runner navigation through the raw URL, flag early browser failures as context errors, and wrap the CLI docstring for lint compliance

## Testing
- `poetry run ruff check worker`
- `poetry run pytest -q`
- `poetry run python -m camoufox path`
- `poetry run python -m camoufox version`

## Security
- no changes


------
https://chatgpt.com/codex/tasks/task_e_68dd6ed27b10832a94eec9aa18d09221