### PR TITLE
Add FastAPI worker service with configurable browser flags

### DIFF
--- a/services/camoufox_worker/AGENT_NOTES.md
+++ b/services/camoufox_worker/AGENT_NOTES.md
@@ -1,12 +1,12 @@
 # AGENT_NOTES — camoufox_worker
 
 ## Overview
-Camoufox worker обеспечивает выполнение короткоживущих браузерных задач в двух режимах: нативный запуск Camoufox внутри контейнера и оркестрация удалённых сессий через Gateway/Runner. Реализованы асинхронные HTTP-хелперы для orchestrator-режима с ретраями, единый CLI и юнит-тесты, покрывающие оба сценария.
+Camoufox worker обеспечивает выполнение короткоживущих браузерных задач в двух режимах: нативный запуск Camoufox внутри контейнера и оркестрация удалённых сессий через Gateway/Runner. Реализованы асинхронные HTTP-хелперы для orchestrator-режима с ретраями, единый CLI, юнит-тесты и полноценный FastAPI-сервис для проксирования runner'а (REST + WebSocket) c поддержкой VNC.
 
 ## Interfaces
 * CLI `python -m worker.main run` для запуска единичной задачи с параметрами URL и таймаутом; выводит JSON с полями результата. Режим выбирается через `--mode` или `WORKER_MODE`, для orchestrator доступны опции/ENV `--gateway-url` (`GATEWAY_URL`), `--gateway-token` (`GATEWAY_TOKEN`), `--poll-timeout`, `--poll-interval`.
 * Контейнерный entrypoint `bin/worker-launch.sh` отображает переменные `WORKER_*` (URL, таймауты, режим, gateway) в CLI и при явной передаче аргументов делегирует управление `python -m worker.main ...`.
-* Планируемые интеграции: очередь задач (Redis/AMQP), HTTP API Gateway/Runner для orchestrator-режима.
+* FastAPI сервис (`worker.service.create_app`) предоставляет REST API `GET/POST /sessions`, `GET /sessions/{id}`, `POST /sessions/{id}/touch`, `DELETE /sessions/{id}`, `GET /health`, `GET /metrics`, а также WebSocket `/sessions/{id}/ws` для проксирования Playwright-трафика. Прокси вебсокета повторно использует runner endpoint и поддерживает двунаправленную пересылку.
 
 ## Data & Models
 * `worker.jobs.Job` — Pydantic-модель, описывающая параметры задачи (URL, прокси, таймаут). Помимо нормализованного `HttpUrl` хранит исходную строку `url_source`, чтобы браузер открывал URL без навязанного завершающего слэша.
@@ -20,6 +20,7 @@ Camoufox worker обеспечивает выполнение короткожи
 * CLI основан на Click для дальнейшего расширения команды `run` под дополнительные опции.
 * При ошибках исполнения Camoufox исключения конвертируются в `JobResult` со статусом `failure`, чтобы потребители могли логировать/ретраить без исключений.
 * Orchestrator-helpers используют `httpx.AsyncClient` с Bearer-аутентификацией, экспоненциальным бэкоффом (5xx/сетевые ошибки) и гарантированным `DELETE` в блоке `finally`.
+* FastAPI-слой повторно использует runner REST API, нормализует wsEndpoint и обеспечивает гибкую конфигурацию обязательных флагов браузера через `WorkerSettings.browser_required_flags`, объединяя их с опциональными флагами из запроса без правок кода при изменении набора ключей.
 * Pytest-конфигурация добавляет каталог `services/camoufox_worker` в `sys.path`,
   регистрирует маркер `anyio` и оставляет только `--strict-markers`/`--maxfail=1`
   для базового запуска без `pytest-cov`. Поскольку защитные пропуски удалены,
@@ -64,3 +65,4 @@ Camoufox worker обеспечивает выполнение короткожи
 * 2025-02-23 · gpt-5-codex · Удалены `pytest.importorskip`, глобально прокинут shim `camoufox`,
   обновлены инструкции по зависимостям и тестам.
 * 2025-02-24 · ChatGPT · Добавлен модуль очереди с Redis/AMQP адаптерами, Prometheus метриками, тумблерами профиля и тестами интеграций.
+* 2025-02-26 · ChatGPT · Интегрирован FastAPI worker (REST/VNC/WebSocket), добавлены конфиги `worker.config`, обязательные флаги браузера и unit-тесты `test_service.py`; обновлены зависимости Poetry.

