### PR TITLE
Add orchestrator HTTP helpers and CLI integration

### DIFF
--- a/services/camoufox_worker/AGENT_NOTES.md
+++ b/services/camoufox_worker/AGENT_NOTES.md
@@ -1,28 +1,31 @@
 # AGENT_NOTES — camoufox_worker
 
 ## Overview
-Camoufox worker обеспечивает выполнение короткоживущих браузерных задач в двух режимах: нативный запуск Camoufox внутри контейнера и оркестрация удалённых сессий через Gateway/Runner. Текущий коммит добавляет каркас сервиса, документацию и базовые заглушки для дальнейшей реализации.
+Camoufox worker обеспечивает выполнение короткоживущих браузерных задач в двух режимах: нативный запуск Camoufox внутри контейнера и оркестрация удалённых сессий через Gateway/Runner. Реализованы асинхронные HTTP-хелперы для orchestrator-режима с ретраями, единый CLI и юнит-тесты, покрывающие оба сценария.
 
 ## Interfaces
-* CLI `python -m worker.main run` для запуска единичной задачи с параметрами URL и таймаутом; выводит JSON с полями результата.
+* CLI `python -m worker.main run` для запуска единичной задачи с параметрами URL и таймаутом; выводит JSON с полями результата. Режим выбирается через `--mode` или `WORKER_MODE`, для orchestrator доступны опции/ENV `--gateway-url` (`GATEWAY_URL`), `--gateway-token` (`GATEWAY_TOKEN`), `--poll-timeout`, `--poll-interval`.
 * Планируемые интеграции: очередь задач (Redis/AMQP), HTTP API Gateway/Runner для orchestrator-режима.
 
 ## Data & Models
 * `worker.jobs.Job` — Pydantic-модель, описывающая параметры задачи (URL, прокси, таймаут). Помимо нормализованного `HttpUrl` хранит исходную строку `url_source`, чтобы браузер открывал URL без навязанного завершающего слэша.
 * `worker.jobs.JobStatus`/`JobResult` — структура результата с флагом `ok`, статусом (`success|failure|aborted`), таймстемпами начала/окончания, метриками (`JobMetrics.duration_ms`) и описанием ошибки (`JobError`). Поле `JobMetrics.extra` допускает числовые и строковые значения (например, статусы навигации, тип исключения, длительности).
 * `worker.runner_native.run_job` возвращает `JobResult` вместо словаря, применяет per-job proxy и наполняет `JobMetrics.extra` полями `navigation_status`, `navigation_duration_ms`, `timeout_ms`, `exception_type`.
+* `worker.runner_orch.run_orchestrated_job` использует те же модели `Job`/`JobResult`, создаёт сессию через Gateway, обновляет прокси/heartbeat, собирает метаданные (`session_id`, `poll_attempts`, `session_status`, `touched_at`) и конвертирует ошибки/таймауты в `JobError`.
 
 ## Decisions
 * Выбраны отдельные модули для native и orchestrator режимов, чтобы облегчить параллельную разработку и тестирование.
 * В образе подразумевается предварительный `camoufox fetch`; в рантайме операции загрузки запрещены (см. AGENTS.md).
 * CLI основан на Click для дальнейшего расширения команды `run` под дополнительные опции.
 * При ошибках исполнения Camoufox исключения конвертируются в `JobResult` со статусом `failure`, чтобы потребители могли логировать/ретраить без исключений.
+* Orchestrator-helpers используют `httpx.AsyncClient` с Bearer-аутентификацией, экспоненциальным бэкоффом (5xx/сетевые ошибки) и гарантированным `DELETE` в блоке `finally`.
 
 ## Constraints & Invariants
 * Выполнение под non-root пользователем, без `pip install`/`camoufox fetch` в рантайме.
 * Значение `CAMOUFOX_HEADLESS` по умолчанию — `virtual`; ожидается наличие Xvfb в базовом образе Playwright.
 * Каждый запуск создаёт изолированный Camoufox context с приоритетом прокси SOCKS > HTTPS > HTTP и закрывает страницу/контекст даже при исключениях. Если Camoufox падает до навигации, `navigation_status` принудительно переводится в `context_failed`.
 * Навигация выполняется с таймаутом `job.timeout_sec` (преобразованным в миллисекунды для Camoufox API) и использует исходную строку URL из `Job.url_source`.
