### PR TITLE
Add idle session reaper and touch endpoint

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -5,11 +5,14 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 
 ## Interfaces
 - **HTTP**
-  - `GET /health` — возвращает `{status, runner_id, camoufox_path, slots, vnc, proxy, prewarm}`;
+  - `GET /health` — возвращает `{status, runner_id, camoufox_path, slots, vnc, proxy, prewarm, ttl}`;
     `slots.total` считывается из `RunnerSettings.slot_limit`, `slots.active` — количество
-    не-`DEAD` сессий; `prewarm` включает счётчик и последнюю ошибку прогрева.
+    не-`DEAD` сессий; `prewarm` включает счётчик и последнюю ошибку прогрева;
+    `ttl` содержит ближайшее истечение (`next_expiry_at`) и счетчики работы
+    фонового reaper-а (`total_runs`, `expired_sessions`, `last_run_at`).
   - `POST /sessions` — accepts `SessionCreatePayload`, returns created `core.Session` snapshot.
   - `PATCH /sessions/{id}` — accepts `SessionUpdatePayload`, merges labels/metadata, returns updated `core.Session`.
+  - `POST /sessions/{id}/touch` — обновляет `last_seen_at`, продлевая TTL и публикуя heartbeat-событие.
   - `DELETE /sessions/{id}` — marks session as `DEAD`, returns terminal snapshot.
 - **Event transport**
   - `SessionEventPublisher.publish(SessionEvent)` — protocol for pushing lifecycle events downstream. Default implementation stores events in memory (`InMemorySessionEventPublisher`) but can be swapped for HTTP/SSE bridges via `CallbackSessionEventPublisher`.
@@ -20,7 +23,8 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 - Local payload models (`SessionCreatePayload`, `SessionUpdatePayload`) act as request DTOs before conversion into immutable core models.
 - Sessions are keyed by UUID and persisted in-memory; timestamps sourced from an injectable clock (UTC aware).
 - `SessionManagerMetrics` агрегирует счётчик активных сессий и историю ошибок прогрева (bounded deque по
-  `RunnerSettings.prewarm_failure_history_size`).
+  `RunnerSettings.prewarm_failure_history_size`), ближайшее истечение TTL и статистику
+  фонового reaper-а (кол-во запусков, количество завершённых сессий и отметку последнего запуска).
 
 ## Decisions
 - **In-memory publisher**: Стандартный транспорт построен на `InMemorySessionEventPublisher` и считается продукционным решением; при необходимости можно оборачивать его через `CallbackSessionEventPublisher` для сторонних интеграций без отказа от in-memory ядра.
@@ -33,6 +37,10 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
   показывать последние сбои без риска утечки памяти.
 - **Gateway proxy compatibility**: `SessionCreatePayload` остаётся публичным контрактом, но теперь вызывается через Gateway, потому важна обратная совместимость и строгая валидация.
 - **Playwright launch lifecycle**: `app.browser.launch_browser` стартует Playwright в режиме `launch-server`, сохраняет `wsEndpoint`/PID в метаданных и позволяет `SessionManager` останавливать процесс при переходе в `DEAD` или очистке endpoint. Исключения при старте выполняют откат без публикации событий.
+- **Idle TTL reaper**: `SessionManager` содержит AnyIO-based reaper, который вызывает
+  `reap_expired_sessions`, завершает истёкшие по `idle_ttl_seconds` сессии и публикует события
+  `session.ended` с reason=`idle-timeout`. Запускается/останавливается через `start()`/`stop()` и
+  lifecycle-хуки FastAPI.
 
 ## Constraints & Invariants
 - `RunnerSettings.vnc_token_ttl_seconds` capped at 300 seconds to align with `SessionVncDetails` validation.
@@ -42,6 +50,8 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 - Health payload normalises proxy base URLs by stripping trailing slashes
   only when the configured path is empty, preserving operator-provided
   values.
+- Idle reaper использует инъецируемые часы и общее состояние `SessionManager`; пересчёт ближайшего TTL выполняется после любых
+  апдейтов/завершений, чтобы метрики `next_expiry_at`/`reaper` оставались консистентными.
 
 ## Known Gaps / TODO
 - [ ] Зафиксировать профиль нагрузки для in-memory издателя после появления боевых метрик, чтобы подтвердить соответствие latency требованиям.