--- a/services/camoufox_worker/poetry.lock
+++ b/services/camoufox_worker/poetry.lock
@@ -601,6 +601,27 @@ files = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.115.14"
+description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca"},
+    {file = "fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739"},
+]
+
+[package.dependencies]
+pydantic = ">=1.7.4,<1.8 || >1.8,<1.8.1 || >1.8.1,<2.0.0 || >2.0.0,<2.0.1 || >2.0.1,<2.1.0 || >2.1.0,<3.0.0"
+starlette = ">=0.40.0,<0.47.0"
+typing-extensions = ">=4.8.0"
+
+[package.extras]
+all = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "itsdangerous (>=1.1.0)", "jinja2 (>=3.1.5)", "orjson (>=3.2.1)", "pydantic-extra-types (>=2.0.0)", "pydantic-settings (>=2.0.0)", "python-multipart (>=0.0.18)", "pyyaml (>=5.3.1)", "ujson (>=4.0.1,!=4.0.2,!=4.1.0,!=4.2.0,!=4.3.0,!=5.0.0,!=5.1.0)", "uvicorn[standard] (>=0.12.0)"]
+standard = ["email-validator (>=2.0.0)", "fastapi-cli[standard] (>=0.0.5)", "httpx (>=0.23.0)", "jinja2 (>=3.1.5)", "python-multipart (>=0.0.18)", "uvicorn[standard] (>=0.12.0)"]
+
+[[package]]
 name = "frozenlist"
 version = "1.7.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"