+* Для orchestrator-режима обязательны `GATEWAY_URL` и `GATEWAY_TOKEN`; при удалении сессии 404 считается идемпотентным успехом.
 * Код должен содержать docstring у каждого публичного объекта (соответствие корневым инструкциям).
 
 ## Known Gaps / TODO
@@ -33,7 +36,7 @@ Camoufox worker обеспечивает выполнение короткожи
 ## How to Test
 * `poetry install` — установка зависимостей и публикация пакета `worker`.
 * `poetry run ruff check .` — статический анализ.
-* `poetry run pytest -q` — запуск юнит-тестов (покрытие моделей и нативного раннера через моки).
+* `poetry run pytest -q` — запуск юнит-тестов (покрытие моделей, нативного раннера и orchestrator-хелперов через `httpx.MockTransport`).
 * `poetry run python -m camoufox path` и `poetry run python -m camoufox version` — валидация окружения Camoufox.
 
 ## Changelog (for agents)
@@ -43,3 +46,4 @@ Camoufox worker обеспечивает выполнение короткожи
 * 2024-09-03 · gpt-5-codex · Добавлены структурированные модели результата (`JobResult`, `JobMetrics`, `JobError`), обновлены CLI/runner и покрыты юнит-тестами.
 * 2024-09-06 · gpt-5-codex · Реализована поддержка прокси и таймаутов в native-runner, добавлены метрики навигации и регрессионные тесты (proxy/timeout).
 * 2025-02-15 · gpt-5-codex · Зафиксирована версия camoufox 0.4.11, добавлены `Job.url_source` и гибкие `JobMetrics.extra`, обновлены статусы навигации, тесты и гайд по запуску.
+* 2025-02-17 · gpt-5-codex · Реализованы async-хелперы orchestrator-режима (create/touch/proxy/delete/poll) с ретраями, обновлён CLI (ENV + gateway credentials) и добавлены pytest-моки `httpx.MockTransport` для проверки ретраев/ошибок.

