### PR TITLE
feat(runner): add process-backed noVNC support

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -30,7 +30,7 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
 - **In-memory publisher**: Стандартный транспорт построен на `InMemorySessionEventPublisher` и считается продукционным решением; при необходимости можно оборачивать его через `CallbackSessionEventPublisher` для сторонних интеграций без отказа от in-memory ядра.
 - **HTTP publisher toggle**: `get_event_publisher` читает `RunnerSettings.event_endpoint` и, если URL задан, использует `HttpSessionEventPublisher`, публикующий события в Gateway через `POST /events`.
 - **Camoufox stub dependency**: Для unit-тестов в CI runner использует локальный путь-зависимость `packages/camoufox`, реализующую CLI/API-совместимый stub. Это позволяет выполнять `poetry install` без доступа к проприетарному пакету.
-- **Automatic VNC stubs**: When sessions are non-headless and no explicit VNC payload is provided, the manager synthesises `SessionVncDetails` using configurable base URLs and bounded TTL (<=300s) to respect `SessionVncDetails` invariants. Глобальный флаг `RunnerSettings.vnc_enabled` отключает генерацию stub-значений.
+- **Process-backed VNC controller**: Non-headless sessions allocate Xvfb/x11vnc/websockify helpers via `ProcessVncController`. The controller maintains a bounded pool of displays and ports, composes public HTTP/WS URLs from `RunnerSettings`, and tears down helpers whenever sessions terminate or switch to headless mode.
 - **Gateway-signed VNC tokens**: Runner never persists VNC `token` or `token_ttl_seconds`; any user-supplied values are stripped and synthetic descriptors leave them `None` so that the gateway can issue signed credentials.
 - **Environment-driven settings**: `RunnerSettings.from_env` centralises configuration parsing without extra dependencies, easing future extension. Дополнительные параметры: `slot_limit`, базовые VNC URL, глобальный флаг прокси и ёмкость истории ошибок прогрева.
 - **Bounded prewarm history**: менеджер хранит ошибки прогрева в `deque` с ограничением размера, что позволяет health-эндпоинту
@@ -54,13 +54,14 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
   апдейтов/завершений, чтобы метрики `next_expiry_at`/`reaper` оставались консистентными.
 - Взаимодействие с Gateway/SSE происходит только внутри доверенной сети кластера; авторизация на уровне HTTP не ожидается,
   вместо этого требуется сетевое разделение и настройка доверенных CIDR на стороне Gateway.
+- Доступность VNC зависит от бинарей `Xvfb`, `x11vnc` и `websockify`; при их отсутствии `ProcessVncController` отключается и сессии остаются без VNC-URL.
 
 ## Known Gaps / TODO
 - [ ] Зафиксировать профиль нагрузки для in-memory издателя после появления боевых метрик, чтобы подтвердить соответствие latency требованиям.
 
 ## How to Test
 - `poetry install --no-root`
-- `poetry run pytest -q` (anyio-powered unit tests)
+- `PYTHONPATH=. poetry run pytest -q` (anyio-powered unit tests)
 - `poetry run ruff check .`
 
 ## Changelog (for agents)
@@ -72,3 +73,4 @@ FastAPI-based service that manages browser sessions for Ghost Browsers. Provides
   чтобы `poetry install` и unit-тесты проходили в офлайн-окружении без лишних слешей.
 - 2025-10-10 · gpt-5-codex · Добавлен модуль `app.browser` с управлением процессом Playwright/Camoufox и интеграционными тестами на создание/завершение сессий.
 - 2025-10-11 · gpt-5-codex · Добавлены фоновые reaper-задачи, TTL-метрики в `/health`, эндпоинт `POST /sessions/{id}/touch` и покрытие тестами.
+- 2025-10-12 · gpt-5-codex · Интегрирован процессный noVNC-контроллер, расширены настройки VNC и обновлены unit-тесты с заглушками.

--- a/services/runner/app/config/settings.py
+++ b/services/runner/app/config/settings.py
@@ -6,7 +6,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PositiveInt
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PositiveInt, model_validator
 
 
 class RunnerSettings(BaseModel):
@@ -54,12 +54,38 @@ class RunnerSettings(BaseModel):
     vnc_enabled: bool = Field(default=True)
     vnc_http_base_url: AnyUrl = Field(default="http://127.0.0.1:8060/vnc")
     vnc_ws_base_url: AnyUrl = Field(default="ws://127.0.0.1:8060/vnc")
+    vnc_display_min: PositiveInt = Field(default=100, ge=1, le=1024)
+    vnc_display_max: PositiveInt = Field(default=199, ge=1, le=1024)
+    vnc_port_min: PositiveInt = Field(default=5900, ge=1024, le=65535)
+    vnc_port_max: PositiveInt = Field(default=5999, ge=1024, le=65535)
+    vnc_ws_port_min: PositiveInt = Field(default=6900, ge=1024, le=65535)
+    vnc_ws_port_max: PositiveInt = Field(default=6999, ge=1024, le=65535)
+    vnc_resolution: str = Field(default="1920x1080x24")
+    vnc_web_assets_path: Path | None = Field(default=Path("/usr/share/novnc"))
+    vnc_startup_timeout_seconds: float = Field(default=5.0, gt=0.0, le=30.0)
     vnc_token_ttl_seconds: PositiveInt = Field(default=120, le=300)
     proxy_enabled: bool = Field(default=False)
     proxy_http_base_url: AnyUrl | None = Field(default=None)
     proxy_https_base_url: AnyUrl | None = Field(default=None)
     proxy_socks_base_url: AnyUrl | None = Field(default=None)
     prewarm_failure_history_size: PositiveInt = Field(default=5, ge=1, le=50)