@@ -1794,6 +1815,30 @@ files = [
 typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
+name = "pydantic-settings"
+version = "2.11.0"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pydantic_settings-2.11.0-py3-none-any.whl", hash = "sha256:fe2cea3413b9530d10f3a5875adffb17ada5c1e1bab0b2885546d7310415207c"},
+    {file = "pydantic_settings-2.11.0.tar.gz", hash = "sha256:d0e87a1c7d33593beb7194adb8470fc426e95ba02af83a0f23474a04c9a08180"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "boto3-stubs[secretsmanager]"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pyee"
 version = "13.0.0"
 description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
@@ -1940,6 +1985,21 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
+name = "python-dotenv"
+version = "1.1.1"
+description = "Read key-value pairs from a .env file and set them as environment variables"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc"},
+    {file = "python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"},
+]
+
+[package.extras]
+cli = ["click (>=5.0)"]
 
 [[package]]
 name = "pyyaml"
@@ -2122,6 +2182,24 @@ files = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.46.2"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35"},
+    {file = "starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
@@ -2218,6 +2296,107 @@ brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "uvicorn"
+version = "0.30.6"
+description = "The lightning-fast ASGI server."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "uvicorn-0.30.6-py3-none-any.whl", hash = "sha256:65fd46fe3fda5bdc1b03b94eb634923ff18cd35b2f084813ea79d1f103f711b5"},
+    {file = "uvicorn-0.30.6.tar.gz", hash = "sha256:4b15decdda1e72be08209e860a1e10e92439ad5b97cf44cc945fcbee66fc5788"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+h11 = ">=0.8"
+
+[package.extras]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
+
+[[package]]
+name = "websockets"
+version = "12.0"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "websockets-12.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d554236b2a2006e0ce16315c16eaa0d628dab009c33b63ea03f41c6107958374"},
+    {file = "websockets-12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2d225bb6886591b1746b17c0573e29804619c8f755b5598d875bb4235ea639be"},
+    {file = "websockets-12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eb809e816916a3b210bed3c82fb88eaf16e8afcf9c115ebb2bacede1797d2547"},
+    {file = "websockets-12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c588f6abc13f78a67044c6b1273a99e1cf31038ad51815b3b016ce699f0d75c2"},
+    {file = "websockets-12.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5aa9348186d79a5f232115ed3fa9020eab66d6c3437d72f9d2c8ac0c6858c558"},
+    {file = "websockets-12.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6350b14a40c95ddd53e775dbdbbbc59b124a5c8ecd6fbb09c2e52029f7a9f480"},
+    {file = "websockets-12.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:70ec754cc2a769bcd218ed8d7209055667b30860ffecb8633a834dde27d6307c"},
+    {file = "websockets-12.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6e96f5ed1b83a8ddb07909b45bd94833b0710f738115751cdaa9da1fb0cb66e8"},
+    {file = "websockets-12.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4d87be612cbef86f994178d5186add3d94e9f31cc3cb499a0482b866ec477603"},
+    {file = "websockets-12.0-cp310-cp310-win32.whl", hash = "sha256:befe90632d66caaf72e8b2ed4d7f02b348913813c8b0a32fae1cc5fe3730902f"},
+    {file = "websockets-12.0-cp310-cp310-win_amd64.whl", hash = "sha256:363f57ca8bc8576195d0540c648aa58ac18cf85b76ad5202b9f976918f4219cf"},
+    {file = "websockets-12.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:5d873c7de42dea355d73f170be0f23788cf3fa9f7bed718fd2830eefedce01b4"},
+    {file = "websockets-12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3f61726cae9f65b872502ff3c1496abc93ffbe31b278455c418492016e2afc8f"},
+    {file = "websockets-12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ed2fcf7a07334c77fc8a230755c2209223a7cc44fc27597729b8ef5425aa61a3"},
+    {file = "websockets-12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8e332c210b14b57904869ca9f9bf4ca32f5427a03eeb625da9b616c85a3a506c"},
+    {file = "websockets-12.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5693ef74233122f8ebab026817b1b37fe25c411ecfca084b29bc7d6efc548f45"},
+    {file = "websockets-12.0-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6e9e7db18b4539a29cc5ad8c8b252738a30e2b13f033c2d6e9d0549b45841c04"},
+    {file = "websockets-12.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:6e2df67b8014767d0f785baa98393725739287684b9f8d8a1001eb2839031447"},
+    {file = "websockets-12.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:bea88d71630c5900690fcb03161ab18f8f244805c59e2e0dc4ffadae0a7ee0ca"},
+    {file = "websockets-12.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dff6cdf35e31d1315790149fee351f9e52978130cef6c87c4b6c9b3baf78bc53"},
+    {file = "websockets-12.0-cp311-cp311-win32.whl", hash = "sha256:3e3aa8c468af01d70332a382350ee95f6986db479ce7af14d5e81ec52aa2b402"},
+    {file = "websockets-12.0-cp311-cp311-win_amd64.whl", hash = "sha256:25eb766c8ad27da0f79420b2af4b85d29914ba0edf69f547cc4f06ca6f1d403b"},
+    {file = "websockets-12.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0e6e2711d5a8e6e482cacb927a49a3d432345dfe7dea8ace7b5790df5932e4df"},
+    {file = "websockets-12.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:dbcf72a37f0b3316e993e13ecf32f10c0e1259c28ffd0a85cee26e8549595fbc"},
+    {file = "websockets-12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:12743ab88ab2af1d17dd4acb4645677cb7063ef4db93abffbf164218a5d54c6b"},
+    {file = "websockets-12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b645f491f3c48d3f8a00d1fce07445fab7347fec54a3e65f0725d730d5b99cb"},
+    {file = "websockets-12.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9893d1aa45a7f8b3bc4510f6ccf8db8c3b62120917af15e3de247f0780294b92"},
+    {file = "websockets-12.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f38a7b376117ef7aff996e737583172bdf535932c9ca021746573bce40165ed"},
+    {file = "websockets-12.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f764ba54e33daf20e167915edc443b6f88956f37fb606449b4a5b10ba42235a5"},
+    {file = "websockets-12.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:1e4b3f8ea6a9cfa8be8484c9221ec0257508e3a1ec43c36acdefb2a9c3b00aa2"},
+    {file = "websockets-12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:9fdf06fd06c32205a07e47328ab49c40fc1407cdec801d698a7c41167ea45113"},
+    {file = "websockets-12.0-cp312-cp312-win32.whl", hash = "sha256:baa386875b70cbd81798fa9f71be689c1bf484f65fd6fb08d051a0ee4e79924d"},
+    {file = "websockets-12.0-cp312-cp312-win_amd64.whl", hash = "sha256:ae0a5da8f35a5be197f328d4727dbcfafa53d1824fac3d96cdd3a642fe09394f"},
+    {file = "websockets-12.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5f6ffe2c6598f7f7207eef9a1228b6f5c818f9f4d53ee920aacd35cec8110438"},
+    {file = "websockets-12.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9edf3fc590cc2ec20dc9d7a45108b5bbaf21c0d89f9fd3fd1685e223771dc0b2"},
+    {file = "websockets-12.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8572132c7be52632201a35f5e08348137f658e5ffd21f51f94572ca6c05ea81d"},
+    {file = "websockets-12.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:604428d1b87edbf02b233e2c207d7d528460fa978f9e391bd8aaf9c8311de137"},
+    {file = "websockets-12.0-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1a9d160fd080c6285e202327aba140fc9a0d910b09e423afff4ae5cbbf1c7205"},
+    {file = "websockets-12.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:87b4aafed34653e465eb77b7c93ef058516cb5acf3eb21e42f33928616172def"},
+    {file = "websockets-12.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:b2ee7288b85959797970114deae81ab41b731f19ebcd3bd499ae9ca0e3f1d2c8"},
+    {file = "websockets-12.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:7fa3d25e81bfe6a89718e9791128398a50dec6d57faf23770787ff441d851967"},
+    {file = "websockets-12.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:a571f035a47212288e3b3519944f6bf4ac7bc7553243e41eac50dd48552b6df7"},
+    {file = "websockets-12.0-cp38-cp38-win32.whl", hash = "sha256:3c6cc1360c10c17463aadd29dd3af332d4a1adaa8796f6b0e9f9df1fdb0bad62"},
+    {file = "websockets-12.0-cp38-cp38-win_amd64.whl", hash = "sha256:1bf386089178ea69d720f8db6199a0504a406209a0fc23e603b27b300fdd6892"},
+    {file = "websockets-12.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:ab3d732ad50a4fbd04a4490ef08acd0517b6ae6b77eb967251f4c263011a990d"},
+    {file = "websockets-12.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a1d9697f3337a89691e3bd8dc56dea45a6f6d975f92e7d5f773bc715c15dde28"},
+    {file = "websockets-12.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1df2fbd2c8a98d38a66f5238484405b8d1d16f929bb7a33ed73e4801222a6f53"},
+    {file = "websockets-12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:23509452b3bc38e3a057382c2e941d5ac2e01e251acce7adc74011d7d8de434c"},
+    {file = "websockets-12.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2e5fc14ec6ea568200ea4ef46545073da81900a2b67b3e666f04adf53ad452ec"},
+    {file = "websockets-12.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46e71dbbd12850224243f5d2aeec90f0aaa0f2dde5aeeb8fc8df21e04d99eff9"},
+    {file = "websockets-12.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b81f90dcc6c85a9b7f29873beb56c94c85d6f0dac2ea8b60d995bd18bf3e2aae"},
+    {file = "websockets-12.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:a02413bc474feda2849c59ed2dfb2cddb4cd3d2f03a2fedec51d6e959d9b608b"},
+    {file = "websockets-12.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:bbe6013f9f791944ed31ca08b077e26249309639313fff132bfbf3ba105673b9"},
+    {file = "websockets-12.0-cp39-cp39-win32.whl", hash = "sha256:cbe83a6bbdf207ff0541de01e11904827540aa069293696dd528a6640bd6a5f6"},
+    {file = "websockets-12.0-cp39-cp39-win_amd64.whl", hash = "sha256:fc4e7fa5414512b481a2483775a8e8be7803a35b30ca805afa4998a84f9fd9e8"},
+    {file = "websockets-12.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:248d8e2446e13c1d4326e0a6a4e9629cb13a11195051a73acf414812700badbd"},
+    {file = "websockets-12.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f44069528d45a933997a6fef143030d8ca8042f0dfaad753e2906398290e2870"},
+    {file = "websockets-12.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c4e37d36f0d19f0a4413d3e18c0d03d0c268ada2061868c1e6f5ab1a6d575077"},
+    {file = "websockets-12.0-pp310-pypy310_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d829f975fc2e527a3ef2f9c8f25e553eb7bc779c6665e8e1d52aa22800bb38b"},
+    {file = "websockets-12.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:2c71bd45a777433dd9113847af751aae36e448bc6b8c361a566cb043eda6ec30"},
+    {file = "websockets-12.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0bee75f400895aef54157b36ed6d3b308fcab62e5260703add87f44cee9c82a6"},
+    {file = "websockets-12.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:423fc1ed29f7512fceb727e2d2aecb952c46aa34895e9ed96071821309951123"},
+    {file = "websockets-12.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:27a5e9964ef509016759f2ef3f2c1e13f403725a5e6a1775555994966a66e931"},
+    {file = "websockets-12.0-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3181df4583c4d3994d31fb235dc681d2aaad744fbdbf94c4802485ececdecf2"},
+    {file = "websockets-12.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:b067cb952ce8bf40115f6c19f478dc71c5e719b7fbaa511359795dfd9d1a6468"},
+    {file = "websockets-12.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:00700340c6c7ab788f176d118775202aadea7602c5cc6be6ae127761c16d6b0b"},
+    {file = "websockets-12.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e469d01137942849cff40517c97a30a93ae79917752b34029f0ec72df6b46399"},
+    {file = "websockets-12.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffefa1374cd508d633646d51a8e9277763a9b78ae71324183693959cf94635a7"},
+    {file = "websockets-12.0-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba0cab91b3956dfa9f512147860783a1829a8d905ee218a9837c18f683239611"},
+    {file = "websockets-12.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:2cb388a5bfb56df4d9a406783b7f9dbefb888c09b71629351cc6b036e9259370"},
+    {file = "websockets-12.0-py3-none-any.whl", hash = "sha256:dc284bbc8d7c78a6c69e0c7325ab46ee5e40bb4d50e494d8131a07ef47500e9e"},
+    {file = "websockets-12.0.tar.gz", hash = "sha256:81df9cbcbb6c260de1e007e58c011bfebe2dafc8435107b0537f393dd38c8b1b"},
+]
 
 [[package]]
 name = "yarl"
