### PR TITLE
feat(vnc-gateway): harden websocket relay with timeouts

### DIFF
--- a/services/vnc-gateway/AGENT_NOTES.md
+++ b/services/vnc-gateway/AGENT_NOTES.md
@@ -18,6 +18,7 @@ FastAPI service that validates short-lived VNC access tokens and proxies HTTP/WS
 - Dependency wiring relies on `typing.Annotated` wrappers to avoid Ruff `B008` violations while keeping FastAPI semantics.
 - Tests inject stubbed `RunnerProxy` via dependency overrides; `tests/conftest.py` adjusts `sys.path` instead of installing the package.
 - Runner proxy keeps a singleton `httpx.AsyncClient` and resolves `target_port` from query/referer/cookie (persisting it via `vnc-target-port` cookie) to build Runner URLs with configurable prefixes, mirroring the upstream beta implementation. WebSocket relaying now mirrors the production gateway behaviour with `FIRST_EXCEPTION` waiting semantics and graceful close codes (1008/1011).
+- WebSocket relay now enforces explicit open/idle/send timeouts and relies on a bounded upstream frame queue (`max_queue=16`) to ensure backpressure, closing client connections with 1011 on timeout or network failures.
 
 ## Constraints & Invariants
 - Tokens must include the matching session identifier; mismatches immediately rejected.
@@ -43,3 +44,4 @@ poetry run pytest -q
 - 2025-02-14 · gpt-5-codex · Initial FastAPI service implementation with token validator, proxy wiring, and unit tests.
 - 2025-10-03 · gpt-5-codex · Переведён валидатор на HS256 JWT и синхронизирован с Gateway `VncTokenService`.
 - 2025-10-06 · gpt-5-codex · Синхронизирован HTTP/WS-прокси с beta-референсом: общий `httpx.AsyncClient`, выбор `target_port` из query/referer/cookie с cookie-фолбэком, обновлённая двунаправленная WebSocket-переадресация и unit-тесты на таргет-порт хелперы.
+- 2025-10-08 · gpt-5-codex · Добавлены тайм-ауты/бэктрэш для WS-прокси, интеграция с `WebSocketState` и новые юнит-тесты на счастливый путь, ошибки сети и коды закрытия 1008/1011.

--- a/services/vnc-gateway/app/camou_vnc_gateway/proxy.py
+++ b/services/vnc-gateway/app/camou_vnc_gateway/proxy.py
@@ -32,6 +32,7 @@ import websockets
 from fastapi import Request, WebSocket
 from fastapi.responses import Response
 from starlette import status
+from starlette.websockets import WebSocketState
 from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 
 from .config import Settings
@@ -40,10 +41,23 @@ LOG = logging.getLogger(__name__)
 
 TARGET_PORT_COOKIE: Final[str] = "vnc-target-port"
 
+# Default operational parameters for WebSocket relaying.  The values mirror the
+# upstream gateway deployment where the public connection is considered idle
+# after 30 seconds of inactivity and the upstream ``websockets`` client keeps a
+# bounded frame buffer to exert backpressure on the Runner.
+_DEFAULT_WS_OPEN_TIMEOUT: Final[float] = 10.0
+_DEFAULT_WS_IDLE_TIMEOUT: Final[float] = 30.0
+_DEFAULT_WS_SEND_TIMEOUT: Final[float] = 15.0
+_DEFAULT_WS_MAX_QUEUE: Final[int] = 16
+
 
 class TargetPortError(ValueError):
     """Raised when ``target_port`` cannot be parsed or validated."""
 
+
+
+class RelayTimeoutError(RuntimeError):
+    """Raised when the WebSocket relay exceeds an operational timeout."""
 
 
 class RunnerProxy:
@@ -52,7 +66,9 @@ class RunnerProxy:
     The implementation relies on :mod:`httpx` for HTTP traffic and the
     :mod:`websockets` package for bidirectional WebSocket streaming.  Only the
     minimal functionality required by the assignment is implemented; the class