+
+    @model_validator(mode="after")
+    def _validate_vnc_ranges(self) -> "RunnerSettings":
+        """Ensure VNC port and display ranges are coherent."""
+
+        if self.vnc_display_min > self.vnc_display_max:
+            raise ValueError("vnc_display_min must be <= vnc_display_max")
+        if self.vnc_port_min > self.vnc_port_max:
+            raise ValueError("vnc_port_min must be <= vnc_port_max")
+        if self.vnc_ws_port_min > self.vnc_ws_port_max:
+            raise ValueError("vnc_ws_port_min must be <= vnc_ws_port_max")
+        display_span = self.vnc_display_max - self.vnc_display_min + 1
+        vnc_span = self.vnc_port_max - self.vnc_port_min + 1
+        ws_span = self.vnc_ws_port_max - self.vnc_ws_port_min + 1
+        if min(display_span, vnc_span, ws_span) <= 0:
+            raise ValueError("VNC resource ranges must include at least one value")
+        return self
 
     @classmethod
     def from_env(cls, environ: dict[str, str] | None = None) -> "RunnerSettings":
@@ -91,6 +117,26 @@ class RunnerSettings(BaseModel):
             source["vnc_ws_base_url"] = env["VNC_WS_BASE_URL"]
         if "VNC_TOKEN_TTL_SECONDS" in env:
             source["vnc_token_ttl_seconds"] = int(env["VNC_TOKEN_TTL_SECONDS"])
+        if "VNC_DISPLAY_MIN" in env:
+            source["vnc_display_min"] = int(env["VNC_DISPLAY_MIN"])
+        if "VNC_DISPLAY_MAX" in env:
+            source["vnc_display_max"] = int(env["VNC_DISPLAY_MAX"])
+        if "VNC_PORT_MIN" in env:
+            source["vnc_port_min"] = int(env["VNC_PORT_MIN"])
+        if "VNC_PORT_MAX" in env:
+            source["vnc_port_max"] = int(env["VNC_PORT_MAX"])
+        if "VNC_WS_PORT_MIN" in env:
+            source["vnc_ws_port_min"] = int(env["VNC_WS_PORT_MIN"])
+        if "VNC_WS_PORT_MAX" in env:
+            source["vnc_ws_port_max"] = int(env["VNC_WS_PORT_MAX"])
+        if "VNC_RESOLUTION" in env:
+            source["vnc_resolution"] = env["VNC_RESOLUTION"]
+        if "VNC_WEB_ASSETS_PATH" in env:
+            source["vnc_web_assets_path"] = Path(env["VNC_WEB_ASSETS_PATH"])
+        if "VNC_STARTUP_TIMEOUT_SECONDS" in env:
+            source["vnc_startup_timeout_seconds"] = float(
+                env["VNC_STARTUP_TIMEOUT_SECONDS"]
+            )
         if "PROXY_ENABLED" in env:
             source["proxy_enabled"] = env["PROXY_ENABLED"].lower() in {"1", "true", "yes"}
         if "PROXY_HTTP_BASE_URL" in env:

--- a/services/runner/app/dependencies/__init__.py
+++ b/services/runner/app/dependencies/__init__.py
@@ -4,10 +4,12 @@ from .session_manager import (
     get_event_publisher,
     get_runner_settings,
     get_session_manager,
+    get_vnc_controller,
 )
 
 __all__ = [
     "get_event_publisher",
     "get_runner_settings",
     "get_session_manager",
+    "get_vnc_controller",
 ]

--- a/services/runner/app/dependencies/session_manager.py
+++ b/services/runner/app/dependencies/session_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from functools import lru_cache
 
 from ..config import RunnerSettings
@@ -11,6 +12,9 @@ from ..events import (
     SessionEventPublisher,
 )
 from ..session_manager import SessionManager
+from ..vnc import ProcessVncController, VncController, VncUnavailableError
+
+LOGGER = logging.getLogger(__name__)
 
 
 @lru_cache
@@ -31,14 +35,33 @@ def get_event_publisher() -> SessionEventPublisher:
 
 
 @lru_cache
+def get_vnc_controller() -> VncController | None:
+    """Instantiate the process-based VNC controller when tooling is available."""
+
+    settings = get_runner_settings()
+    if not settings.vnc_enabled:
+        return None
+    try:
+        return ProcessVncController(settings)
+    except VncUnavailableError as exc:
+        LOGGER.warning("VNC disabled: %s", exc)
+        return None
+
+
+@lru_cache
 def get_session_manager() -> SessionManager:
     """Return a singleton :class:`SessionManager` wired with default dependencies."""
 
-    return SessionManager(get_runner_settings(), get_event_publisher())
+    return SessionManager(
+        get_runner_settings(),
+        get_event_publisher(),
+        vnc_controller=get_vnc_controller(),
+    )
 
 
 __all__ = [
     "get_event_publisher",
     "get_runner_settings",
     "get_session_manager",
+    "get_vnc_controller",
 ]

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+import contextlib
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -24,6 +25,7 @@ from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PositiveInt
 from .browser import BrowserSessionHandle, launch_browser
 from .config import RunnerSettings
 from .events import SessionEventPublisher
+from .vnc import VncController, VncSessionHandle
 
 
 class SessionCreatePayload(BaseModel):
@@ -31,8 +33,8 @@ class SessionCreatePayload(BaseModel):
 
     Attributes mirror :class:`core.models.Session` fields except for ``id`` and
     ``runner_id`` which are derived by the manager. Providing a ``vnc`` payload