--- a/services/camoufox_worker/tests/test_runner_orch.py
+++ b/services/camoufox_worker/tests/test_runner_orch.py
@@ -1,0 +1,174 @@
+"""Tests for the orchestrated runner HTTP helpers."""
+
+from __future__ import annotations
+
+import json
+from typing import List, Tuple
+
+import httpx
+import pytest
+
+from worker.jobs import Job, JobStatus
+from worker.runner_orch import create_gateway_client, run_orchestrated_job
+
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Limit anyio-powered tests to the asyncio backend."""
+
+    return "asyncio"
+
+
+async def test_run_orchestrated_job_successful_flow() -> None:
+    """Execute the happy-path flow and capture session metadata in metrics."""
+
+    call_log: List[Tuple[str, str]] = []
+    poll_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal poll_calls
+        call_log.append((request.method, request.url.path))
+        assert request.headers["Authorization"] == "Bearer secret-token"
+
+        if request.method == "POST" and request.url.path == "/sessions/commands":
+            body = json.loads(request.content.decode())
+            assert body["start_url"] == "https://example.com"
+            assert body["idle_ttl_seconds"] == 60
+            return httpx.Response(201, json={"id": "sess-1", "status": "INIT"}, request=request)
+
+        if request.method == "POST" and request.url.path == "/sessions/sess-1/proxy":
+            body = json.loads(request.content.decode())
+            assert body == {"http": "http://user:pwd@proxy:8080"}
+            return httpx.Response(200, json={"id": "sess-1", "status": "INIT"}, request=request)
+
+        if request.method == "GET" and request.url.path == "/sessions/sess-1":
+            poll_calls += 1
+            if poll_calls == 1:
+                return httpx.Response(
+                    200,
+                    json={"id": "sess-1", "status": "INIT", "last_seen_at": "2025-01-01T00:00:00Z"},
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                json={"id": "sess-1", "status": "READY", "last_seen_at": "2025-01-01T00:00:02Z"},
+                request=request,
+            )
+
+        if request.method == "POST" and request.url.path == "/sessions/sess-1/touch":
+            return httpx.Response(
+                200,
+                json={"id": "sess-1", "status": "READY", "last_seen_at": "2025-01-01T00:00:03Z"},
+                request=request,
+            )
+
+        if request.method == "DELETE" and request.url.path == "/sessions/sess-1":
+            return httpx.Response(204, request=request)
+
+        raise AssertionError(f"Unexpected request: {request.method} {request.url.path}")
+
+    transport = httpx.MockTransport(handler)
+    job = Job(url="https://example.com", http_proxy="http://user:pwd@proxy:8080")
+
+    async with create_gateway_client(
+        "https://gateway.local", "secret-token", transport=transport
+    ) as client:
+        result = await run_orchestrated_job(
+            job,
+            client,
+            poll_interval=0.0,
+            poll_timeout=5.0,
+            backoff=0.0,
+        )
+
+    assert result.ok is True
+    assert result.status is JobStatus.SUCCESS
+    assert result.metrics.extra["session_id"] == "sess-1"
+    assert result.metrics.extra["poll_attempts"] == 2
+    assert result.metrics.extra["session_status"] == "READY"
+    assert result.metrics.extra["touched_at"] == "2025-01-01T00:00:03Z"
+    assert sum(1 for method, path in call_log if path == "/sessions/commands") == 1
+    assert sum(1 for method, path in call_log if path == "/sessions/sess-1") >= 2
+
+
+async def test_poll_retries_and_metrics_are_recorded() -> None:
+    """Retry transient gateway failures while preserving success semantics."""
+
+    poll_requests = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal poll_requests
+
+        if request.method == "POST" and request.url.path == "/sessions/commands":
+            return httpx.Response(201, json={"id": "sess-2", "status": "INIT"}, request=request)
+
+        if request.method == "GET" and request.url.path == "/sessions/sess-2":
+            poll_requests += 1
+            if poll_requests == 1:
+                return httpx.Response(500, json={"detail": "temporary"}, request=request)
+            return httpx.Response(200, json={"id": "sess-2", "status": "READY"}, request=request)
+
+        if request.method == "POST" and request.url.path == "/sessions/sess-2/touch":
+            return httpx.Response(200, json={"id": "sess-2", "status": "READY"}, request=request)
+
+        if request.method == "DELETE" and request.url.path == "/sessions/sess-2":
+            return httpx.Response(204, request=request)
+
+        raise AssertionError(f"Unexpected request: {request.method} {request.url.path}")
+
+    transport = httpx.MockTransport(handler)
+    job = Job(url="https://retry.example")
+
+    async with create_gateway_client(
+        "https://gateway.local", "token", transport=transport
+    ) as client:
+        result = await run_orchestrated_job(
+            job,
+            client,
+            poll_interval=0.0,
+            poll_timeout=5.0,
+            backoff=0.0,
+        )
+
+    assert poll_requests == 2
+    assert result.ok is True
+    assert result.status is JobStatus.SUCCESS
+    assert result.metrics.extra["session_status"] == "READY"
+    assert result.metrics.extra["poll_attempts"] == 1
+
+
+async def test_run_orchestrated_job_failure_on_create() -> None:
+    """Surface gateway creation failures as ``JobResult`` errors after retries."""
+
+    create_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal create_calls
+        if request.method == "POST" and request.url.path == "/sessions/commands":
+            create_calls += 1
+            return httpx.Response(500, json={"detail": "boom"}, request=request)
+        raise AssertionError(f"Unexpected request: {request.method} {request.url.path}")
+
+    transport = httpx.MockTransport(handler)
+    job = Job(url="https://failure.example")
+
+    async with create_gateway_client(
+        "https://gateway.local", "token", transport=transport
+    ) as client:
+        result = await run_orchestrated_job(
+            job,
+            client,
+            poll_interval=0.0,
+            poll_timeout=1.0,
+            backoff=0.0,
+        )
+
+    assert create_calls == 4  # initial attempt + 3 retries
+    assert result.ok is False
+    assert result.status is JobStatus.FAILURE
+    assert result.error is not None
+    assert result.error.type == "GatewayRequestError"
+    assert "session_id" not in result.metrics.extra

--- a/services/camoufox_worker/worker/main.py
+++ b/services/camoufox_worker/worker/main.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from typing import Optional
 
 import click
 
-from .jobs import Job
+from .jobs import Job, JobResult
 from .runner_native import run_job
+from .runner_orch import create_gateway_client, run_orchestrated_job
 
 
 @click.group()
@@ -22,11 +24,46 @@ def cli() -> None:
 @click.option(
     "--mode",
     type=click.Choice(["native", "orchestrator"], case_sensitive=False),
+    envvar="WORKER_MODE",
     default="native",
     show_default=True,
-    help="Режим выполнения задачи.",
+    help="Режим выполнения задачи (можно переопределить переменной WORKER_MODE).",
 )
-def run(url: str, timeout: int, mode: str) -> None:
+@click.option(
+    "--gateway-url",
+    envvar="GATEWAY_URL",
+    default=None,
+    help="Базовый URL Gateway для orchestrator-режима.",
+)
+@click.option(
+    "--gateway-token",
+    envvar="GATEWAY_TOKEN",
+    default=None,
+    help="Bearer-токен Gateway (env GATEWAY_TOKEN).",
+)
+@click.option(
+    "--poll-timeout",
+    type=float,
+    default=90.0,
+    show_default=True,
+    help="Таймаут ожидания готовности сессии в orchestrator-режиме (сек).",
+)
+@click.option(
+    "--poll-interval",
+    type=float,
+    default=1.0,
+    show_default=True,
+    help="Интервал опроса статуса сессии в orchestrator-режиме (сек).",
+)
+def run(
+    url: str,
+    timeout: int,
+    mode: str,
+    gateway_url: Optional[str],
+    gateway_token: Optional[str],
+    poll_timeout: float,
+    poll_interval: float,
+) -> None:
     """Parse CLI arguments and trigger a single job execution.
 
     Parameters