@@ -2341,4 +2520,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.13"
-content-hash = "8ba12caa57c150500a9fde606501824faed7b0f67d5b47222e3496c561e76e18"
+content-hash = "9352854ab36cec5da65fe59adec32711cab2a651f34014c3deb40bdd15857f52"

--- a/services/camoufox_worker/pyproject.toml
+++ b/services/camoufox_worker/pyproject.toml
@@ -13,6 +13,10 @@ camoufox = { version = "^0.4.11", extras = ["geoip"] }
 prometheus-client = "^0.20.0"
 redis = "^5.0.7"
 aio-pika = "^9.4.1"
+fastapi = "^0.115.2"
+uvicorn = "^0.30.6"
+pydantic-settings = "^2.6.1"
+websockets = "^12.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/services/camoufox_worker/tests/test_service.py
+++ b/services/camoufox_worker/tests/test_service.py
@@ -1,0 +1,124 @@
+"""Tests covering the FastAPI worker service integration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from worker.config import SessionDefaults, WorkerSettings
+from worker import service
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Constrain AnyIO-backed tests to the asyncio implementation."""
+
+    return "asyncio"
+
+
+class _StubRunnerClient:
+    """Minimal stub mimicking :class:`worker.runner_client.RunnerClient`."""
+
+    def __init__(self) -> None:
+        self.created_payload: dict | None = None
+
+    async def health(self) -> dict:
+        return {"status": "ok", "checks": {"runner": "up"}}
+
+    async def list_sessions(self) -> list[dict]:
+        now = datetime.now().isoformat()
+        return [
+            {
+                "id": "sess-1",
+                "status": "READY",
+                "created_at": now,
+                "last_seen_at": now,
+                "browser": "camoufox",
+                "headless": False,
+                "idle_ttl_seconds": 300,
+                "labels": {},
+                "vnc": {},
+                "vnc_enabled": True,
+                "start_url_wait": "load",
+            }
+        ]
+
+    async def create_session(self, payload: dict) -> dict:
+        self.created_payload = payload
+        now = datetime.now().isoformat()
+        return {
+            "id": "sess-created",
+            "status": "INIT",
+            "created_at": now,
+            "last_seen_at": now,
+            "browser": "camoufox",
+            "headless": payload.get("headless", False),
+            "idle_ttl_seconds": payload.get("idle_ttl_seconds", 300),
+            "labels": payload.get("labels", {}),
+            "vnc": {},
+            "vnc_enabled": bool(payload.get("vnc", False)),
+            "start_url_wait": payload.get("start_url_wait", "load"),
+        }
+
+    async def get_session(self, session_id: str) -> dict:  # pragma: no cover - unused in tests
+        raise NotImplementedError
+
+    async def delete_session(self, session_id: str) -> dict:  # pragma: no cover - unused in tests
+        raise NotImplementedError
+
+    async def touch_session(self, session_id: str) -> dict:  # pragma: no cover - unused in tests
+        raise NotImplementedError
+
+
+@pytest.mark.anyio
+async def test_create_session_merges_required_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubRunnerClient()
+    monkeypatch.setattr(service, "RunnerClient", lambda base_url: stub)
+    settings = WorkerSettings(
+        runner_base_url="http://runner",
+        supports_vnc=True,
+        browser_required_flags={"MOZ_DISABLE_HTTP3": "1"},
+        session_defaults=SessionDefaults(headless=False, idle_ttl_seconds=120, start_url_wait="load"),
+    )
+    app = service.create_app(settings)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://worker") as client:
+        response = await client.post(
+            "/sessions",
+            json={
+                "headless": True,
+                "browser_flags": {"custom": "flag"},
+            },
+        )
+    assert response.status_code == 201
+    assert stub.created_payload is not None
+    assert stub.created_payload["metadata"]["browser_flags"] == {
+        "custom": "flag",
+        "MOZ_DISABLE_HTTP3": "1",
+    }
+    assert stub.created_payload["idle_ttl_seconds"] == 120
+    assert stub.created_payload["start_url_wait"] == "load"
+
+
+@pytest.mark.anyio
+async def test_create_session_rejects_vnc_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubRunnerClient()
+    monkeypatch.setattr(service, "RunnerClient", lambda base_url: stub)
+    settings = WorkerSettings(
+        runner_base_url="http://runner",
+        supports_vnc=False,
+        session_defaults=SessionDefaults(),
+    )
+    app = service.create_app(settings)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://worker") as client:
+        response = await client.post(
+            "/sessions",
+            json={"vnc": True},
+        )
+    assert response.status_code == 400
+    assert response.json()["detail"] == "VNC is not supported by this worker"
+    assert stub.created_payload is None
+