-    is optional; when omitted the manager constructs a stub value based on
-    :class:`RunnerSettings`.
+    is optional; when omitted the manager provisions a local noVNC pipeline
+    using :class:`RunnerSettings` and advertises the generated connection data.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -134,6 +136,7 @@ class SessionManager:
         clock: Callable[[], datetime] | None = None,
         *,
         reaper_interval_seconds: float = 1.0,
+        vnc_controller: VncController | None = None,
     ) -> None:
         self._settings = settings
         self._publisher = event_publisher
@@ -146,6 +149,8 @@ class SessionManager:
         )
         self._last_prewarm_error: str | None = None
         self._browser_handles: dict[UUID, BrowserSessionHandle] = {}
+        self._vnc_controller = vnc_controller
+        self._vnc_handles: dict[UUID, VncSessionHandle] = {}
         self._next_idle_expiry_at: datetime | None = None
         self._reaper_total_runs = 0
         self._reaper_expired_sessions = 0
@@ -160,8 +165,10 @@ class SessionManager:
             session_id = uuid4()
             now = self._clock()
             sanitized_vnc = self._sanitize_vnc_payload(payload.vnc)
-            vnc_details = self._resolve_vnc(
-                payload, session_id, sanitized_vnc=sanitized_vnc
+            vnc_details, vnc_handle = await self._resolve_vnc(
+                payload,
+                session_id,
+                sanitized_vnc=sanitized_vnc,
             )
             browser_handle: BrowserSessionHandle | None = None
             metadata = dict(payload.metadata)
@@ -170,10 +177,16 @@ class SessionManager:
                     self._settings,
                     browser=payload.browser,
                     headless=payload.headless,
+                    env=(
+                        vnc_handle.browser_environment()
+                        if vnc_handle is not None
+                        else None
+                    ),
                 )
             except Exception:
                 if browser_handle is not None:
                     await browser_handle.shutdown(force=True)
+                await self._discard_vnc_handle(session_id, vnc_handle)
                 raise
             if browser_handle.pid is not None:
                 metadata.setdefault("runner_browser_pid", browser_handle.pid)
@@ -203,9 +216,12 @@ class SessionManager:
                 )
             except Exception:
                 await browser_handle.shutdown(force=True)
+                await self._discard_vnc_handle(session_id, vnc_handle)
                 raise
             self._sessions[session_id] = session
             self._browser_handles[session_id] = browser_handle
+            if vnc_handle is not None:
+                self._vnc_handles[session_id] = vnc_handle
             self._recalculate_next_idle_expiry_locked()
             if session.status is not SessionStatus.DEAD:
                 self._active_sessions += 1
@@ -249,6 +265,8 @@ class SessionManager:
                 await self._shutdown_browser(
                     session_id, force=session.status is SessionStatus.DEAD
                 )