@@ -36,7 +73,16 @@ def run(url: str, timeout: int, mode: str) -> None:
     timeout: int
         Таймаут выполнения задачи в секундах.
     mode: str
-        Режим выполнения (`native` или `orchestrator`). Заглушка, пока поддерживается только native.
+        Режим выполнения (`native` или `orchestrator`). Значение по умолчанию
+        можно задать переменной окружения ``WORKER_MODE``.
+    gateway_url: str | None
+        Базовый URL Gateway для orchestrator-режима. Читается из ``GATEWAY_URL``.
+    gateway_token: str | None
+        Bearer-токен для Gateway. Можно передать через ``GATEWAY_TOKEN``.
+    poll_timeout: float
+        Максимальное время ожидания статуса ``READY`` при оркестрации.
+    poll_interval: float
+        Интервал опроса Gateway при ожидании готовности сессии.
 
     Side Effects
     ------------
@@ -45,13 +91,66 @@ def run(url: str, timeout: int, mode: str) -> None:
     """
 
     job = Job(url=url, timeout_sec=timeout)
-    if mode.lower() != "native":
-        click.echo("Orchestrator mode is not yet implemented.", err=True)
-        sys.exit(1)
-    result = run_job(job)
+    normalized_mode = mode.lower()
+    if normalized_mode == "native":
+        result = run_job(job)
+    else:
+        if not gateway_url or not gateway_token:
+            click.echo(
+                "Gateway URL и токен обязательны для orchestrator-режима (см. GATEWAY_URL/GATEWAY_TOKEN).",
+                err=True,
+            )
+            sys.exit(1)
+        result = asyncio.run(
+            _run_orchestrator(
+                job,
+                gateway_url=gateway_url,
+                gateway_token=gateway_token,
+                poll_timeout=poll_timeout,
+                poll_interval=poll_interval,
+            )
+        )
     click.echo(result.model_dump_json(indent=2, exclude_none=True))
     if not result.ok:
         sys.exit(1)
+
+
+async def _run_orchestrator(
+    job: Job,
+    *,
+    gateway_url: str,
+    gateway_token: str,
+    poll_timeout: float,
+    poll_interval: float,
+) -> JobResult:
+    """Execute a job against the gateway orchestrator and return its result.
+
+    Parameters
+    ----------
+    job:
+        Подготовленная задача.
+    gateway_url:
+        Базовый URL публичного Gateway.
+    gateway_token:
+        Bearer-токен для аутентификации.
+    poll_timeout:
+        Максимальное время ожидания статуса ``READY``.
+    poll_interval:
+        Интервал опроса статуса сессии.
+
+    Returns
+    -------
+    JobResult
+        Результат выполнения orchestrator-потока.
+    """
+
+    async with create_gateway_client(gateway_url, gateway_token) as client:
+        return await run_orchestrated_job(
+            job,
+            client,
+            poll_timeout=poll_timeout,
+            poll_interval=poll_interval,
+        )
 
 
 def main(argv: Optional[list[str]] = None) -> int:

--- a/services/camoufox_worker/worker/runner_orch.py
+++ b/services/camoufox_worker/worker/runner_orch.py
@@ -1,41 +1,535 @@
-"""HTTP client helpers for orchestrating sessions via the public gateway."""
+"""Async HTTP helpers for orchestrating sessions via the public gateway."""
 
 from __future__ import annotations
 
-from typing import Any, Dict
+import asyncio
+import time
+from datetime import UTC, datetime
+from typing import Any, Dict, Mapping, Optional, Sequence, Tuple
 
 import httpx
 
+from .jobs import Job, JobError, JobMetrics, JobResult, JobStatus
 
-def create_session(gateway_url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
-    """Request session creation from the gateway and return its JSON payload.
+DEFAULT_TIMEOUT = 10.0
+RETRY_STATUS_CODES = (500, 502, 503, 504)
+
+
+class GatewayRequestError(RuntimeError):
+    """Raised when the gateway rejects a request after exhausting retries."""
+
+
+def create_gateway_client(
+    base_url: str,
+    token: str,
+    *,
+    timeout: float = DEFAULT_TIMEOUT,
+    transport: httpx.AsyncBaseTransport | None = None,
+) -> httpx.AsyncClient:
+    """Return an authenticated :class:`httpx.AsyncClient` for the gateway.
 
     Parameters
     ----------
-    gateway_url: str
-        Базовый URL публичного gateway, например `https://gateway.example.com`.
-    payload: dict[str, Any]
-        Тело запроса, совместимое с `POST /sessions` в gateway.
+    base_url:
+        Базовый URL публичного Gateway (например, ``https://gateway.example``).
+    token:
+        Bearer-токен для аутентификации HTTP-запросов.
+    timeout:
+        Таймаут в секундах, применяемый к каждому запросу (по умолчанию 10 сек).
+    transport:
+        Необязательный транспорт (например, ``httpx.MockTransport``) — удобно
+        использовать в unit-тестах.
+
+    Returns
+    -------
+    httpx.AsyncClient
+        Клиент с установленным заголовком ``Authorization`` и JSON Accept.
+
+    Examples
+    --------
+    >>> client = create_gateway_client("https://gateway", "token")
+    >>> isinstance(client, httpx.AsyncClient)
+    True
+    """
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json",
+    }
+    return httpx.AsyncClient(
+        base_url=base_url,
+        timeout=timeout,
+        headers=headers,
+        transport=transport,
+    )
+
+
+async def create_session(
+    client: httpx.AsyncClient,
+    payload: Mapping[str, Any],
+    *,
+    retries: int = 3,
+    backoff: float = 0.5,
+) -> Dict[str, Any]:
+    """Create a session via ``POST /sessions/commands`` and return the payload.
+
+    Parameters
+    ----------
+    client:
+        Предварительно аутентифицированный ``httpx.AsyncClient``.
+    payload:
+        Тело запроса, совместимое с контрактом ``POST /sessions/commands``.
+    retries:
+        Количество повторов при сетевых и 5xx ошибках (по умолчанию 3).
+    backoff:
+        Базовая задержка (сек) перед повтором; увеличивается экспоненциально.
 
     Returns
     -------
     dict[str, Any]
-        Ответ gateway, преобразованный из JSON.
+        JSON-ответ Gateway, преобразованный в словарь.
 
     Raises
     ------
-    httpx.HTTPStatusError
-        Если сервер вернул код ответа >=400.
-    httpx.TransportError
-        Если запрос не был выполнен из-за сетевой ошибки.
-
-    Examples
-    --------
-    >>> create_session("https://gateway.example.com", {"runner_id": "local"})
-    {'id': 'session-123', ...}
+    GatewayRequestError
+        Если запрос завершился ошибкой после всех ретраев.
     """
 