@@ -59,3 +69,4 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 - 2025-10-09 · gpt-5-codex · Переключили зависимость `camoufox` на локальный stub-пакет и нормализовали выдачу proxy URL в `/health`,
   чтобы `poetry install` и unit-тесты проходили в офлайн-окружении без лишних слешей.
 - 2025-10-10 · gpt-5-codex · Добавлен модуль `app.browser` с управлением процессом Playwright/Camoufox и интеграционными тестами на создание/завершение сессий.
+- 2025-10-11 · gpt-5-codex · Добавлены фоновые reaper-задачи, TTL-метрики в `/health`, эндпоинт `POST /sessions/{id}/touch` и покрытие тестами.

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Annotated, Any
 from uuid import UUID
 
@@ -53,6 +54,25 @@ RunnerSettingsDep = Annotated[RunnerSettings, Depends(get_runner_settings)]
 SessionManagerDep = Annotated[SessionManager, Depends(get_session_manager)]
 
 
+def _isoformat_or_none(value: datetime | None) -> str | None:
+    """Return an ISO formatted timestamp or ``None`` when absent.
+
+    Args:
+        value: Timestamp sourced from metrics.
+
+    Returns:
+        str | None: ISO-8601 representation or ``None``.
+
+    Example:
+        >>> _isoformat_or_none(datetime(2024, 1, 1))
+        '2024-01-01T00:00:00'
+    """
+
+    if value is None:
+        return None
+    return value.isoformat()
+
+
 @app.get("/health", summary="Runner health probe")
 async def health(
     settings: RunnerSettingsDep, manager: SessionManagerDep
@@ -86,6 +106,14 @@ async def health(
         "prewarm": {
             "failures": metrics.prewarm_failure_count,
             "last_error": metrics.last_prewarm_error,
+        },
+        "ttl": {
+            "next_expiry_at": _isoformat_or_none(metrics.next_idle_expiry_at),
+            "reaper": {
+                "total_runs": metrics.reaper_total_runs,
+                "expired_sessions": metrics.reaper_expired_sessions,
+                "last_run_at": _isoformat_or_none(metrics.reaper_last_run_at),
+            },
         },
     }
 
@@ -122,6 +150,23 @@ async def update_session(
         ) from exc
 
 
+@app.post(
+    "/sessions/{session_id}/touch",
+    response_model=Session,
+    summary="Touch a session",
+)
+async def touch_session(session_id: UUID, manager: SessionManagerDep) -> Session:
+    """Refresh the heartbeat for ``session_id`` to extend its idle TTL."""
+
+    try:
+        return await manager.touch_session(session_id)
+    except SessionNotFoundError as exc:  # pragma: no cover - defensive branch
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="session not found",
+        ) from exc
+
+
 @app.delete("/sessions/{session_id}", response_model=Session, summary="Terminate a session")
 async def delete_session(
     session_id: UUID,
@@ -136,6 +181,20 @@ async def delete_session(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="session not found",
         ) from exc
+
+
+@app.on_event("startup")
+async def _on_startup() -> None:
+    """Initialise background services such as the idle reaper."""
+
+    await get_session_manager().start()
+
+
+@app.on_event("shutdown")
+async def _on_shutdown() -> None:
+    """Tear down background tasks before process exit."""
+
+    await get_session_manager().stop()
 
 
 __all__ = ["app"]

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from collections import deque
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID, uuid4
 
 import anyio
+from anyio.abc import TaskGroup
 from core.models import (
     Session,
     SessionEvent,
@@ -83,14 +84,22 @@ class SessionManagerMetrics(BaseModel):
         active_sessions: Number of sessions that are not in the ``DEAD`` state.
         prewarm_failures: Ordered list of recorded prewarm failure messages.
         last_prewarm_error: Most recent prewarm failure message, if any.
+        next_idle_expiry_at: Timestamp for the soonest idle timeout, if any.
+        reaper_total_runs: Number of times the idle reaper executed.
+        reaper_expired_sessions: Cumulative count of sessions ended by the
+            idle reaper.
+        reaper_last_run_at: Timestamp of the most recent reaper execution.
 
     Example:
         >>> SessionManagerMetrics(
         ...     active_sessions=1,
         ...     prewarm_failures=["boom"],
         ...     last_prewarm_error="boom",
+        ...     next_idle_expiry_at=datetime.now(datetime.UTC),
+        ...     reaper_total_runs=2,
+        ...     reaper_expired_sessions=1,
         ... )
-        SessionManagerMetrics(active_sessions=1, prewarm_failures=['boom'], last_prewarm_error='boom')
+        SessionManagerMetrics(active_sessions=1, prewarm_failures=['boom'], last_prewarm_error='boom', ...)
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -98,6 +107,10 @@ class SessionManagerMetrics(BaseModel):
     active_sessions: int = Field(default=0, ge=0)
     prewarm_failures: list[str] = Field(default_factory=list)
     last_prewarm_error: str | None = Field(default=None)
+    next_idle_expiry_at: datetime | None = Field(default=None)
+    reaper_total_runs: int = Field(default=0, ge=0)
+    reaper_expired_sessions: int = Field(default=0, ge=0)
+    reaper_last_run_at: datetime | None = Field(default=None)
 
     @property
     def prewarm_failure_count(self) -> int:
@@ -107,13 +120,20 @@ class SessionManagerMetrics(BaseModel):
 
 
 class SessionManager:
-    """Manage session lifecycle and publish events for downstream consumers."""
+    """Manage session lifecycle and publish events for downstream consumers.
+
+    The manager tracks sessions in-memory, publishes lifecycle events, and
+    optionally runs a background reaper that enforces idle timeouts. The reaper
+    interval is configurable via ``reaper_interval_seconds`` to ease testing.
+    """
 
     def __init__(
         self,
         settings: RunnerSettings,
         event_publisher: SessionEventPublisher,
         clock: Callable[[], datetime] | None = None,
+        *,
+        reaper_interval_seconds: float = 1.0,
     ) -> None:
         self._settings = settings
         self._publisher = event_publisher
@@ -126,6 +146,12 @@ class SessionManager:
         )
         self._last_prewarm_error: str | None = None
         self._browser_handles: dict[UUID, BrowserSessionHandle] = {}
+        self._next_idle_expiry_at: datetime | None = None
+        self._reaper_total_runs = 0
+        self._reaper_expired_sessions = 0
+        self._reaper_last_run_at: datetime | None = None
+        self._reaper_interval = max(0.1, float(reaper_interval_seconds))
+        self._reaper_task_group: TaskGroup | None = None
 
     async def create_session(self, payload: SessionCreatePayload) -> Session:
         """Create, persist, and broadcast a new session object."""
@@ -180,6 +206,7 @@ class SessionManager:
                 raise
             self._sessions[session_id] = session
             self._browser_handles[session_id] = browser_handle
+            self._recalculate_next_idle_expiry_locked()
             if session.status is not SessionStatus.DEAD:
                 self._active_sessions += 1
             await self._publish(session, SessionEventType.CREATED, reason=None)
@@ -217,6 +244,7 @@ class SessionManager:
             session = existing.model_copy(update=update_data, deep=True)
             self._sessions[session_id] = session
             self._recalculate_active_sessions(existing.status, session.status)
+            self._recalculate_next_idle_expiry_locked()
             if self._should_cleanup_browser(existing, session):
                 await self._shutdown_browser(
                     session_id, force=session.status is SessionStatus.DEAD
@@ -283,11 +311,108 @@ class SessionManager:
             active_sessions = self._active_sessions
             failures = list(self._prewarm_failures)
             last_error = self._last_prewarm_error
+            next_idle_expiry = self._next_idle_expiry_at
+            reaper_total_runs = self._reaper_total_runs
+            reaper_expired_sessions = self._reaper_expired_sessions
+            reaper_last_run = self._reaper_last_run_at
         return SessionManagerMetrics(
             active_sessions=active_sessions,
             prewarm_failures=failures,
             last_prewarm_error=last_error,
+            next_idle_expiry_at=next_idle_expiry,
+            reaper_total_runs=reaper_total_runs,
+            reaper_expired_sessions=reaper_expired_sessions,
+            reaper_last_run_at=reaper_last_run,
         )
+
+    async def touch_session(self, session_id: UUID) -> Session:
+        """Refresh the ``last_seen_at`` timestamp to keep the session alive.
+
+        Args:
+            session_id: Identifier of the session to update.
+
+        Returns:
+            Session: Updated session snapshot reflecting the new heartbeat.
+
+        Example:
+            >>> await manager.touch_session(session_id)  # doctest: +SKIP
+        """
+
+        return await self.update_session(
+            session_id, SessionUpdatePayload(last_seen_at=self._clock())
+        )
+
+    async def reap_expired_sessions(self) -> int:
+        """End sessions that exceeded their idle TTL and return the count.
+
+        Returns:
+            int: Number of sessions transitioned to ``DEAD`` during the sweep.
+
+        Example:
+            >>> await manager.reap_expired_sessions()  # doctest: +SKIP
+        """
+
+        now = self._clock()
+        async with self._lock:
+            expired_ids: list[UUID] = []
+            next_expiry: datetime | None = None
+            for session in self._sessions.values():
+                if session.status is SessionStatus.DEAD:
+                    continue
+                candidate = session.last_seen_at + timedelta(
+                    seconds=session.idle_ttl_seconds
+                )
+                if candidate <= now:
+                    expired_ids.append(session.id)
+                    continue
+                if next_expiry is None or candidate < next_expiry:
+                    next_expiry = candidate
+            self._next_idle_expiry_at = next_expiry
+            self._reaper_total_runs += 1
+            self._reaper_last_run_at = now
+        expired = 0
+        for session_id in expired_ids:
+            try:
+                await self.end_session(
+                    session_id,
+                    reason="idle-timeout",
+                    ended_at=now,
+                )
+            except SessionNotFoundError:  # pragma: no cover - defensive guard
+                continue
+            expired += 1
+        if expired:
+            async with self._lock:
+                self._reaper_expired_sessions += expired
+        return expired
+
+    async def start(self) -> None:
+        """Start the background idle reaper task if not already running.
+
+        Example:
+            >>> await manager.start()  # doctest: +SKIP
+        """
+
+        async with self._lock:
+            if self._reaper_task_group is not None:
+                return
+            task_group = anyio.create_task_group()
+            await task_group.__aenter__()
+            task_group.start_soon(self._reaper_loop)
+            self._reaper_task_group = task_group
+
+    async def stop(self) -> None:
+        """Stop the background idle reaper task if it is running.
+
+        Example:
+            >>> await manager.stop()  # doctest: +SKIP
+        """
+
+        async with self._lock:
+            task_group = self._reaper_task_group
+            self._reaper_task_group = None
+        if task_group is not None:
+            await task_group.__aexit__(None, None, None)
 
     def _resolve_vnc(
         self,
@@ -346,6 +471,24 @@ class SessionManager:
             self._active_sessions = max(0, self._active_sessions - 1)
         elif not was_active and is_active:
             self._active_sessions += 1
+
+    def _recalculate_next_idle_expiry_locked(self) -> None:
+        """Recompute the nearest idle expiry using the current session map.
+
+        Example:
+            >>> manager._recalculate_next_idle_expiry_locked()  # doctest: +SKIP
+        """
+
+        next_expiry: datetime | None = None
+        for session in self._sessions.values():
+            if session.status is SessionStatus.DEAD:
+                continue
+            candidate = session.last_seen_at + timedelta(
+                seconds=session.idle_ttl_seconds
+            )
+            if next_expiry is None or candidate < next_expiry:
+                next_expiry = candidate
+        self._next_idle_expiry_at = next_expiry
 
     async def _publish(
         self,
@@ -409,6 +552,21 @@ class SessionManager:
         if handle is None:
             return
         await handle.shutdown(force=force)
+
+
+    async def _reaper_loop(self) -> None:
+        """Background coroutine periodically reaping idle sessions.
+
+        Example:
+            >>> await manager._reaper_loop()  # doctest: +SKIP
+        """
+
+        try:
+            while True:
+                await anyio.sleep(self._reaper_interval)
+                await self.reap_expired_sessions()
+        except BaseException:  # pragma: no cover - cancellation/propagation
+            raise
 
 
 __all__ = [

--- a/services/runner/tests/test_main.py
+++ b/services/runner/tests/test_main.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from httpx import AsyncClient
 
@@ -36,6 +38,23 @@ class _MainStubHandle:
         return None
 
 
+class _ApiStubClock:
+    """Mutable clock used to produce deterministic timestamps in API tests."""
+
+    def __init__(self, start: datetime) -> None:
+        self._now = start
+
+    def advance(self, seconds: float) -> None:
+        """Advance the current timestamp by ``seconds``."""
+
+        self._now += timedelta(seconds=seconds)
+
+    def __call__(self) -> datetime:
+        """Return the current timestamp."""
+
+        return self._now
+
+
 @pytest.fixture
 def stub_launch_browser(monkeypatch: pytest.MonkeyPatch) -> None:
     """Patch session manager browser launch to avoid spawning Playwright."""
@@ -56,6 +75,7 @@ async def test_health_endpoint_reports_extended_metrics(
 ) -> None:
     """``GET /health`` should expose slots, proxy, VNC, and prewarm diagnostics."""
 
+    clock = _ApiStubClock(datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC))
     settings = RunnerSettings(
         runner_id="runner-health",
         camoufox_path="/usr/bin/camoufox",
@@ -68,7 +88,12 @@ async def test_health_endpoint_reports_extended_metrics(
         prewarm_failure_history_size=5,
     )
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(settings, publisher)
+    manager = SessionManager(
+        settings,
+        publisher,
+        clock=clock,
+        reaper_interval_seconds=5.0,
+    )
 
     await manager.create_session(SessionCreatePayload())
     await manager.create_session(SessionCreatePayload())
@@ -106,3 +131,54 @@ async def test_health_endpoint_reports_extended_metrics(
         "failures": 2,
         "last_error": "prewarm retry failed",
     }
+    ttl = payload["ttl"]
+    assert ttl["reaper"] == {
+        "total_runs": 0,
+        "expired_sessions": 0,
+        "last_run_at": None,
+    }
+    assert ttl["next_expiry_at"] == (
+        clock() + timedelta(seconds=300)
+    ).isoformat()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_touch_endpoint_extends_idle_deadline(
+    stub_launch_browser: None,
+) -> None:
+    """``POST /sessions/{id}/touch`` should refresh ``last_seen_at``."""
+
+    clock = _ApiStubClock(datetime(2024, 2, 2, 10, 0, 0, tzinfo=UTC))
+    settings = RunnerSettings(
+        runner_id="runner-touch",
+        camoufox_path="/usr/bin/camoufox",
+    )
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(
+        settings,
+        publisher,
+        clock=clock,
+        reaper_interval_seconds=5.0,
+    )
+    session = await manager.create_session(
+        SessionCreatePayload(idle_ttl_seconds=45)
+    )
+
+    app.dependency_overrides[get_runner_settings] = lambda: settings
+    app.dependency_overrides[get_event_publisher] = lambda: publisher
+    app.dependency_overrides[get_session_manager] = lambda: manager
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            clock.advance(20)
+            response = await client.post(f"/sessions/{session.id}/touch")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == str(session.id)
+    expected_last_seen = clock().isoformat().replace("+00:00", "Z")
+    assert body["last_seen_at"] == expected_last_seen
+    metrics = await manager.get_metrics()
+    assert metrics.next_idle_expiry_at == clock() + timedelta(seconds=45)

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from app.config import RunnerSettings
@@ -236,6 +236,106 @@ async def test_metrics_track_active_sessions_and_prewarm_failures(
     assert metrics.prewarm_failures == ["warmup-1", "warmup-2"]
 
 
+@pytest.mark.anyio("asyncio")
+async def test_touch_session_updates_last_seen_and_publishes_update(
+    stub_launch_browser: list["_StubBrowserHandle"],
+) -> None:
+    """``touch_session`` should extend TTL and emit a heartbeat update."""
+
+    clock = _StubClock(datetime(2024, 6, 6, 12, 0, 0, tzinfo=UTC))
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(
+        RunnerSettings(runner_id="runner-touch", camoufox_path="/usr/bin/camoufox"),
+        publisher,
+        clock=clock,
+    )
+    session = await manager.create_session(
+        SessionCreatePayload(idle_ttl_seconds=60)
+    )
+
+    clock.advance(15)
+    touched = await manager.touch_session(session.id)
+
+    assert touched.last_seen_at == clock()
+    events = await publisher.drain()
+    assert [event.type for event in events] == [
+        SessionEventType.CREATED,
+        SessionEventType.UPDATED,
+    ]
+    assert events[-1].session.id == session.id
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reap_expired_sessions_marks_session_dead_and_records_metrics(
+    stub_launch_browser: list["_StubBrowserHandle"],
+) -> None:
+    """Idle sessions should transition to DEAD with an ``idle-timeout`` reason."""
+
+    clock = _StubClock(datetime(2024, 7, 7, 12, 0, 0, tzinfo=UTC))
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(
+        RunnerSettings(runner_id="runner-reap", camoufox_path="/usr/bin/camoufox"),
+        publisher,
+        clock=clock,
+    )
+    session = await manager.create_session(
+        SessionCreatePayload(idle_ttl_seconds=30)
+    )
+
+    clock.advance(31)
+    expired = await manager.reap_expired_sessions()
+
+    assert expired == 1
+    ended = await manager.get_session(session.id)
+    assert ended.status is SessionStatus.DEAD
+    events = await publisher.drain()
+    assert [event.type for event in events] == [
+        SessionEventType.CREATED,
+        SessionEventType.ENDED,
+    ]
+    assert events[-1].reason == "idle-timeout"
+    metrics = await manager.get_metrics()
+    assert metrics.reaper_expired_sessions == 1
+    assert metrics.reaper_total_runs == 1
+    assert metrics.next_idle_expiry_at is None
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reap_skips_recently_touched_session(
+    stub_launch_browser: list["_StubBrowserHandle"],
+) -> None:
+    """Touching a session should postpone its idle deadline for reaper runs."""
+
+    clock = _StubClock(datetime(2024, 8, 8, 12, 0, 0, tzinfo=UTC))
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(
+        RunnerSettings(runner_id="runner-skip", camoufox_path="/usr/bin/camoufox"),
+        publisher,
+        clock=clock,
+    )
+    session = await manager.create_session(
+        SessionCreatePayload(idle_ttl_seconds=40)
+    )
+
+    clock.advance(20)
+    assert await manager.reap_expired_sessions() == 0
+    metrics = await manager.get_metrics()
+    expected_expiry = session.last_seen_at + timedelta(seconds=40)
+    assert metrics.next_idle_expiry_at == expected_expiry
+
+    clock.advance(5)
+    touched = await manager.touch_session(session.id)
+    clock.advance(10)
+    assert await manager.reap_expired_sessions() == 0
+    metrics_after_touch = await manager.get_metrics()
+    assert metrics_after_touch.reaper_total_runs == 2
+    assert metrics_after_touch.reaper_expired_sessions == 0
+    assert (
+        metrics_after_touch.next_idle_expiry_at
+        == touched.last_seen_at + timedelta(seconds=40)
+    )
+
+
 class _StubBrowserHandle:
     """Test double mimicking :class:`BrowserSessionHandle`."""
 
@@ -248,6 +348,23 @@ class _StubBrowserHandle:
         """Record shutdown invocations for assertions."""
 
         self.shutdown_calls.append({"force": force, "timeout": timeout})
+
+
+class _StubClock:
+    """Mutable clock fixture to deterministically advance time in tests."""
+
+    def __init__(self, start: datetime) -> None:
+        self._now = start
+
+    def advance(self, seconds: float) -> None:
+        """Advance the current time by ``seconds`` in place."""
+
+        self._now += timedelta(seconds=seconds)
+
+    def __call__(self) -> datetime:
+        """Return the current timestamp."""
+
+        return self._now
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- add a background idle-session reaper with TTL metrics and lifecycle controls in the session manager
- expose TTL telemetry on /health and provide a /sessions/{id}/touch heartbeat endpoint
- extend unit and API tests to cover touch and expiry flows and document the behaviour in AGENT_NOTES

## Testing
- PYTHONPATH=. poetry run pytest tests/test_session_manager.py tests/test_main.py -q

## Security
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68dd8cf98188832aac13ae4587d24c67