--- a/services/camoufox_worker/worker/__init__.py
+++ b/services/camoufox_worker/worker/__init__.py
@@ -1,8 +1,12 @@
-"""Camoufox worker package exposing job definitions and runner entrypoints."""
+"""Camoufox worker package exposing job utilities and the HTTP API service."""
 
 __all__ = [
+    "config",
     "jobs",
+    "models",
+    "queue",
+    "runner_client",
     "runner_native",
     "runner_orch",
-    "queue",
+    "service",
 ]

--- a/services/camoufox_worker/worker/config.py
+++ b/services/camoufox_worker/worker/config.py
@@ -1,0 +1,77 @@
+"""Configuration models powering the Camoufox worker service."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Annotated, Any
+
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SessionDefaults(BaseModel):
+    """Default session parameters applied when clients omit optional fields."""
+
+    idle_ttl_seconds: Annotated[int, Field(ge=30, le=3600)] = 300
+    headless: bool = False
+    start_url_wait: str = Field(default="load", pattern="^(none|domcontentloaded|load)$")
+
+
+class WorkerSettings(BaseSettings):
+    """Runtime settings sourced from environment variables and `.env` files.
+
+    Attributes
+    ----------
+    host:
+        Host interface exposed by the FastAPI application (defaults to
+        ``0.0.0.0`` for container compatibility).
+    port:
+        TCP port used by the HTTP server. This value is not consumed directly
+        by the ASGI application but is provided for entrypoint scripts.
+    shutdown_timeout:
+        Grace period in seconds granted to background tasks during shutdown.
+    metrics_endpoint:
+        URL path for exposing Prometheus metrics collected by the worker.
+    session_defaults:
+        Default parameters merged into session creation requests when the
+        client leaves a field unset.
+    cleanup_interval:
+        How often, in seconds, the worker should instruct the runner to purge
+        stale sessions. The value mirrors the beta branch implementation to
+        simplify deployment.
+    runner_base_url:
+        Base URL of the Camoufox runner sidecar proxied by this worker.
+    supports_vnc:
+        Flag indicating whether this worker instance can provision VNC-backed
+        sessions. The create endpoint rejects ``vnc=true`` when the flag is
+        ``False``.
+    browser_required_flags:
+        Mapping of mandatory browser launch flags applied to every session.
+        Values are opaque for the worker and passed straight to the runner via
+        session metadata. The structure intentionally accepts arbitrary keys to
+        avoid code changes when operators adjust launch options in Helm charts
+        or Compose files.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="WORKER_", env_file=".env", extra="ignore")
+
+    host: str = "0.0.0.0"
+    port: int = 8080
+    shutdown_timeout: int = 10
+    metrics_endpoint: str = "/metrics"
+    session_defaults: SessionDefaults = Field(default_factory=SessionDefaults)
+    cleanup_interval: Annotated[int, Field(gt=0, le=3600)] = 15
+    runner_base_url: str = "http://127.0.0.1:8070"
+    supports_vnc: bool = False
+    browser_required_flags: dict[str, Any] = Field(default_factory=dict)
+
+
+@lru_cache
+def load_settings() -> WorkerSettings:
+    """Return a cached :class:`WorkerSettings` instance."""
+
+    return WorkerSettings()
+
+
+__all__ = ["WorkerSettings", "SessionDefaults", "load_settings"]
+