+            if self._should_cleanup_vnc(existing, session):
+                await self._release_vnc_handle(session_id)
             event_type = (
                 SessionEventType.ENDED
                 if session.status is SessionStatus.DEAD
@@ -413,26 +431,25 @@ class SessionManager:
             self._reaper_task_group = None
         if task_group is not None:
             await task_group.__aexit__(None, None, None)
+        await self._shutdown_all_vnc()
 
-    def _resolve_vnc(
+    async def _resolve_vnc(
         self,
         payload: SessionCreatePayload,
         session_id: UUID,
         *,
         sanitized_vnc: SessionVncDetails | None,
-    ) -> SessionVncDetails | None:
-        """Return VNC details honouring payload overrides and settings defaults."""
+    ) -> tuple[SessionVncDetails | None, VncSessionHandle | None]:
+        """Resolve VNC details and, if necessary, provision helper processes."""
 
         if payload.headless or not self._settings.vnc_enabled:
-            return None
+            return None, None
         if sanitized_vnc is not None:
-            return sanitized_vnc
-        return SessionVncDetails(
-            http_url=f"{self._settings.vnc_http_base_url}/{session_id}",
-            websocket_url=f"{self._settings.vnc_ws_base_url}/{session_id}",
-            token=None,
-            token_ttl_seconds=None,
-        )
+            return sanitized_vnc, None
+        if self._vnc_controller is None:
+            return None, None
+        handle = await self._vnc_controller.allocate(str(session_id))
+        return handle.details, handle
 
     def _sanitize_vnc_payload(
         self, details: SessionVncDetails | None
@@ -552,6 +569,54 @@ class SessionManager:
         if handle is None:
             return
         await handle.shutdown(force=force)
+
+    async def _release_vnc_handle(self, session_id: UUID) -> None:
+        """Stop helper processes backing the VNC session for ``session_id``."""
+
+        handle = self._vnc_handles.pop(session_id, None)
+        if handle is None or self._vnc_controller is None:
+            return
+        await self._vnc_controller.release(handle)
+
+    async def _discard_vnc_handle(
+        self, session_id: UUID, handle: VncSessionHandle | None
+    ) -> None:
+        """Release ``handle`` regardless of whether it was persisted."""
+
+        if handle is None:
+            return
+        if session_id in self._vnc_handles:
+            await self._release_vnc_handle(session_id)
+            return
+        if self._vnc_controller is not None:
+            await self._vnc_controller.release(handle)
+
+    async def _shutdown_all_vnc(self) -> None:
+        """Terminate every tracked VNC handle during service shutdown."""
+
+        if self._vnc_controller is None:
+            self._vnc_handles.clear()
+            return
+        handles = list(self._vnc_handles.items())
+        self._vnc_handles.clear()
+        for _session_id, handle in handles:
+            with contextlib.suppress(Exception):
+                await self._vnc_controller.release(handle)
+
+    def _should_cleanup_vnc(self, previous: Session, current: Session) -> bool:
+        """Determine whether the stored VNC handle should be released."""
+
+        if previous.id != current.id:
+            return False
+        if previous.id not in self._vnc_handles:
+            return False
+        if current.status is SessionStatus.DEAD:
+            return True
+        if current.headless:
+            return True
+        if current.vnc is None or not current.vnc_enabled:
+            return True
+        return False
 
 
     async def _reaper_loop(self) -> None:

--- a/services/runner/app/vnc.py
+++ b/services/runner/app/vnc.py
@@ -1,0 +1,419 @@
+"""Utilities for managing noVNC helper processes used by the runner."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+from asyncio import streams, subprocess
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping, Protocol
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+from core.models import SessionVncDetails
+
+from .config import RunnerSettings
+
+LOGGER = logging.getLogger(__name__)
+
+
+class VncError(RuntimeError):
+    """Base exception raised for VNC orchestration failures."""
+
+
+class VncUnavailableError(VncError):
+    """Raised when the environment lacks required noVNC tooling."""
+
+
+class VncSessionHandle(Protocol):
+    """Protocol describing VNC session handles stored by the manager."""
+
+    details: SessionVncDetails
+
+    def browser_environment(self) -> Mapping[str, str]:
+        """Return environment variables required for the associated browser."""
+
+
+class VncController(Protocol):
+    """Protocol describing VNC lifecycle controllers."""
+
+    async def allocate(self, session_id: str) -> VncSessionHandle:
+        """Provision helper processes and return a handle for ``session_id``."""
+
+    async def release(self, handle: VncSessionHandle | None) -> None:
+        """Terminate helper processes associated with ``handle`` if present."""
+
+
+@dataclass(slots=True, frozen=True)
+class _VncSlot:
+    """Represents a reserved combination of display and TCP ports."""
+
+    display: int
+    vnc_port: int
+    ws_port: int
+
+
+class _VncResourcePool:
+    """Maintain a pool of VNC resources safe for concurrent use."""
+
+    def __init__(
+        self,
+        *,
+        displays: Iterable[int],
+        vnc_ports: Iterable[int],
+        ws_ports: Iterable[int],
+    ) -> None:
+        self._display_pool = deque(displays)
+        self._vnc_ports = deque(vnc_ports)
+        self._ws_ports = deque(ws_ports)
+        self._active: set[_VncSlot] = set()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self) -> _VncSlot:
+        """Reserve the next available slot, raising when exhausted."""
+
+        async with self._lock:
+            if not self._display_pool or not self._vnc_ports or not self._ws_ports:
+                raise VncError("no VNC resources available")
+            slot = _VncSlot(
+                display=self._display_pool.popleft(),
+                vnc_port=self._vnc_ports.popleft(),
+                ws_port=self._ws_ports.popleft(),
+            )
+            self._active.add(slot)
+            return slot
+
+    async def release(self, slot: _VncSlot | None) -> None:
+        """Return ``slot`` back to the pool if it is currently reserved."""
+
+        if slot is None:
+            return
+        async with self._lock:
+            if slot not in self._active:
+                return
+            self._active.remove(slot)
+            self._display_pool.append(slot.display)
+            self._vnc_ports.append(slot.vnc_port)
+            self._ws_ports.append(slot.ws_port)
+
+
+@dataclass(slots=True)
+class _ProcessVncSession:
+    """Concrete :class:`VncSessionHandle` implementation for subprocesses."""
+
+    slot: _VncSlot
+    display: str
+    details: SessionVncDetails
+    processes: list[subprocess.Process]
+    drain_tasks: list[asyncio.Task[None]]
+    pool: _VncResourcePool
+
+    def browser_environment(self) -> Mapping[str, str]:
+        """Expose environment variables consumed by :mod:`app.browser`."""
+
+        return {"DISPLAY": self.display}
+
+    async def close(self) -> None:
+        """Terminate helper processes and return the slot to the pool."""
+
+        try:
+            await _terminate_processes(self.processes, self.drain_tasks)
+        finally:
+            await self.pool.release(self.slot)
+
+
+class ProcessVncController:
+    """Spawn Xvfb/x11vnc/websockify pipelines to back visual sessions."""
+
+    def __init__(self, settings: RunnerSettings) -> None:
+        self._settings = settings
+        self._pool = _VncResourcePool(
+            displays=range(settings.vnc_display_min, settings.vnc_display_max + 1),
+            vnc_ports=range(settings.vnc_port_min, settings.vnc_port_max + 1),
+            ws_ports=range(settings.vnc_ws_port_min, settings.vnc_ws_port_max + 1),
+        )
+        self._assets_path = settings.vnc_web_assets_path
+        self._check_binaries()
+
+    async def allocate(self, session_id: str) -> _ProcessVncSession:
+        """Start helper processes and return a handle for ``session_id``."""
+
+        slot = await self._pool.acquire()
+        display = f":{slot.display}"
+        processes: list[subprocess.Process] = []
+        drain_tasks: list[asyncio.Task[None]] = []
+        try:
+            xvfb = await self._spawn_process(
+                [
+                    "Xvfb",
+                    display,
+                    "-screen",
+                    "0",
+                    self._settings.vnc_resolution,
+                    "+extension",
+                    "RANDR",
+                    "-nolisten",
+                    "tcp",
+                ],
+                name=f"vnc-xvfb:{slot.display}",
+            )
+            processes.append(xvfb.process)
+            drain_tasks.extend(xvfb.tasks)
+            await self._wait_for_display_socket(slot, xvfb.process)
+
+            x11vnc = await self._spawn_process(
+                [
+                    "x11vnc",
+                    "-display",
+                    display,
+                    "-shared",
+                    "-forever",
+                    "-rfbport",
+                    str(slot.vnc_port),
+                    "-localhost",
+                    "-nopw",
+                    "-quiet",
+                ],
+                name=f"vnc-x11vnc:{slot.display}",
+            )
+            processes.append(x11vnc.process)
+            drain_tasks.extend(x11vnc.tasks)
+
+            websockify_cmd = ["websockify"]
+            assets = self._assets_path
+            if assets and assets.is_dir():
+                websockify_cmd.append(f"--web={assets}")
+            websockify_cmd.extend([
+                str(slot.ws_port),
+                f"127.0.0.1:{slot.vnc_port}",
+            ])
+            websockify = await self._spawn_process(
+                websockify_cmd,
+                name=f"vnc-websockify:{slot.ws_port}",
+            )
+            processes.append(websockify.process)
+            drain_tasks.extend(websockify.tasks)
+            await self._wait_for_port("127.0.0.1", slot.ws_port, websockify.process)
+
+            http_url = self._compose_url(
+                str(self._settings.vnc_http_base_url),
+                slot.ws_port,
+                "/vnc.html",
+                query_params={"path": "websockify"},
+            )
+            websocket_url = self._compose_url(
+                str(self._settings.vnc_ws_base_url),
+                slot.ws_port,
+                "/websockify",
+            )
+            details = SessionVncDetails(
+                http_url=http_url,
+                websocket_url=websocket_url,
+                token=None,
+                token_ttl_seconds=None,
+            )
+            return _ProcessVncSession(
+                slot=slot,
+                display=display,
+                details=details,
+                processes=processes,
+                drain_tasks=drain_tasks,
+                pool=self._pool,
+            )
+        except Exception:
+            await _terminate_processes(processes, drain_tasks)
+            await self._pool.release(slot)
+            raise
+
+    async def release(self, handle: VncSessionHandle | None) -> None:
+        """Best-effort cleanup for a previously allocated session."""
+
+        if handle is None:
+            return
+        if isinstance(handle, _ProcessVncSession):
+            await handle.close()
+        else:  # pragma: no cover - defensive branch
+            raise TypeError("unsupported VNC handle implementation")
+
+    def _check_binaries(self) -> None:
+        """Ensure ``Xvfb``, ``x11vnc`` and ``websockify`` are available."""
+
+        missing = [
+            binary
+            for binary in ("Xvfb", "x11vnc", "websockify")
+            if shutil.which(binary) is None
+        ]
+        if missing:
+            raise VncUnavailableError(
+                f"missing required VNC binaries: {', '.join(sorted(missing))}"
+            )
+
+    async def _wait_for_display_socket(
+        self, slot: _VncSlot, process: subprocess.Process
+    ) -> None:
+        """Wait until Xvfb exposes its UNIX socket for ``slot``."""
+
+        socket_path = Path("/tmp/.X11-unix") / f"X{slot.display}"
+        deadline = asyncio.get_running_loop().time() + self._settings.vnc_startup_timeout_seconds
+        while True:
+            if socket_path.exists():
+                return
+            if process.returncode is not None:
+                raise VncError(
+                    f"Xvfb exited with code {process.returncode} before socket initialisation"
+                )
+            if asyncio.get_running_loop().time() >= deadline:
+                raise VncError(
+                    f"timed out waiting for Xvfb display :{slot.display}"
+                )
+            await asyncio.sleep(0.05)
+
+    async def _wait_for_port(
+        self, host: str, port: int, process: subprocess.Process
+    ) -> None:
+        """Poll ``host:port`` until ``websockify`` starts accepting connections."""
+
+        deadline = asyncio.get_running_loop().time() + self._settings.vnc_startup_timeout_seconds
+        while True:
+            try:
+                reader, writer = await asyncio.open_connection(host, port)
+            except OSError:
+                if process.returncode is not None:
+                    raise VncError(
+                        f"websockify exited with code {process.returncode}"
+                    )
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise VncError(
+                        f"timed out waiting for websockify on {host}:{port}"
+                    )
+                await asyncio.sleep(0.1)
+            else:
+                writer.close()
+                with contextlib.suppress(Exception):
+                    await writer.wait_closed()
+                if reader.at_eof():
+                    return
+                return
+
+    async def _spawn_process(
+        self, args: list[str], *, name: str
+    ) -> "_SpawnedProcess":
+        """Create a subprocess and drain its standard streams."""
+
+        LOGGER.debug("starting %s with args: %s", name, args)
+        process = await subprocess.create_subprocess_exec(
+            *args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        tasks: list[asyncio.Task[None]] = []
+        if process.stdout is not None:
+            tasks.append(
+                asyncio.create_task(
+                    _drain_stream(process.stdout, f"{name}-stdout"),
+                    name=f"{name}-stdout",
+                )
+            )
+        if process.stderr is not None:
+            tasks.append(
+                asyncio.create_task(
+                    _drain_stream(process.stderr, f"{name}-stderr"),
+                    name=f"{name}-stderr",
+                )
+            )
+        return _SpawnedProcess(process=process, tasks=tasks)
+
+    def _compose_url(
+        self,
+        base: str,
+        port: int,
+        path_suffix: str,
+        *,
+        query_params: dict[str, str] | None = None,
+    ) -> str | None:
+        """Return a user-facing URL constructed from ``base`` and ``port``."""
+
+        if not base:
+            return None
+        try:
+            parsed = urlparse(base)
+        except ValueError:
+            LOGGER.warning("invalid VNC base URL: %s", base)
+            return None
+        hostname = parsed.hostname or parsed.netloc
+        if not hostname:
+            LOGGER.warning("missing hostname in VNC base URL: %s", base)
+            return None
+        scheme = parsed.scheme or ("https" if path_suffix.endswith(".html") else "ws")
+        if ":" in hostname and not hostname.startswith("["):
+            host_part = f"[{hostname}]"
+        else:
+            host_part = hostname
+        port_value = parsed.port if parsed.port is not None else port
+        userinfo = ""
+        if parsed.username:
+            userinfo = parsed.username
+            if parsed.password:
+                userinfo += f":{parsed.password}"
+            userinfo += "@"
+        netloc = f"{userinfo}{host_part}:{port_value}"
+        base_path = parsed.path.rstrip("/")
+        combined_path = f"{base_path}{path_suffix}" if path_suffix else base_path or "/"
+        if not combined_path.startswith("/"):
+            combined_path = f"/{combined_path}"
+        query_items = parse_qsl(parsed.query, keep_blank_values=True)
+        if query_params:
+            query_items.extend(query_params.items())
+        query = urlencode(query_items)
+        return urlunparse((scheme, netloc, combined_path, "", query, ""))
+
+
+@dataclass(slots=True)
+class _SpawnedProcess:
+    """Represents a subprocess with tasks draining its IO streams."""
+
+    process: subprocess.Process
+    tasks: list[asyncio.Task[None]]
+
+
+async def _drain_stream(stream: streams.StreamReader, name: str) -> None:
+    """Consume a subprocess pipe and emit its output to the logger."""
+
+    while True:
+        chunk = await stream.readline()
+        if not chunk:
+            return
+        LOGGER.debug("%s: %s", name, chunk.decode(errors="ignore").rstrip())
+
+
+async def _terminate_processes(
+    processes: list[subprocess.Process], tasks: list[asyncio.Task[None]]
+) -> None:
+    """Terminate helper processes and cancel drain tasks."""
+
+    for process in reversed(processes):
+        with contextlib.suppress(Exception):
+            if process.returncode is None:
+                process.kill()
+            await process.wait()
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+    processes.clear()
+    tasks.clear()
+
+
+__all__ = [
+    "ProcessVncController",
+    "VncController",
+    "VncError",
+    "VncSessionHandle",
+    "VncUnavailableError",
+]
+

--- a/services/runner/tests/test_main.py
+++ b/services/runner/tests/test_main.py
@@ -16,6 +16,7 @@ from app.dependencies.session_manager import (
 from app.events import InMemorySessionEventPublisher
 from app.main import app
 from app.session_manager import SessionCreatePayload, SessionManager
+from core.models import SessionVncDetails
 
 
 @pytest.fixture
@@ -34,6 +35,37 @@ class _MainStubHandle:
 
     async def shutdown(self, *, force: bool, timeout: float = 5.0) -> None:
         """Pretend to terminate the Playwright subprocess."""
+
+        return None
+
+
+class _MainStubVncHandle:
+    """Lightweight VNC handle used by API-level tests."""
+
+    def __init__(self, session_id: str) -> None:
+        self.details = SessionVncDetails(
+            http_url=f"http://stub-vnc/{session_id}",
+            websocket_url=f"ws://stub-vnc/{session_id}",
+            token=None,
+            token_ttl_seconds=None,
+        )
+
+    def browser_environment(self) -> dict[str, str]:
+        """Expose a fake ``DISPLAY`` environment for browsers."""
+
+        return {"DISPLAY": ":stub"}
+
+
+class _MainStubVncController:
+    """Test double replacing the process-based VNC controller."""
+
+    async def allocate(self, session_id: str) -> _MainStubVncHandle:
+        """Return a deterministic handle for ``session_id``."""
+
+        return _MainStubVncHandle(session_id)
+
+    async def release(self, handle: _MainStubVncHandle | None) -> None:
+        """No-op release hook for compatibility with the real controller."""
 
         return None
 
@@ -61,7 +93,13 @@ def stub_launch_browser(monkeypatch: pytest.MonkeyPatch) -> None:
 
     counter = 0
 
-    async def _fake_launch(settings: RunnerSettings, *, browser: str, headless: bool):
+    async def _fake_launch(
+        settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        env: dict[str, str] | None = None,
+    ) -> _MainStubHandle:
         nonlocal counter
         counter += 1
         return _MainStubHandle(f"ws://health/{counter}", pid=4500 + counter)
@@ -93,10 +131,11 @@ async def test_health_endpoint_reports_extended_metrics(
         publisher,
         clock=clock,
         reaper_interval_seconds=5.0,
+        vnc_controller=_MainStubVncController(),
     )
 
-    await manager.create_session(SessionCreatePayload())
-    await manager.create_session(SessionCreatePayload())
+    await manager.create_session(SessionCreatePayload(headless=False))
+    await manager.create_session(SessionCreatePayload(headless=False))
     await manager.record_prewarm_failure("prewarm timeout")
     await manager.record_prewarm_failure("prewarm retry failed")
 
@@ -159,9 +198,10 @@ async def test_touch_endpoint_extends_idle_deadline(
         publisher,
         clock=clock,
         reaper_interval_seconds=5.0,
+        vnc_controller=_MainStubVncController(),
     )
     session = await manager.create_session(
-        SessionCreatePayload(idle_ttl_seconds=45)
+        SessionCreatePayload(idle_ttl_seconds=45, headless=False)
     )
 
     app.dependency_overrides[get_runner_settings] = lambda: settings

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -28,28 +28,43 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture
-def stub_launch_browser(monkeypatch: pytest.MonkeyPatch) -> list["_StubBrowserHandle"]:
+def stub_launch_browser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list["_StubBrowserHandle"]:
     """Patch ``launch_browser`` to return deterministic stub handles."""
 
     handles: list[_StubBrowserHandle] = []
 
     async def _fake_launch(
-        settings: RunnerSettings, *, browser: str, headless: bool
+        settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        env: dict[str, str] | None = None,
     ) -> "_StubBrowserHandle":
         handle = _StubBrowserHandle(
             ws_endpoint=f"ws://stub/{browser}/{len(handles)}",
             pid=4300 + len(handles),
         )
         handles.append(handle)
+        handle.launch_env = env or {}
         return handle
 
     monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
     return handles
 
 
+@pytest.fixture
+def stub_vnc_controller() -> _StubVncController:
+    """Provide a fake VNC controller for tests that expect noVNC support."""
+
+    return _StubVncController()
+
+
 @pytest.mark.anyio("asyncio")
 async def test_create_session_emits_event_and_vnc_stub(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """``create_session`` should store the session and publish a CREATED event."""
 
@@ -62,7 +77,12 @@ async def test_create_session_emits_event_and_vnc_stub(
         vnc_token_ttl_seconds=60,
     )
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(settings, publisher, clock=lambda: clock_now)
+    manager = SessionManager(
+        settings,
+        publisher,
+        clock=lambda: clock_now,
+        vnc_controller=stub_vnc_controller,
+    )
 
     payload = SessionCreatePayload(
         start_url="https://example.test",
@@ -78,7 +98,7 @@ async def test_create_session_emits_event_and_vnc_stub(
     assert session.vnc is not None
     assert session.vnc.token is None
     assert session.vnc.token_ttl_seconds is None
-    assert str(session.vnc.http_url).endswith(str(session.id))
+    assert str(session.vnc.http_url).startswith("http://stub-vnc/")
     events = await publisher.drain()
     assert len(events) == 1
     assert events[0].type is SessionEventType.CREATED
@@ -89,6 +109,7 @@ async def test_create_session_emits_event_and_vnc_stub(
 @pytest.mark.anyio("asyncio")
 async def test_update_session_merges_labels_and_publishes_update(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """Updates should merge labels and emit ``session.updated`` events."""
 
@@ -98,6 +119,7 @@ async def test_update_session_merges_labels_and_publishes_update(
         RunnerSettings(runner_id="runner-test", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=lambda: clock_now,
+        vnc_controller=stub_vnc_controller,
     )
     session = await manager.create_session(SessionCreatePayload(headless=True))
 
@@ -121,6 +143,7 @@ async def test_update_session_merges_labels_and_publishes_update(
 @pytest.mark.anyio("asyncio")
 async def test_create_session_strips_user_vnc_token(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """User-supplied VNC tokens must be removed before persisting sessions."""
 
@@ -132,6 +155,7 @@ async def test_create_session_strips_user_vnc_token(
         ),
         publisher,
         clock=lambda: clock_now,
+        vnc_controller=stub_vnc_controller,
     )
     payload = SessionCreatePayload(
         headless=False,
@@ -152,6 +176,7 @@ async def test_create_session_strips_user_vnc_token(
 @pytest.mark.anyio("asyncio")
 async def test_update_session_strips_user_vnc_token(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """Updates attempting to inject VNC tokens are sanitised."""
 
@@ -163,6 +188,7 @@ async def test_update_session_strips_user_vnc_token(
         ),
         publisher,
         clock=lambda: clock_now,
+        vnc_controller=stub_vnc_controller,
     )
     session = await manager.create_session(
         SessionCreatePayload(headless=False)
@@ -187,6 +213,7 @@ async def test_update_session_strips_user_vnc_token(
 @pytest.mark.anyio("asyncio")
 async def test_end_session_sets_terminal_state_and_event(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """``end_session`` should mark the session as DEAD and send ENDED event."""
 
@@ -196,6 +223,7 @@ async def test_end_session_sets_terminal_state_and_event(
         RunnerSettings(runner_id="runner-test", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=lambda: clock_now,
+        vnc_controller=stub_vnc_controller,
     )
     session = await manager.create_session(SessionCreatePayload())
 
@@ -211,6 +239,7 @@ async def test_end_session_sets_terminal_state_and_event(
 @pytest.mark.anyio("asyncio")
 async def test_metrics_track_active_sessions_and_prewarm_failures(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """Metrics should reflect active sessions and retain bounded prewarm errors."""
 
@@ -223,6 +252,7 @@ async def test_metrics_track_active_sessions_and_prewarm_failures(
             prewarm_failure_history_size=2,
         ),
         publisher,
+        vnc_controller=stub_vnc_controller,
     )
 
     first = await manager.create_session(SessionCreatePayload())
@@ -239,6 +269,7 @@ async def test_metrics_track_active_sessions_and_prewarm_failures(
 @pytest.mark.anyio("asyncio")
 async def test_touch_session_updates_last_seen_and_publishes_update(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """``touch_session`` should extend TTL and emit a heartbeat update."""
 
@@ -248,6 +279,7 @@ async def test_touch_session_updates_last_seen_and_publishes_update(
         RunnerSettings(runner_id="runner-touch", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=clock,
+        vnc_controller=stub_vnc_controller,
     )
     session = await manager.create_session(
         SessionCreatePayload(idle_ttl_seconds=60)
@@ -268,6 +300,7 @@ async def test_touch_session_updates_last_seen_and_publishes_update(
 @pytest.mark.anyio("asyncio")
 async def test_reap_expired_sessions_marks_session_dead_and_records_metrics(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """Idle sessions should transition to DEAD with an ``idle-timeout`` reason."""
 
@@ -277,6 +310,7 @@ async def test_reap_expired_sessions_marks_session_dead_and_records_metrics(
         RunnerSettings(runner_id="runner-reap", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=clock,
+        vnc_controller=stub_vnc_controller,
     )
     session = await manager.create_session(
         SessionCreatePayload(idle_ttl_seconds=30)
@@ -303,6 +337,7 @@ async def test_reap_expired_sessions_marks_session_dead_and_records_metrics(
 @pytest.mark.anyio("asyncio")
 async def test_reap_skips_recently_touched_session(
     stub_launch_browser: list["_StubBrowserHandle"],
+    stub_vnc_controller: _StubVncController,
 ) -> None:
     """Touching a session should postpone its idle deadline for reaper runs."""
 
@@ -312,6 +347,7 @@ async def test_reap_skips_recently_touched_session(
         RunnerSettings(runner_id="runner-skip", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=clock,
+        vnc_controller=stub_vnc_controller,
     )
     session = await manager.create_session(
         SessionCreatePayload(idle_ttl_seconds=40)
@@ -343,6 +379,7 @@ class _StubBrowserHandle:
         self.ws_endpoint = ws_endpoint
         self.pid = pid
         self.shutdown_calls: list[dict[str, object]] = []
+        self.launch_env: dict[str, str] = {}
 
     async def shutdown(self, *, force: bool, timeout: float = 5.0) -> None:
         """Record shutdown invocations for assertions."""
@@ -367,6 +404,47 @@ class _StubClock:
         return self._now
 
 
+class _StubVncHandle:
+    """Lightweight handle representing a fake VNC allocation."""
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        self.details = SessionVncDetails(
+            http_url=f"http://stub-vnc/{session_id}",
+            websocket_url=f"ws://stub-vnc/{session_id}",
+            token=None,
+            token_ttl_seconds=None,
+        )
+        self.browser_env = {"DISPLAY": ":stub"}
+        self.released = False
+
+    def browser_environment(self) -> dict[str, str]:
+        """Expose environment variables expected by the runner."""
+
+        return dict(self.browser_env)
+
+
+class _StubVncController:
+    """Test double implementing the VNC controller protocol."""
+
+    def __init__(self) -> None:
+        self.handles: dict[str, _StubVncHandle] = {}
+
+    async def allocate(self, session_id: str) -> _StubVncHandle:
+        """Return a predictable handle keyed by ``session_id``."""
+
+        handle = _StubVncHandle(session_id)
+        self.handles[session_id] = handle
+        return handle
+
+    async def release(self, handle: _StubVncHandle | None) -> None:
+        """Mark the handle as released to assert cleanup paths."""
+
+        if handle is None:
+            return
+        handle.released = True
+
+
 @pytest.mark.anyio("asyncio")
 async def test_create_session_launches_browser(monkeypatch: pytest.MonkeyPatch) -> None:
     """Browser launch helper should provide the ws endpoint and metadata."""
@@ -374,15 +452,24 @@ async def test_create_session_launches_browser(monkeypatch: pytest.MonkeyPatch) 
     stub_handle = _StubBrowserHandle(ws_endpoint="ws://playwright.test/session")
     launch_calls: list[tuple[str, bool]] = []
 
-    async def _fake_launch(settings: RunnerSettings, *, browser: str, headless: bool):
+    async def _fake_launch(
+        settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        env: dict[str, str] | None = None,
+    ):
         launch_calls.append((browser, headless))
+        stub_handle.launch_env = env or {}
         return stub_handle
 
     monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
     publisher = InMemorySessionEventPublisher()
+    stub_vnc = _StubVncController()
     manager = SessionManager(
         RunnerSettings(runner_id="runner-browser", camoufox_path="/usr/bin/camoufox"),
         publisher,
+        vnc_controller=stub_vnc,
     )
 
     session = await manager.create_session(
@@ -405,14 +492,23 @@ async def test_update_session_cleans_up_browser(monkeypatch: pytest.MonkeyPatch)
 
     stub_handle = _StubBrowserHandle(ws_endpoint="ws://playwright.test/cleanup")
 
-    async def _fake_launch(settings: RunnerSettings, *, browser: str, headless: bool):
+    async def _fake_launch(
+        settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        env: dict[str, str] | None = None,
+    ):
+        stub_handle.launch_env = env or {}
         return stub_handle
 
     monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
     publisher = InMemorySessionEventPublisher()
+    stub_vnc = _StubVncController()
     manager = SessionManager(
         RunnerSettings(runner_id="runner-cleanup", camoufox_path="/usr/bin/camoufox"),
         publisher,
+        vnc_controller=stub_vnc,
     )
     session = await manager.create_session(SessionCreatePayload())
 
@@ -439,14 +535,22 @@ async def test_create_session_rolls_back_on_launch_failure(
 ) -> None:
     """Session creation should not persist state when browser launch fails."""
 
-    async def _failing_launch(settings: RunnerSettings, *, browser: str, headless: bool):
+    async def _failing_launch(
+        settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        env: dict[str, str] | None = None,
+    ):
         raise RuntimeError("launch boom")
 
     monkeypatch.setattr("app.session_manager.launch_browser", _failing_launch)
     publisher = InMemorySessionEventPublisher()
+    stub_vnc = _StubVncController()
     manager = SessionManager(
         RunnerSettings(runner_id="runner-fail", camoufox_path="/usr/bin/camoufox"),
         publisher,
+        vnc_controller=stub_vnc,
     )
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Summary
- add a process-backed VNC controller that launches Xvfb/x11vnc/websockify and exposes browser environments for noVNC sessions
- extend runner settings and dependency wiring to configure the controller and gracefully disable it when tooling is missing
- update session manager logic, unit tests, and notes to exercise real VNC lifecycles via stub controllers

## Testing
- PYTHONPATH=. poetry run pytest -q

## Security
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68de04763ab4832a909d61718734f31d