-    with httpx.Client(timeout=5) as client:
-        response = client.post(f"{gateway_url}/sessions", json=payload)
-        response.raise_for_status()
-        return response.json()
+    response = await _request_with_retry(
+        client,
+        "POST",
+        "/sessions/commands",
+        json=dict(payload),
+        expected_status=(201,),
+        retries=retries,
+        backoff=backoff,
+    )
+    return response.json()
+
+
+async def update_session_proxy(
+    client: httpx.AsyncClient,
+    session_id: str,
+    proxy_payload: Mapping[str, Any],
+    *,
+    retries: int = 3,
+    backoff: float = 0.5,
+) -> Dict[str, Any]:
+    """Update proxy configuration via ``POST /sessions/{id}/proxy``.
+
+    Parameters
+    ----------
+    client:
+        Аутентифицированный HTTP-клиент Gateway.
+    session_id:
+        Идентификатор сессии, возвращённый ``create_session``.
+    proxy_payload:
+        Поля, соответствующие ``SessionProxySettings`` (минимум одно значение).
+    retries:
+        Допустимое число повторов при временных сбоях.
+    backoff:
+        Базовый интервал экспоненциальной задержки перед ретраем.
+
+    Returns
+    -------
+    dict[str, Any]
+        Обновлённое состояние сессии.
+
+    Raises
+    ------
+    GatewayRequestError
+        При исчерпании ретраев или неожидаемом HTTP-статусе.
+    """
+
+    response = await _request_with_retry(
+        client,
+        "POST",
+        f"/sessions/{session_id}/proxy",
+        json=dict(proxy_payload),
+        expected_status=(200,),
+        retries=retries,
+        backoff=backoff,
+    )
+    return response.json()
+
+
+async def touch_session(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    timestamp: datetime | None = None,
+    retries: int = 3,
+    backoff: float = 0.5,
+) -> Dict[str, Any]:
+    """Send ``POST /sessions/{id}/touch`` to refresh ``last_seen_at``.
+
+    Parameters
+    ----------
+    client:
+        Аутентифицированный HTTP-клиент Gateway.
+    session_id:
+        Целевая сессия.
+    timestamp:
+        Пользовательский таймстемп (UTC); по умолчанию используется текущее время.
+    retries:
+        Количество ретраев при временных ошибках.
+    backoff:
+        Базовый интервал экспоненциальной задержки.
+
+    Returns
+    -------
+    dict[str, Any]
+        Обновлённое состояние сессии.
+
+    Raises
+    ------
+    GatewayRequestError
+        Если запрос неоднократно завершился ошибкой.
+    """
+
+    timestamp = timestamp or datetime.now(tz=UTC)
+    payload = {"timestamp": timestamp.isoformat()}
+    response = await _request_with_retry(
+        client,
+        "POST",
+        f"/sessions/{session_id}/touch",
+        json=payload,
+        expected_status=(200,),
+        retries=retries,
+        backoff=backoff,
+    )
+    return response.json()
+
+
+async def delete_session(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    retries: int = 3,
+    backoff: float = 0.5,
+) -> None:
+    """Issue ``DELETE /sessions/{id}`` and swallow 404 responses gracefully.
+
+    Parameters
+    ----------
+    client:
+        Аутентифицированный HTTP-клиент Gateway.
+    session_id:
+        Идентификатор сессии.
+    retries:
+        Максимальное количество повторов для временных ошибок.
+    backoff:
+        Базовый интервал экспоненциальной задержки.
+
+    Raises
+    ------
+    GatewayRequestError
+        При ошибках сети или неожидаемом статусе, отличном от ``204``/``404``.
+    """
+
+    await _request_with_retry(
+        client,
+        "DELETE",
+        f"/sessions/{session_id}",
+        expected_status=(204, 404),
+        retries=retries,
+        backoff=backoff,
+    )
+
+
+async def poll_session_status(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    target_statuses: Sequence[str] = ("READY",),
+    poll_interval: float = 1.0,
+    poll_timeout: float = 60.0,
+    retries: int = 3,
+    backoff: float = 0.5,
+) -> Tuple[Dict[str, Any], int]:
+    """Poll ``GET /sessions/{id}`` until it reaches one of ``target_statuses``.
+
+    Parameters
+    ----------
+    client:
+        Аутентифицированный HTTP-клиент Gateway.
+    session_id:
+        Целевая сессия.
+    target_statuses:
+        Набор статусов (в верхнем регистре), при достижении которых polling
+        завершается успехом.
+    poll_interval:
+        Интервал (сек) между успешными запросами.
+    poll_timeout:
+        Общее время ожидания (сек) до генерации ``asyncio.TimeoutError``.
+    retries:
+        Количество повторов при временных сетевых/серверных сбоях.
+    backoff:
+        Базовая задержка перед ретраем запросов, завершившихся ошибкой.
+
+    Returns
+    -------
+    tuple[dict[str, Any], int]
+        Кортеж из последнего ответа Gateway и количества выполненных попыток.
+
+    Raises
+    ------
+    asyncio.TimeoutError
+        Если целевой статус не достигнут за ``poll_timeout`` секунд.
+    GatewayRequestError
+        При исчерпании ретраев.
+    """
+
+    start = time.perf_counter()
+    attempts = 0
+    while True:
+        attempts += 1
+        response = await _request_with_retry(
+            client,
+            "GET",
+            f"/sessions/{session_id}",
+            expected_status=(200,),
+            retries=retries,
+            backoff=backoff,
+        )
+        payload = response.json()
+        status = str(payload.get("status", "")).upper()
+        if status in {value.upper() for value in target_statuses}:
+            return payload, attempts
+
+        elapsed = time.perf_counter() - start
+        if elapsed >= poll_timeout:
+            raise asyncio.TimeoutError(
+                f"Timed out after {poll_timeout}s waiting for status in {target_statuses}"
+            )
+        await asyncio.sleep(poll_interval)
+
+
+async def run_orchestrated_job(
+    job: Job,
+    client: httpx.AsyncClient,
+    *,
+    poll_interval: float = 1.0,
+    poll_timeout: float = 60.0,
+    idle_ttl_seconds: int | None = None,
+    retries: int = 3,
+    backoff: float = 0.5,
+) -> JobResult:
+    """Execute a job via the orchestrator flow and return a :class:`JobResult`.
+
+    Parameters
+    ----------
+    job:
+        Pydantic-модель с параметрами задачи.
+    client:
+        Аутентифицированный HTTP-клиент Gateway (см. ``create_gateway_client``).
+    poll_interval:
+        Интервал между запросами ``GET /sessions/{id}``.
+    poll_timeout:
+        Максимальное время ожидания целевого статуса.
+    idle_ttl_seconds:
+        Необязательное переопределение ``idle_ttl_seconds`` для создаваемой
+        сессии. Если не указано — используется ``job.timeout_sec`` (с ограниче-
+        нием 30–3600 секунд).
+    retries:
+        Количество повторов при сетевых и серверных ошибках.
+    backoff:
+        Базовая задержка (сек) перед ретраями, применяется экспоненциально.
+
+    Returns
+    -------
+    JobResult
+        Структурированный результат выполнения оркестраторного сценария.
+
+    Notes
+    -----
+    Функция создаёт сессию, при необходимости настраивает прокси, ожидает
+    статуса ``READY``, отправляет ``touch`` и гарантированно пытается удалить
+    сессию в финале.
+    """
+
+    started_at = datetime.now(tz=UTC)
+    started_perf = time.perf_counter()
+    status = JobStatus.SUCCESS
+    error: Optional[JobError] = None
+    session_id: Optional[str] = None
+    metrics_extra: Dict[str, Any] = {
+        "mode": "orchestrator",
+    }
+
+    try:
+        payload = _job_to_session_payload(job, idle_ttl_seconds)
+        session = await create_session(
+            client,
+            payload,
+            retries=retries,
+            backoff=backoff,
+        )
+        session_id = str(session.get("id")) if session.get("id") is not None else None
+        if session_id:
+            metrics_extra["session_id"] = session_id
+
+        proxy_payload = _job_to_proxy_payload(job)
+        if session_id and proxy_payload:
+            session = await update_session_proxy(
+                client,
+                session_id,
+                proxy_payload,
+                retries=retries,
+                backoff=backoff,
+            )
+
+        if session_id:
+            poll_result, attempts = await poll_session_status(
+                client,
+                session_id,
+                poll_interval=poll_interval,
+                poll_timeout=poll_timeout,
+                retries=retries,
+                backoff=backoff,
+            )
+            metrics_extra["poll_attempts"] = attempts
+            metrics_extra["session_status"] = poll_result.get("status")
+            metrics_extra["last_seen_at"] = poll_result.get("last_seen_at")
+
+            touched = await touch_session(
+                client,
+                session_id,
+                retries=retries,
+                backoff=backoff,
+            )
+            if "last_seen_at" in touched:
+                metrics_extra["touched_at"] = touched["last_seen_at"]
+    except asyncio.TimeoutError as exc:
+        status = JobStatus.FAILURE
+        error = JobError(type=exc.__class__.__name__, message=str(exc))
+    except GatewayRequestError as exc:
+        status = JobStatus.FAILURE
+        error = JobError(type=exc.__class__.__name__, message=str(exc))
+    finally:
+        if session_id:
+            try:
+                await delete_session(
+                    client,
+                    session_id,
+                    retries=retries,
+                    backoff=backoff,
+                )
+            except GatewayRequestError as exc:
+                metrics_extra["cleanup_error"] = str(exc)
+                status = JobStatus.FAILURE
+                if error is None:
+                    error = JobError(type=exc.__class__.__name__, message=str(exc))
+
+    finished_at = datetime.now(tz=UTC)
+    metrics = JobMetrics(
+        duration_ms=(time.perf_counter() - started_perf) * 1000.0,
+        extra=metrics_extra,
+    )
+    return JobResult(
+        job=job,
+        status=status,
+        ok=status is JobStatus.SUCCESS,
+        started_at=started_at,
+        finished_at=finished_at,
+        metrics=metrics,
+        error=error,
+    )
+
+
+def _job_to_session_payload(job: Job, idle_ttl_seconds: int | None = None) -> Dict[str, Any]:
+    """Convert a :class:`Job` into a payload for ``POST /sessions/commands``."""
+
+    ttl = idle_ttl_seconds if idle_ttl_seconds is not None else int(job.timeout_sec)
+    ttl = max(30, min(int(ttl), 3600))
+    payload: Dict[str, Any] = {
+        "browser": "camoufox",
+        "headless": True,
+        "idle_ttl_seconds": ttl,
+        "start_url": job.url_source,
+        "labels": {
+            "worker_mode": "orchestrator",
+        },
+        "metadata": {
+            "job_timeout_sec": job.timeout_sec,
+        },
+    }
+    proxy_payload = _job_to_proxy_payload(job)
+    if proxy_payload:
+        payload["proxy"] = proxy_payload
+    return payload
+
+
+def _job_to_proxy_payload(job: Job) -> Dict[str, str] | None:
+    """Return a ``SessionProxySettings``-compatible mapping for the job."""
+
+    proxy_payload = {
+        "http": job.http_proxy,
+        "https": job.https_proxy,
+        "socks": job.socks_proxy,
+    }
+    compact = {key: value for key, value in proxy_payload.items() if value}
+    return compact or None
+
+
+async def _request_with_retry(
+    client: httpx.AsyncClient,
+    method: str,
+    path: str,
+    *,
+    json: Mapping[str, Any] | None = None,
+    expected_status: Sequence[int] = (200,),
+    retries: int = 3,
+    backoff: float = 0.5,
+) -> httpx.Response:
+    """Execute an HTTP request with retry semantics for transient failures."""
+
+    attempt = 0
+    last_error: Optional[BaseException] = None
+    while attempt <= retries:
+        try:
+            response = await client.request(method, path, json=json)
+            if response.status_code not in expected_status:
+                if response.status_code >= 400:
+                    try:
+                        response.raise_for_status()
+                    except httpx.HTTPStatusError as exc:
+                        raise exc
+                raise GatewayRequestError(
+                    f"Unexpected status {response.status_code} for {method} {path}"
+                )
+            return response
+        except httpx.HTTPStatusError as exc:
+            last_error = exc
+            status_code = exc.response.status_code
+            if status_code in RETRY_STATUS_CODES and attempt < retries:
+                await asyncio.sleep(backoff * (2**attempt))
+                attempt += 1
+                continue
+            raise GatewayRequestError(
+                f"Gateway rejected {method} {path} with status {status_code}"
+            ) from exc
+        except httpx.HTTPError as exc:
+            last_error = exc
+            if attempt < retries:
+                await asyncio.sleep(backoff * (2**attempt))
+                attempt += 1
+                continue
+            raise GatewayRequestError(
+                f"Failed to execute {method} {path}: {exc}"
+            ) from exc
+
+    assert last_error is not None  # pragma: no cover - defensive guard
+    raise GatewayRequestError(str(last_error))
+
+
+__all__ = [
+    "GatewayRequestError",
+    "create_gateway_client",
+    "create_session",
+    "delete_session",
+    "poll_session_status",
+    "run_orchestrated_job",
+    "touch_session",
+    "update_session_proxy",
+]


### PR DESCRIPTION
Summary:
- add async gateway helpers in `runner_orch` to manage session lifecycle with retries, proxy updates, heartbeats, and cleanup
- extend the worker CLI to drive orchestrator mode via env/flags while reusing `Job`/`JobResult` typing across modes
- cover orchestrator flows with httpx-powered pytest suites that verify success and retry/error handling paths

Testing:
- `PYTHONPATH=. poetry run pytest -q`

Security:
- n/a


------
https://chatgpt.com/codex/tasks/task_e_68dd75558fcc832aad9a874a8265ba0f