--- a/services/camoufox_worker/worker/models.py
+++ b/services/camoufox_worker/worker/models.py
@@ -1,0 +1,79 @@
+"""Pydantic models describing the worker HTTP API surface."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class SessionStatus(str, Enum):
+    """Lifecycle phases mirrored from the runner implementation."""
+
+    INIT = "INIT"
+    READY = "READY"
+    TERMINATING = "TERMINATING"
+    DEAD = "DEAD"
+
+
+class SessionCreateRequest(BaseModel):
+    """Inbound payload for creating a new browser session via the worker API."""
+
+    headless: bool | None = None
+    idle_ttl_seconds: Annotated[int | None, Field(ge=30, le=3600)] = None
+    start_url: Annotated[str | None, Field(max_length=1024)] = None
+    start_url_wait: Literal["none", "domcontentloaded", "load"] | None = None
+    labels: dict[str, str] | None = None
+    vnc: bool = False
+    browser_flags: dict[str, Any] | None = None
+
+
+class SessionSummary(BaseModel):
+    """Compact description exposed by listing endpoints."""
+
+    id: str
+    status: SessionStatus
+    created_at: datetime
+    last_seen_at: datetime
+    browser: str
+    headless: bool
+    idle_ttl_seconds: int
+    labels: dict[str, str]
+    worker_id: str
+    vnc_enabled: bool
+    start_url_wait: Literal["none", "domcontentloaded", "load"]
+
+
+class SessionDetail(SessionSummary):
+    """Extended session representation used by the UI."""
+
+    ws_endpoint: str
+    vnc: dict[str, Any]
+
+
+class SessionDeleteResponse(BaseModel):
+    """Acknowledgement payload returned after scheduling a deletion."""
+
+    id: str
+    status: SessionStatus
+
+
+class HealthResponse(BaseModel):
+    """Structured health payload consumed by operators."""
+
+    status: str
+    version: str
+    checks: dict[str, str]
+
+
+__all__ = [
+    "SessionStatus",
+    "SessionCreateRequest",
+    "SessionSummary",
+    "SessionDetail",
+    "SessionDeleteResponse",
+    "HealthResponse",
+]
+

--- a/services/camoufox_worker/worker/runner_client.py
+++ b/services/camoufox_worker/worker/runner_client.py
@@ -1,0 +1,73 @@
+"""Async HTTP client wrapper for interacting with the Camoufox runner."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class RunnerClient:
+    """Thin convenience wrapper around the runner REST API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 30.0,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._owns_client = http_client is None
+        self._client = httpx.AsyncClient(base_url=base_url, timeout=timeout) if http_client is None else http_client
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client if it was created by the wrapper."""
+
+        if self._owns_client:
+            await self._client.aclose()
+
+    async def health(self) -> dict[str, Any]:
+        """Retrieve the runner health payload."""
+
+        response = await self._client.get("health")
+        response.raise_for_status()
+        return response.json()
+
+    async def list_sessions(self) -> list[dict[str, Any]]:
+        """Return the list of active sessions maintained by the runner."""
+
+        response = await self._client.get("sessions")
+        response.raise_for_status()
+        return response.json()
+
+    async def create_session(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Ask the runner to create a new browser session."""
+
+        response = await self._client.post("sessions", json=payload)
+        response.raise_for_status()
+        return response.json()
+
+    async def get_session(self, session_id: str) -> dict[str, Any]:
+        """Return metadata for a specific session identifier."""
+
+        response = await self._client.get(f"sessions/{session_id}")
+        response.raise_for_status()
+        return response.json()
+
+    async def delete_session(self, session_id: str) -> dict[str, Any]:
+        """Request graceful termination of a session."""
+
+        response = await self._client.delete(f"sessions/{session_id}")
+        response.raise_for_status()
+        return response.json()
+
+    async def touch_session(self, session_id: str) -> dict[str, Any]:
+        """Refresh the idle timeout for ``session_id``."""
+
+        response = await self._client.post(f"sessions/{session_id}/touch")
+        response.raise_for_status()
+        return response.json()
+
+
+__all__ = ["RunnerClient"]
+

--- a/services/camoufox_worker/worker/service.py
+++ b/services/camoufox_worker/worker/service.py
@@ -1,0 +1,270 @@
+"""FastAPI application providing the Camoufox worker HTTP surface."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+from fastapi import Depends, FastAPI, HTTPException, Response, WebSocket, WebSocketDisconnect, status
+from fastapi.middleware.cors import CORSMiddleware
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
+import websockets
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+
+from .config import WorkerSettings, load_settings
+from .models import (
+    HealthResponse,
+    SessionCreateRequest,
+    SessionDeleteResponse,
+    SessionDetail,
+    SessionStatus,
+)
+from .runner_client import RunnerClient
+
+LOGGER = logging.getLogger(__name__)
+
+
+class AppState:
+    """Container storing shared application state objects."""
+
+    def __init__(self, settings: WorkerSettings) -> None:
+        self.settings = settings
+        self.runner = RunnerClient(settings.runner_base_url)
+        self.registry = CollectorRegistry()
+        self.worker_id = str(uuid.uuid4())
+        self.required_browser_flags = dict(settings.browser_required_flags)
+
+    async def shutdown(self) -> None:
+        """Release HTTP resources on shutdown."""
+
+        await self.runner.close()
+
+
+def get_settings() -> WorkerSettings:
+    """Return cached worker settings for dependency injection."""
+
+    return load_settings()
+
+
+def create_app(settings: WorkerSettings | None = None) -> FastAPI:
+    """Create and configure the FastAPI worker application."""
+
+    cfg = settings or load_settings()
+    state = AppState(cfg)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI):
+        app.state.app_state = state
+        try:
+            yield
+        finally:
+            await state.shutdown()
+
+    app = FastAPI(title="Camoufox Worker", version="0.1.0", lifespan=lifespan)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    def require_state() -> AppState:
+        return state
+
+    @app.get("/health", response_model=HealthResponse)
+    async def health(app_state: AppState = Depends(require_state)) -> HealthResponse:
+        try:
+            data = await app_state.runner.health()
+            status_text = data.get("status", "unknown")
+            checks = data.get("checks", {})
+        except Exception as exc:  # pragma: no cover - defensive branch
+            LOGGER.warning("runner health probe failed: %s", exc)
+            status_text = "degraded"
+            checks = {"runner": "unreachable"}
+        return HealthResponse(status=status_text, version=app.version, checks=checks)
+
+    @app.get("/sessions", response_model=list[SessionDetail])
+    async def list_sessions(app_state: AppState = Depends(require_state)) -> list[SessionDetail]:
+        data = await app_state.runner.list_sessions()
+        return [_to_worker_detail(app_state, item) for item in data]
+
+    @app.post("/sessions", response_model=SessionDetail, status_code=status.HTTP_201_CREATED)
+    async def create_session(
+        request: SessionCreateRequest, app_state: AppState = Depends(require_state)
+    ) -> SessionDetail:
+        if request.vnc and not app_state.settings.supports_vnc:
+            raise HTTPException(status_code=400, detail="VNC is not supported by this worker")
+
+        payload = request.model_dump(exclude_unset=True)
+        optional_flags = payload.pop("browser_flags", None)
+        payload.setdefault("headless", app_state.settings.session_defaults.headless)
+        payload.setdefault(
+            "idle_ttl_seconds", app_state.settings.session_defaults.idle_ttl_seconds
+        )
+        payload.setdefault("start_url_wait", app_state.settings.session_defaults.start_url_wait)
+
+        merged_flags = _merge_browser_flags(app_state.required_browser_flags, optional_flags)
+        if merged_flags:
+            metadata = payload.setdefault("metadata", {})
+            metadata["browser_flags"] = merged_flags
+
+        data = await app_state.runner.create_session(payload)
+        return _to_worker_detail(app_state, data)
+
+    @app.get("/sessions/{session_id}", response_model=SessionDetail)
+    async def get_session(session_id: str, app_state: AppState = Depends(require_state)) -> SessionDetail:
+        try:
+            data = await app_state.runner.get_session(session_id)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise HTTPException(status_code=404, detail="Session not found") from exc
+            raise
+        return _to_worker_detail(app_state, data)
+
+    @app.delete("/sessions/{session_id}", response_model=SessionDeleteResponse)
+    async def delete_session(
+        session_id: str, app_state: AppState = Depends(require_state)
+    ) -> SessionDeleteResponse:
+        try:
+            data = await app_state.runner.delete_session(session_id)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise HTTPException(status_code=404, detail="Session not found") from exc
+            raise
+        return SessionDeleteResponse(id=data["id"], status=SessionStatus(data["status"]))
+
+    @app.post("/sessions/{session_id}/touch", response_model=SessionDetail)
+    async def touch_session(
+        session_id: str, app_state: AppState = Depends(require_state)
+    ) -> SessionDetail:
+        try:
+            data = await app_state.runner.touch_session(session_id)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                raise HTTPException(status_code=404, detail="Session not found") from exc
+            raise
+        return _to_worker_detail(app_state, data)
+
+    @app.get(cfg.metrics_endpoint)
+    async def metrics(app_state: AppState = Depends(require_state)) -> Response:
+        content = generate_latest(app_state.registry)
+        return Response(content=content, media_type=CONTENT_TYPE_LATEST)
+
+    @app.websocket("/sessions/{session_id}/ws")
+    async def session_websocket(session_id: str, websocket: WebSocket) -> None:
+        await websocket.accept()
+        try:
+            state_ref: AppState = app.state.app_state
+            data = await state_ref.runner.get_session(session_id)
+        except httpx.HTTPStatusError:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+        except Exception:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+        upstream = data.get("ws_endpoint")
+        if not upstream:
+            await websocket.close(code=status.WS_1008_POLICY_VIOLATION)
+            return
+        await _bridge_websocket(websocket, upstream)
+
+    return app
+
+
+def _merge_browser_flags(
+    required: dict[str, Any], optional: dict[str, Any] | None
+) -> dict[str, Any]:
+    combined: dict[str, Any] = dict(optional or {})
+    for key, value in required.items():
+        combined[key] = value
+    return combined
+
+
+def _to_worker_detail(app_state: AppState, data: dict[str, Any]) -> SessionDetail:
+    return SessionDetail(
+        id=data["id"],
+        status=SessionStatus(data["status"]),
+        created_at=data["created_at"],
+        last_seen_at=data["last_seen_at"],
+        browser=data.get("browser", "camoufox"),
+        headless=data["headless"],
+        idle_ttl_seconds=data["idle_ttl_seconds"],
+        labels=data.get("labels", {}),
+        worker_id=app_state.worker_id,
+        vnc_enabled=bool(data.get("vnc_enabled", False)),
+        start_url_wait=data.get("start_url_wait", app_state.settings.session_defaults.start_url_wait),
+        ws_endpoint=f"/sessions/{data['id']}/ws",
+        vnc=data.get("vnc", {}) or {},
+    )
+
+
+async def _bridge_websocket(websocket: WebSocket, upstream_endpoint: str) -> None:
+    try:
+        async with websockets.connect(upstream_endpoint, ping_interval=None) as upstream:
+            client_to_upstream = asyncio.create_task(
+                _forward_client_to_upstream(websocket, upstream),
+                name="camoufox-worker-client-to-runner",
+            )
+            upstream_to_client = asyncio.create_task(
+                _forward_upstream_to_client(websocket, upstream),
+                name="camoufox-worker-runner-to-client",
+            )
+            done, pending = await asyncio.wait(
+                {client_to_upstream, upstream_to_client},
+                return_when=asyncio.FIRST_EXCEPTION,
+            )
+            for task in pending:
+                task.cancel()
+            for task in done:
+                exc = task.exception()
+                if exc:
+                    raise exc
+    except (ConnectionClosedError, ConnectionClosedOK, WebSocketDisconnect):
+        with contextlib.suppress(RuntimeError):
+            await websocket.close()
+    except Exception as exc:  # pragma: no cover - defensive branch
+        LOGGER.warning("websocket bridge failure: %s", exc)
+        with contextlib.suppress(RuntimeError):
+            await websocket.close(code=status.WS_1011_INTERNAL_ERROR)
+
+
+async def _forward_client_to_upstream(
+    websocket: WebSocket, upstream: websockets.WebSocketClientProtocol
+) -> None:
+    try:
+        while True:
+            message = await websocket.receive()
+            message_type = message.get("type")
+            if message_type == "websocket.disconnect":
+                await upstream.close()
+                break
+            if "text" in message and message["text"] is not None:
+                await upstream.send(message["text"])
+            elif "bytes" in message and message["bytes"] is not None:
+                await upstream.send(message["bytes"])
+    except WebSocketDisconnect:
+        await upstream.close()
+
+
+async def _forward_upstream_to_client(
+    websocket: WebSocket, upstream: websockets.WebSocketClientProtocol
+) -> None:
+    try:
+        async for payload in upstream:
+            if isinstance(payload, (bytes, bytearray)):
+                await websocket.send_bytes(payload)
+            else:
+                await websocket.send_text(payload)
+    finally:
+        with contextlib.suppress(RuntimeError):
+            await websocket.close()
+
+
+__all__ = ["create_app", "get_settings"]
+


### PR DESCRIPTION
## Summary
- introduce FastAPI-based worker API with REST endpoints, WebSocket bridge, and VNC-aware session proxying built on reusable configuration/state helpers
- add configurable mandatory browser flag support via WorkerSettings along with new Pydantic models, runner client, and documentation updates
- expand project dependencies and tests to cover the new service behaviour and ensure configuration merging works as expected

## Testing
- `cd services/camoufox_worker && poetry run pytest -q`

## Security
- No security impact identified; the worker continues to rely on upstream authentication layers and only proxies to the runner.

------
https://chatgpt.com/codex/tasks/task_e_68de0fe99304832a969231423287350d