-    focuses on the two routes exposed by this service.
+    focuses on the two routes exposed by this service while providing explicit
+    timeout handling and bounded internal buffers to honour backpressure on both
+    sides of the tunnel.
     """
 
     def __init__(self, settings: Settings) -> None:
@@ -63,6 +79,10 @@ class RunnerProxy:
         self._http_prefix = (self._http_base.path or "").rstrip("/")
         self._ws_prefix = (self._ws_base.path or "").rstrip("/")
         self._cookie_path = _join_paths(self._http_prefix, "/vnc")
+        self._ws_open_timeout = _DEFAULT_WS_OPEN_TIMEOUT
+        self._ws_idle_timeout = _DEFAULT_WS_IDLE_TIMEOUT
+        self._ws_send_timeout = _DEFAULT_WS_SEND_TIMEOUT
+        self._ws_max_queue = _DEFAULT_WS_MAX_QUEUE
 
     async def aclose(self) -> None:
         """Release the shared HTTP client resources."""
@@ -194,6 +214,10 @@ class RunnerProxy:
         if extra_headers:
             connect_kwargs["extra_headers"] = extra_headers
 
+        connect_kwargs.setdefault("open_timeout", self._ws_open_timeout)
+        connect_kwargs.setdefault("close_timeout", self._ws_send_timeout)
+        connect_kwargs.setdefault("max_queue", self._ws_max_queue)
+
         try:
             async with websockets.connect(upstream_url, **connect_kwargs) as runner_ws:
                 await websocket.accept(subprotocol=runner_ws.subprotocol)
@@ -201,18 +225,35 @@ class RunnerProxy:
                 async def client_to_runner() -> None:
                     try:
                         while True:
-                            message = await websocket.receive()
+                            try:
+                                message = await asyncio.wait_for(
+                                    websocket.receive(),
+                                    timeout=self._ws_idle_timeout,
+                                )
+                            except asyncio.TimeoutError as exc:
+                                raise RelayTimeoutError("Client inactivity timeout") from exc
+
                             message_type = message.get("type")
                             if message_type == "websocket.disconnect":
                                 await runner_ws.close()
                                 break
+
                             text_data = message.get("text")
                             if text_data is not None:
-                                await runner_ws.send(text_data)
+                                await asyncio.wait_for(
+                                    runner_ws.send(text_data),
+                                    timeout=self._ws_send_timeout,
+                                )
                                 continue
+
                             binary_data = message.get("bytes")
                             if binary_data is not None:
-                                await runner_ws.send(binary_data)
+                                await asyncio.wait_for(
+                                    runner_ws.send(binary_data),
+                                    timeout=self._ws_send_timeout,
+                                )
+                    except RelayTimeoutError:
+                        raise
                     except Exception:  # pragma: no cover - defensive logging aid
                         LOG.exception(
                             "client_to_runner failed",
@@ -222,11 +263,32 @@ class RunnerProxy:
 
                 async def runner_to_client() -> None:
                     try:
-                        async for payload in runner_ws:
-                            if isinstance(payload, str):
-                                await websocket.send_text(payload)
-                            else:
-                                await websocket.send_bytes(payload)
+                        while True:
+                            try:
+                                payload = await asyncio.wait_for(
+                                    runner_ws.recv(),
+                                    timeout=self._ws_idle_timeout,
+                                )
+                            except asyncio.TimeoutError as exc:
+                                raise RelayTimeoutError("Upstream inactivity timeout") from exc
+                            except (ConnectionClosedError, ConnectionClosedOK):
+                                break
+
+                            if websocket.application_state is WebSocketState.DISCONNECTED:
+                                break
+
+                            sender = websocket.send_text if isinstance(payload, str) else websocket.send_bytes
+                            try:
+                                await asyncio.wait_for(
+                                    sender(payload),
+                                    timeout=self._ws_send_timeout,
+                                )
+                            except asyncio.TimeoutError as exc:
+                                raise RelayTimeoutError("Client send timeout") from exc
+                            except RuntimeError:
+                                break
+                    except RelayTimeoutError:
+                        raise
                     except Exception:  # pragma: no cover - defensive logging aid
                         LOG.exception(
                             "runner_to_client failed",
@@ -242,15 +304,26 @@ class RunnerProxy:
                     tasks,
                     return_when=asyncio.FIRST_EXCEPTION,
                 )
-                for task in pending:
-                    task.cancel()
-                    with suppress(asyncio.CancelledError):
-                        await task
+                error: Exception | None = None
                 for task in done:
                     with suppress(asyncio.CancelledError):
                         exc = task.exception()
                         if exc:
-                            raise exc
+                            error = exc
+                for task in pending:
+                    task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await task
+                if error:
+                    raise error
+        except RelayTimeoutError as exc:
+            LOG.warning(
+                "WebSocket relay timeout",
+                extra={"session_id": session_id},
+                exc_info=exc,
+            )
+            with suppress(RuntimeError):
+                await websocket.close(code=status.WS_1011_INTERNAL_ERROR, reason=str(exc))
         except (ConnectionClosedError, ConnectionClosedOK):
             with suppress(RuntimeError):
                 await websocket.close()

--- a/services/vnc-gateway/tests/test_proxy.py
+++ b/services/vnc-gateway/tests/test_proxy.py
@@ -1,0 +1,210 @@
+"""Tests covering the RunnerProxy websocket implementation."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from starlette import status
+from starlette.datastructures import Headers, QueryParams
+from starlette.websockets import WebSocketState
+from websockets.exceptions import ConnectionClosedOK
+
+from camou_vnc_gateway.config import Settings
+from camou_vnc_gateway.proxy import RunnerProxy
+
+
+class StubRunnerConnection:
+    """Deterministic upstream websocket used to simulate the Runner."""
+
+    def __init__(self) -> None:
+        self.subprotocol = "binary"
+        self.sent: list[Any] = []
+        self.closed = False
+        self._incoming: asyncio.Queue[Any] = asyncio.Queue()
+
+    async def send(self, payload: Any) -> None:
+        """Record payloads forwarded by the gateway."""
+
+        self.sent.append(payload)
+
+    async def recv(self) -> Any:
+        """Return the next payload destined for the client side."""
+
+        payload = await self._incoming.get()
+        if isinstance(payload, ConnectionClosedOK):
+            raise payload
+        return payload
+
+    async def close(self) -> None:
+        """Simulate closing the upstream websocket."""
+
+        if self.closed:
+            return
+        self.closed = True
+        await self._incoming.put(ConnectionClosedOK(1000, "runner closed"))
+
+    def queue_incoming(self, payload: Any) -> None:
+        """Queue a payload that should be delivered to the client."""
+
+        self._incoming.put_nowait(payload)
+
+
+class StubClientWebSocket:
+    """Minimal stand-in for :class:`starlette.websockets.WebSocket`."""
+
+    def __init__(self, *, query_string: str = "", headers: dict[str, str] | None = None) -> None:
+        self.headers = Headers(headers or {})
+        self.query_params = QueryParams(query_string)
+        self.application_state = WebSocketState.CONNECTING
+        self._receive_queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self.sent_text: list[str] = []
+        self.sent_bytes: list[bytes] = []
+        self.close_code: int | None = None
+        self.close_reason: str | None = None
+        self.accepted_subprotocol: str | None = None
+
+    def queue_message(self, message: dict[str, Any]) -> None:
+        """Inject a message that :meth:`receive` should return."""
+
+        self._receive_queue.put_nowait(message)
+
+    async def receive(self) -> dict[str, Any]:
+        """Return the next queued websocket message."""
+
+        message = await self._receive_queue.get()
+        if message.get("type") == "websocket.disconnect":
+            self.application_state = WebSocketState.DISCONNECTED
+        return message
+
+    async def send_text(self, data: str) -> None:
+        """Record text frames delivered to the client."""
+
+        if self.application_state is not WebSocketState.CONNECTED:
+            raise RuntimeError("websocket not connected")
+        self.sent_text.append(data)
+
+    async def send_bytes(self, data: bytes) -> None:
+        """Record binary frames delivered to the client."""
+
+        if self.application_state is not WebSocketState.CONNECTED:
+            raise RuntimeError("websocket not connected")
+        self.sent_bytes.append(data)
+
+    async def accept(self, subprotocol: str | None = None) -> None:
+        """Mark the websocket as connected and capture the negotiated protocol."""
+
+        self.application_state = WebSocketState.CONNECTED
+        self.accepted_subprotocol = subprotocol
+
+    async def close(self, *, code: int = status.WS_1000_NORMAL_CLOSURE, reason: str | None = None) -> None:
+        """Record close information for assertions."""
+
+        self.application_state = WebSocketState.DISCONNECTED
+        self.close_code = code
+        self.close_reason = reason
+
+
+class DummyConnectContext:
+    """Context manager mimicking :func:`websockets.connect`."""
+
+    def __init__(self, connection: StubRunnerConnection) -> None:
+        self._connection = connection
+
+    async def __aenter__(self) -> StubRunnerConnection:
+        return self._connection
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:  # noqa: D401 - standard signature
+        await self._connection.close()
+
+
+async def _run_forward_websocket_happy_path(monkeypatch) -> None:
+    """Scenario helper for the happy path websocket relay test."""
+
+    runner = StubRunnerConnection()
+
+    def fake_connect(url: str, **kwargs: Any) -> DummyConnectContext:  # noqa: D401
+        assert kwargs["subprotocols"] == ["binary"]
+        assert kwargs["open_timeout"] > 0
+        return DummyConnectContext(runner)
+
+    monkeypatch.setattr("camou_vnc_gateway.proxy.websockets.connect", fake_connect)
+
+    settings = Settings(token_secret="secret", runner_http_base="http://runner", runner_ws_base="ws://runner")
+    proxy = RunnerProxy(settings)
+
+    websocket = StubClientWebSocket(query_string="target_port=5901", headers={"sec-websocket-protocol": "binary"})
+
+    runner.queue_incoming("runner-text")
+    runner.queue_incoming(b"runner-bytes")
+    websocket.queue_message({"type": "websocket.receive", "text": "client-text"})
+    websocket.queue_message({"type": "websocket.receive", "bytes": b"client-bytes"})
+
+    async def enqueue_disconnect() -> None:
+        await asyncio.sleep(0)
+        websocket.queue_message({"type": "websocket.disconnect"})
+
+    asyncio.create_task(enqueue_disconnect())
+
+    await proxy.forward_websocket(session_id="abc", websocket=websocket)
+
+    assert websocket.accepted_subprotocol == "binary"
+    assert websocket.sent_text == ["runner-text"]
+    assert websocket.sent_bytes == [b"runner-bytes"]
+    assert runner.sent == ["client-text", b"client-bytes"]
+
+
+async def _run_forward_websocket_invalid_port(monkeypatch) -> None:
+    """Scenario helper verifying policy violation on invalid target_port."""
+
+    def fail_connect(*args: Any, **kwargs: Any) -> object:  # pragma: no cover - safety
+        raise AssertionError("websockets.connect should not be invoked")
+
+    monkeypatch.setattr("camou_vnc_gateway.proxy.websockets.connect", fail_connect)
+
+    settings = Settings(token_secret="secret", runner_http_base="http://runner", runner_ws_base="ws://runner")
+    proxy = RunnerProxy(settings)
+
+    websocket = StubClientWebSocket(query_string="target_port=invalid")
+
+    await proxy.forward_websocket(session_id="bad", websocket=websocket)
+
+    assert websocket.close_code == status.WS_1008_POLICY_VIOLATION
+    assert websocket.close_reason is not None
+
+
+async def _run_forward_websocket_network_error(monkeypatch) -> None:
+    """Scenario helper verifying internal error on network failures."""
+
+    def fake_connect(*args: Any, **kwargs: Any) -> DummyConnectContext:
+        raise OSError("dial tcp: refused")
+
+    monkeypatch.setattr("camou_vnc_gateway.proxy.websockets.connect", fake_connect)
+
+    settings = Settings(token_secret="secret", runner_http_base="http://runner", runner_ws_base="ws://runner")
+    proxy = RunnerProxy(settings)
+
+    websocket = StubClientWebSocket()
+
+    await proxy.forward_websocket(session_id="oops", websocket=websocket)
+
+    assert websocket.close_code == status.WS_1011_INTERNAL_ERROR
+
+
+def test_forward_websocket_happy_path(monkeypatch) -> None:
+    """Proxy relays traffic in both directions and negotiates subprotocols."""
+
+    asyncio.run(_run_forward_websocket_happy_path(monkeypatch))
+
+
+def test_forward_websocket_invalid_port_closes_with_policy_violation(monkeypatch) -> None:
+    """Invalid target_port results in a 1008 policy violation close code."""
+
+    asyncio.run(_run_forward_websocket_invalid_port(monkeypatch))
+
+
+def test_forward_websocket_network_error_closes_with_internal_error(monkeypatch) -> None:
+    """Connection failures are surfaced to the client with close code 1011."""
+
+    asyncio.run(_run_forward_websocket_network_error(monkeypatch))


### PR DESCRIPTION
## Summary
- add explicit timeout and backpressure handling to the RunnerProxy websocket relay while preserving header and target_port filtering
- introduce stub-based unit tests that exercise the happy path plus invalid port (1008) and network failure (1011) closures
- document the new websocket timeout strategy in the service AGENT_NOTES

## Testing
- poetry run pytest -q

## Security
- No security changes

------
https://chatgpt.com/codex/tasks/task_e_68dda211ef88832a866eeac8d029a837