### PR TITLE
Integrate warm pool into session lifecycle

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -12,7 +12,8 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
     не-`DEAD` сессий; `prewarm` включает счётчик и последнюю ошибку прогрева;
     `ttl` содержит ближайшее истечение (`next_expiry_at`) и счетчики работы
     фонового reaper-а (`total_runs`, `expired_sessions`, `last_run_at`).
-  - `POST /sessions` — accepts `SessionCreatePayload`, returns created `core.Session` snapshot.
+  - `POST /sessions` — accepts `SessionCreatePayload`, возвращает созданный `core.Session`.
+    При отсутствии свободных warm-слотов возвращает HTTP 429 (`no warm workstations available`).
   - `PATCH /sessions/{id}` — accepts `SessionUpdatePayload`, merges labels/metadata, returns updated `core.Session`.
   - `POST /sessions/{id}/touch` — обновляет `last_seen_at`, продлевая TTL и публикуя heartbeat-событие.
   - `DELETE /sessions/{id}` — marks session as `DEAD`, returns terminal snapshot.
@@ -50,6 +51,8 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - **Environment-driven settings**: `RunnerSettings.from_env` centralises configuration parsing without extra dependencies, easing future extension. Дополнительные параметры: `slot_limit`, базовые VNC URL, глобальный флаг прокси и ёмкость истории ошибок прогрева.
 - **Bounded prewarm history**: менеджер хранит ошибки прогрева в `deque` с ограничением размера, что позволяет health-эндпоинту
   показывать последние сбои без риска утечки памяти.
+- **Warm pool-backed sessions**: `SessionManager` теперь зависит от `WarmPoolManager`, резервирует слот до создания сессии и
+  рециклирует его при завершении. В случае исчерпания слотов API возвращает 429.
 - **Gateway proxy compatibility**: `SessionCreatePayload` остаётся публичным контрактом, но теперь вызывается через Gateway, потому важна обратная совместимость и строгая валидация.
 - **Playwright launch lifecycle**: `app.browser.launch_browser` стартует Playwright в режиме `launch-server`, сохраняет `wsEndpoint`/PID в метаданных и позволяет `SessionManager` останавливать процесс при переходе в `DEAD` или очистке endpoint. Исключения при старте выполняют откат без публикации событий.
 - **Idle TTL reaper**: `SessionManager` содержит AnyIO-based reaper, который вызывает
@@ -103,3 +106,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-14 · gpt-5-codex · Привели код и тесты к требованиям Ruff (импорт, длины строк, ошибки) и актуализировали конфигурацию линтера.
 - 2025-10-15 · gpt-5-codex · Добавлены warm pool-конфиги (JSON), загрузка при старте, новые настройки и модульные тесты на валидацию/парсинг.
 - 2025-10-16 · gpt-5-codex · Реализован ``WarmPoolManager`` с управлением состояниями, recycle, преднавигацией и юнит-тестами на ключевые сценарии.
+- 2025-10-17 · gpt-5-codex · Интегрирован warm pool в `SessionManager`/API, добавлен отклик 429 при нехватке слотов и покрытие тестами.

--- a/services/runner/app/dependencies/session_manager.py
+++ b/services/runner/app/dependencies/session_manager.py
@@ -12,6 +12,7 @@ from ..events import (
     SessionEventPublisher,
 )
 from ..session_manager import SessionManager
+from ..warm_pool import WarmPoolManager
 from ..vnc import ProcessVncController, VncController, VncUnavailableError
 
 LOGGER = logging.getLogger(__name__)
@@ -56,12 +57,21 @@ def get_session_manager() -> SessionManager:
         get_runner_settings(),
         get_event_publisher(),
         vnc_controller=get_vnc_controller(),
+        warm_pool_manager=get_warm_pool_manager(),
     )
+
+
+@lru_cache
+def get_warm_pool_manager() -> WarmPoolManager:
+    """Return a cached :class:`WarmPoolManager` built from runner settings."""
+
+    return WarmPoolManager(get_runner_settings())
 
 
 __all__ = [
     "get_event_publisher",
     "get_runner_settings",
+    "get_warm_pool_manager",
     "get_session_manager",
     "get_vnc_controller",
 ]

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -15,6 +15,7 @@ from .dependencies import get_runner_settings, get_session_manager
 from .metrics import METRICS_REGISTRY
 from .session_manager import (
     SessionCreatePayload,
+    SessionCapacityError,
     SessionManager,
     SessionNotFoundError,
     SessionUpdatePayload,
@@ -132,7 +133,13 @@ async def create_session(
 ) -> Session:
     """Create a session and emit a ``session.created`` event."""
 
-    return await manager.create_session(payload)
+    try:
+        return await manager.create_session(payload)
+    except SessionCapacityError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="no warm workstations available",
+        ) from exc
 
 
 @app.patch("/sessions/{session_id}", response_model=Session, summary="Update a session")

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -22,7 +22,7 @@ from core.models import (
 )
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PositiveInt
 
-from .browser import BrowserSessionHandle, launch_browser
+from .browser import BrowserSessionHandle
 from .config import RunnerSettings
 from .events import SessionEventPublisher
 from .metrics import (
@@ -34,6 +34,12 @@ from .metrics import (
     VNC_ALLOCATIONS_GAUGE,
 )
 from .vnc import VncController, VncSessionHandle
+from .warm_pool import (
+    WarmPoolManager,
+    WarmPoolProvisioningError,
+    WarmPoolReservation,
+    WarmPoolStateError,
+)
 
 
 class SessionCreatePayload(BaseModel):
@@ -85,6 +91,10 @@ class SessionUpdatePayload(BaseModel):
 
 class SessionNotFoundError(KeyError):
     """Raised when attempting to operate on an unknown session identifier."""
+
+
+class SessionCapacityError(RuntimeError):
+    """Raised when the runner cannot honour a session request due to capacity."""
 
 
 class SessionManagerMetrics(BaseModel):
@@ -146,6 +156,7 @@ class SessionManager:
         *,
         reaper_interval_seconds: float = 1.0,
         vnc_controller: VncController | None = None,
+        warm_pool_manager: WarmPoolManager | None = None,
     ) -> None:
         self._settings = settings
         self._publisher = event_publisher
@@ -160,6 +171,9 @@ class SessionManager:
         self._browser_handles: dict[UUID, BrowserSessionHandle] = {}
         self._vnc_controller = vnc_controller
         self._vnc_handles: dict[UUID, VncSessionHandle] = {}
+        self._warm_pool = warm_pool_manager
+        self._warm_pool_started = False
+        self._warm_sessions: dict[UUID, str] = {}
         self._next_idle_expiry_at: datetime | None = None
         self._reaper_total_runs = 0
         self._reaper_expired_sessions = 0
@@ -185,24 +199,16 @@ class SessionManager:
                 session_id,
                 sanitized_vnc=sanitized_vnc,
             )
-            browser_handle: BrowserSessionHandle | None = None
-            metadata = dict(payload.metadata)
             try:
-                browser_handle = await launch_browser(
-                    self._settings,
-                    browser=payload.browser,
-                    headless=payload.headless,
-                    env=(
-                        vnc_handle.browser_environment()
-                        if vnc_handle is not None
-                        else None
-                    ),
-                )
+                reservation = await self._reserve_warm_slot(payload.metadata)
             except Exception:
-                if browser_handle is not None:
-                    await browser_handle.shutdown(force=True)
                 await self._discard_vnc_handle(session_id, vnc_handle)
                 raise
+            workstation_id = reservation.snapshot.workstation_id
+            browser_handle = reservation.handle
+            metadata = self._merge_warm_pool_metadata(
+                dict(payload.metadata), reservation
+            )
             if browser_handle.pid is not None:
                 metadata.setdefault("runner_browser_pid", browser_handle.pid)
             vnc_enabled = (
@@ -230,11 +236,18 @@ class SessionManager:
                     metadata=metadata,
                 )
             except Exception:
-                await browser_handle.shutdown(force=True)
+                await self._cancel_warm_reservation(workstation_id)
+                await self._discard_vnc_handle(session_id, vnc_handle)
+                raise
+            try:
+                await self._mark_warm_slot_busy(workstation_id)
+            except SessionCapacityError:
+                await self._cancel_warm_reservation(workstation_id)
                 await self._discard_vnc_handle(session_id, vnc_handle)
                 raise
             self._sessions[session_id] = session
             self._browser_handles[session_id] = browser_handle
+            self._warm_sessions[session_id] = workstation_id
             if vnc_handle is not None:
                 self._vnc_handles[session_id] = vnc_handle
             VNC_ALLOCATIONS_GAUGE.set(len(self._vnc_handles))
@@ -284,6 +297,13 @@ class SessionManager:
                 )
             if self._should_cleanup_vnc(existing, session):
                 await self._release_vnc_handle(session_id)
+            release_warm = (
+                existing.status is not SessionStatus.DEAD
+                and session.status is SessionStatus.DEAD
+                and session_id in self._warm_sessions
+            )
+            if release_warm:
+                await self._release_warm_slot(session_id)
             event_type = (
                 SessionEventType.ENDED
                 if session.status is SessionStatus.DEAD
@@ -431,6 +451,9 @@ class SessionManager:
             >>> await manager.start()  # doctest: +SKIP
         """
 
+        if self._warm_pool is not None and not self._warm_pool_started:
+            await self._warm_pool.start()
+            self._warm_pool_started = True
         async with self._lock:
             if self._reaper_task_group is not None:
                 return
@@ -497,6 +520,160 @@ class SessionManager:
         if details.token is None and details.token_ttl_seconds is None:
             return details
         return details.model_copy(update={"token": None, "token_ttl_seconds": None})
+
+    async def _reserve_warm_slot(
+        self, metadata: dict[str, Any]
+    ) -> WarmPoolReservation:
+        """Reserve a warm workstation slot for a new session.
+
+        Args:
+            metadata: Metadata dictionary supplied during session creation.
+
+        Returns:
+            WarmPoolReservation: Snapshot and handle representing the reserved
+            workstation.
+
+        Raises:
+            SessionCapacityError: If warm pool support is disabled or no idle
+                slots are available.
+
+        Example:
+            >>> await manager._reserve_warm_slot({})  # doctest: +SKIP
+        """
+
+        if self._warm_pool is None:
+            raise SessionCapacityError("warm pool is not configured")
+        if not self._warm_pool_started:
+            await self._warm_pool.start()
+            self._warm_pool_started = True
+        requested = self._extract_requested_workstation(metadata)
+        try:
+            return await self._warm_pool.reserve_slot(requested)
+        except WarmPoolStateError as exc:  # pragma: no cover - defensive guard
+            raise SessionCapacityError("no warm workstations available") from exc
+
+    def _extract_requested_workstation(self, metadata: dict[str, Any]) -> str | None:
+        """Return a workstation identifier requested via metadata.
+
+        Args:
+            metadata: Metadata payload supplied by the API caller.
+
+        Returns:
+            str | None: Identifier of the requested workstation when provided,
+            otherwise ``None``.
+
+        Example:
+            >>> manager._extract_requested_workstation(  # doctest: +SKIP
+            ...     {"warm_pool": {"workstation_id": "ws-1"}}
+            ... )
+            'ws-1'
+        """
+
+        warm_hint = metadata.get("warm_pool")
+        if isinstance(warm_hint, dict):
+            value = warm_hint.get("workstation_id")
+            if isinstance(value, str):
+                stripped = value.strip()
+                if stripped:
+                    return stripped
+        return None
+
+    def _merge_warm_pool_metadata(
+        self, metadata: dict[str, Any], reservation: WarmPoolReservation
+    ) -> dict[str, Any]:
+        """Return ``metadata`` augmented with warm pool descriptors.
+
+        Args:
+            metadata: Base metadata cloned from the create payload.
+            reservation: Reservation carrying snapshot and launch environment
+                for the warm workstation.
+
+        Returns:
+            dict[str, Any]: Metadata dictionary enriched with a ``warm_pool``
+            section describing the allocated workstation.
+
+        Example:
+            >>> manager._merge_warm_pool_metadata({}, reservation)  # doctest: +SKIP
+        """
+
+        warm_metadata = {
+            "workstation_id": reservation.snapshot.workstation_id,
+            "fingerprint_id": reservation.snapshot.fingerprint_id,
+            "proxy_url": reservation.snapshot.proxy_url,
+            "launch_env": dict(reservation.environment),
+        }
+        existing = metadata.get("warm_pool")
+        if isinstance(existing, dict):
+            metadata["warm_pool"] = {**existing, **warm_metadata}
+        else:
+            metadata["warm_pool"] = warm_metadata
+        return metadata
+
+    async def _cancel_warm_reservation(self, workstation_id: str) -> None:
+        """Rollback a reserved warm slot back to ``idle`` state.
+
+        Args:
+            workstation_id: Identifier of the reserved workstation to release.
+
+        Example:
+            >>> await manager._cancel_warm_reservation("ws-1")  # doctest: +SKIP
+        """
+
+        if self._warm_pool is None:
+            return
+        with contextlib.suppress(WarmPoolStateError):
+            await self._warm_pool.cancel_reservation(workstation_id)
+
+    async def _mark_warm_slot_busy(self, workstation_id: str) -> None:
+        """Transition a reserved warm slot into the ``busy`` state.
+
+        Args:
+            workstation_id: Identifier of the reserved workstation.
+
+        Raises:
+            SessionCapacityError: If the reservation vanished before it could be
+                marked busy.
+
+        Example:
+            >>> await manager._mark_warm_slot_busy("ws-1")  # doctest: +SKIP
+        """
+
+        if self._warm_pool is None:
+            raise SessionCapacityError("warm pool is not configured")
+        try:
+            await self._warm_pool.mark_busy(workstation_id)
+        except WarmPoolStateError as exc:
+            raise SessionCapacityError(
+                f"warm workstation '{workstation_id}' is no longer reserved"
+            ) from exc
+
+    async def _release_warm_slot(self, session_id: UUID) -> None:
+        """Recycle the warm slot associated with ``session_id``.
+
+        Args:
+            session_id: Identifier of the session whose workstation should be
+                recycled.
+
+        Raises:
+            WarmPoolProvisioningError: Propagated when the recycle process fails
+                to provision a fresh workstation.
+
+        Example:
+            >>> await manager._release_warm_slot(session_id)  # doctest: +SKIP
+        """
+
+        if self._warm_pool is None:
+            return
+        workstation_id = self._warm_sessions.pop(session_id, None)
+        if workstation_id is None:
+            return
+        try:
+            await self._warm_pool.release_slot(workstation_id)
+        except WarmPoolProvisioningError as exc:
+            message = str(exc)
+            self._prewarm_failures.append(message)
+            self._last_prewarm_error = message
+            raise
 
     def _recalculate_active_sessions(
         self, previous_status: SessionStatus, current_status: SessionStatus
@@ -587,8 +764,11 @@ class SessionManager:
             >>> await manager._shutdown_browser(session_id, force=True)  # doctest: +SKIP
         """
 
+        warm_managed = session_id in self._warm_sessions
         handle = self._browser_handles.pop(session_id, None)
         if handle is None:
+            return
+        if warm_managed:
             return
         await handle.shutdown(force=force)
 
@@ -663,6 +843,7 @@ class SessionManager:
 __all__ = [
     "SessionCreatePayload",
     "SessionManager",
+    "SessionCapacityError",
     "SessionNotFoundError",
     "SessionManagerMetrics",
     "SessionUpdatePayload",

--- a/services/runner/app/warm_pool.py
+++ b/services/runner/app/warm_pool.py
@@ -44,6 +44,7 @@ __all__ = [
     "WarmPoolError",
     "WarmPoolManager",
     "WarmPoolProvisioningError",
+    "WarmPoolReservation",
     "WarmPoolSnapshot",
     "WarmPoolState",
     "WarmPoolStateError",
@@ -110,6 +111,15 @@ class WarmPoolSnapshot:
     fingerprint_id: str | None
     proxy_url: str | None
     state: WarmPoolState
+
+
+@dataclass(frozen=True)
+class WarmPoolReservation:
+    """Snapshot and browser handle returned when reserving a warm slot."""
+
+    snapshot: WarmPoolSnapshot
+    handle: BrowserSessionHandle
+    environment: dict[str, str]
 
 
 class WarmPoolManager:
@@ -202,7 +212,9 @@ class WarmPoolManager:
                     },
                 )
 
-    async def reserve_slot(self, workstation_id: str | None = None) -> WarmPoolSnapshot:
+    async def reserve_slot(
+        self, workstation_id: str | None = None
+    ) -> WarmPoolReservation:
         """Move a slot from ``idle`` to ``reserved`` for assignment.
 
         Args:
@@ -210,7 +222,8 @@ class WarmPoolManager:
                 omitted the first available idle slot is used.
 
         Returns:
-            WarmPoolSnapshot: Snapshot reflecting the ``reserved`` state.
+            WarmPoolReservation: Snapshot and handle reflecting the ``reserved``
+                state ready to be attached to a session.
 
         Raises:
             WarmPoolStateError: If the pool is draining, no idle slots exist, or
@@ -225,8 +238,17 @@ class WarmPoolManager:
                 raise WarmPoolStateError(
                     f"workstation '{slot.workstation.id}' is not idle"
                 )
+            if slot.handle is None:
+                raise WarmPoolStateError(
+                    f"workstation '{slot.workstation.id}' is not provisioned"
+                )
             slot.state = WarmPoolState.RESERVED
-            return slot.snapshot()
+            snapshot = slot.snapshot()
+            return WarmPoolReservation(
+                snapshot=snapshot,
+                handle=slot.handle,
+                environment=dict(slot.last_launch_env),
+            )
 
     async def mark_busy(self, workstation_id: str) -> WarmPoolSnapshot:
         """Transition a ``reserved`` slot into the ``busy`` state."""
@@ -238,6 +260,18 @@ class WarmPoolManager:
                     f"workstation '{workstation_id}' is not reserved"
                 )
             slot.state = WarmPoolState.BUSY
+            return slot.snapshot()
+
+    async def cancel_reservation(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Return a ``reserved`` slot back to ``idle`` without recycling."""
+
+        slot = self._require_slot(workstation_id)
+        async with slot.lock:
+            if slot.state is not WarmPoolState.RESERVED:
+                raise WarmPoolStateError(
+                    f"workstation '{workstation_id}' is not reserved"
+                )
+            slot.state = WarmPoolState.IDLE
             return slot.snapshot()
 
     async def release_slot(self, workstation_id: str) -> WarmPoolSnapshot:

--- a/services/runner/tests/test_main.py
+++ b/services/runner/tests/test_main.py
@@ -14,6 +14,7 @@ from app.dependencies.session_manager import (
 from app.events import InMemorySessionEventPublisher
 from app.main import app
 from app.session_manager import SessionCreatePayload, SessionManager
+from app.warm_pool import WarmPoolReservation, WarmPoolSnapshot, WarmPoolState, WarmPoolStateError
 from core.models import SessionVncDetails
 from httpx import AsyncClient
 
@@ -23,19 +24,6 @@ def anyio_backend() -> str:
     """Force the anyio plugin to use the asyncio backend."""
 
     return "asyncio"
-
-
-class _MainStubHandle:
-    """Minimal stub mirroring :class:`BrowserSessionHandle` for API tests."""
-
-    def __init__(self, endpoint: str, pid: int) -> None:
-        self.ws_endpoint = endpoint
-        self.pid = pid
-
-    async def shutdown(self, *, force: bool, timeout: float = 5.0) -> None:
-        """Pretend to terminate the Playwright subprocess."""
-
-        return None
 
 
 class _MainStubVncHandle:
@@ -86,30 +74,127 @@ class _ApiStubClock:
         return self._now
 
 
-@pytest.fixture
-def stub_launch_browser(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Patch session manager browser launch to avoid spawning Playwright."""
+class _MainStubBrowserHandle:
+    """Minimal stub mirroring :class:`BrowserSessionHandle` for API tests."""
 
-    counter = 0
+    def __init__(self, endpoint: str, pid: int) -> None:
+        self.ws_endpoint = endpoint
+        self.pid = pid
+        self.shutdown_calls: list[dict[str, object]] = []
 
-    async def _fake_launch(
-        settings: RunnerSettings,
-        *,
-        browser: str,
-        headless: bool,
-        env: dict[str, str] | None = None,
-    ) -> _MainStubHandle:
-        nonlocal counter
-        counter += 1
-        return _MainStubHandle(f"ws://health/{counter}", pid=4500 + counter)
+    async def shutdown(self, *, force: bool, timeout: float = 5.0) -> None:
+        """Pretend to terminate the Playwright subprocess."""
 
-    monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
+        self.shutdown_calls.append({"force": force, "timeout": timeout})
 
 
+class _MainStubWarmPool:
+    """Warm pool stub exposing idle/reserved/busy transitions."""
+
+    def __init__(self, *, workstations: list[str] | None = None) -> None:
+        self._workstations = workstations or ["ws-1", "ws-2", "ws-3"]
+        self._slots: dict[str, dict[str, object]] = {
+            workstation: {
+                "state": WarmPoolState.IDLE,
+                "fingerprint": f"fp-{workstation}",
+                "handle": _MainStubBrowserHandle(
+                    f"ws://warm/{workstation}/0", pid=5000 + idx
+                ),
+            }
+            for idx, workstation in enumerate(self._workstations)
+        }
+        self.reservations: list[str] = []
+        self.busy: list[str] = []
+        self.releases: list[str] = []
+
+    async def start(self) -> None:
+        """Warm pool stubs start instantly."""
+
+        return None
+
+    async def reserve_slot(self, workstation_id: str | None = None) -> WarmPoolReservation:
+        """Reserve the first idle slot or a specific workstation."""
+
+        if workstation_id is None:
+            workstation_id = self._first_idle()
+        slot = self._require_slot(workstation_id)
+        if slot["state"] is not WarmPoolState.IDLE:
+            raise WarmPoolStateError(f"workstation '{workstation_id}' is not idle")
+        slot["state"] = WarmPoolState.RESERVED
+        self.reservations.append(workstation_id)
+        snapshot = WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=None,
+            state=WarmPoolState.RESERVED,
+        )
+        env = {
+            "CAMOUFOX_WORKSTATION_ID": workstation_id,
+            "CAMOUFOX_FINGERPRINT_ID": slot["fingerprint"],
+        }
+        handle = slot["handle"]
+        assert isinstance(handle, _MainStubBrowserHandle)
+        return WarmPoolReservation(snapshot=snapshot, handle=handle, environment=env)
+
+    async def mark_busy(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Mark a reserved slot as busy."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] is not WarmPoolState.RESERVED:
+            raise WarmPoolStateError(f"workstation '{workstation_id}' is not reserved")
+        slot["state"] = WarmPoolState.BUSY
+        self.busy.append(workstation_id)
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=None,
+            state=WarmPoolState.BUSY,
+        )
+
+    async def cancel_reservation(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Return a reserved slot to idle when session setup fails."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] is not WarmPoolState.RESERVED:
+            raise WarmPoolStateError(f"workstation '{workstation_id}' is not reserved")
+        slot["state"] = WarmPoolState.IDLE
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=None,
+            state=WarmPoolState.IDLE,
+        )
+
+    async def release_slot(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Recycle a busy slot back to idle."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] not in {WarmPoolState.BUSY, WarmPoolState.RESERVED}:
+            raise WarmPoolStateError(
+                f"workstation '{workstation_id}' cannot be recycled from {slot['state'].value}"
+            )
+        slot["state"] = WarmPoolState.IDLE
+        self.releases.append(workstation_id)
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=None,
+            state=WarmPoolState.IDLE,
+        )
+
+    def _require_slot(self, workstation_id: str) -> dict[str, object]:
+        try:
+            return self._slots[workstation_id]
+        except KeyError as exc:  # pragma: no cover - configuration guard
+            raise WarmPoolStateError(f"unknown workstation '{workstation_id}'") from exc
+
+    def _first_idle(self) -> str:
+        for workstation_id, slot in self._slots.items():
+            if slot["state"] is WarmPoolState.IDLE:
+                return workstation_id
+        raise WarmPoolStateError("no idle warm workstations available")
 @pytest.mark.anyio("asyncio")
-async def test_health_endpoint_reports_extended_metrics(
-    stub_launch_browser: None,
-) -> None:
+async def test_health_endpoint_reports_extended_metrics() -> None:
     """``GET /health`` should expose slots, proxy, VNC, and prewarm diagnostics."""
 
     clock = _ApiStubClock(datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC))
@@ -125,12 +210,14 @@ async def test_health_endpoint_reports_extended_metrics(
         prewarm_failure_history_size=5,
     )
     publisher = InMemorySessionEventPublisher()
+    warm_pool = _MainStubWarmPool()
     manager = SessionManager(
         settings,
         publisher,
         clock=clock,
         reaper_interval_seconds=5.0,
         vnc_controller=_MainStubVncController(),
+        warm_pool_manager=warm_pool,
     )
 
     await manager.create_session(SessionCreatePayload(headless=False))
@@ -181,9 +268,7 @@ async def test_health_endpoint_reports_extended_metrics(
 
 
 @pytest.mark.anyio("asyncio")
-async def test_metrics_endpoint_exposes_prometheus_payload(
-    stub_launch_browser: None,
-) -> None:
+async def test_metrics_endpoint_exposes_prometheus_payload() -> None:
     """``GET /metrics`` should serve Prometheus-formatted metrics."""
 
     clock = _ApiStubClock(datetime(2024, 3, 3, 12, 0, 0, tzinfo=UTC))
@@ -199,6 +284,7 @@ async def test_metrics_endpoint_exposes_prometheus_payload(
         clock=clock,
         reaper_interval_seconds=5.0,
         vnc_controller=_MainStubVncController(),
+        warm_pool_manager=_MainStubWarmPool(),
     )
 
     await manager.create_session(SessionCreatePayload(headless=False))
@@ -222,9 +308,7 @@ async def test_metrics_endpoint_exposes_prometheus_payload(
 
 
 @pytest.mark.anyio("asyncio")
-async def test_touch_endpoint_extends_idle_deadline(
-    stub_launch_browser: None,
-) -> None:
+async def test_touch_endpoint_extends_idle_deadline() -> None:
     """``POST /sessions/{id}/touch`` should refresh ``last_seen_at``."""
 
     clock = _ApiStubClock(datetime(2024, 2, 2, 10, 0, 0, tzinfo=UTC))
@@ -239,6 +323,7 @@ async def test_touch_endpoint_extends_idle_deadline(
         clock=clock,
         reaper_interval_seconds=5.0,
         vnc_controller=_MainStubVncController(),
+        warm_pool_manager=_MainStubWarmPool(),
     )
     session = await manager.create_session(
         SessionCreatePayload(idle_ttl_seconds=45, headless=False)
@@ -262,3 +347,33 @@ async def test_touch_endpoint_extends_idle_deadline(
     assert body["last_seen_at"] == expected_last_seen
     metrics = await manager.get_metrics()
     assert metrics.next_idle_expiry_at == clock() + timedelta(seconds=45)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_session_returns_429_when_capacity_exhausted() -> None:
+    """API should respond with 429 when the warm pool has no idle slots."""
+
+    settings = RunnerSettings(runner_id="runner-cap", camoufox_path="/usr/bin/camoufox")
+    publisher = InMemorySessionEventPublisher()
+    warm_pool = _MainStubWarmPool(workstations=["ws-exhausted"])
+    await warm_pool.reserve_slot("ws-exhausted")
+    await warm_pool.mark_busy("ws-exhausted")
+    manager = SessionManager(
+        settings,
+        publisher,
+        vnc_controller=_MainStubVncController(),
+        warm_pool_manager=warm_pool,
+    )
+
+    app.dependency_overrides[get_runner_settings] = lambda: settings
+    app.dependency_overrides[get_event_publisher] = lambda: publisher
+    app.dependency_overrides[get_session_manager] = lambda: manager
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post("/sessions", json={})
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 429
+    assert response.json()["detail"] == "no warm workstations available"

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from typing import Callable
 
 import pytest
 from app.config import RunnerSettings
@@ -10,15 +11,155 @@ from app.events import InMemorySessionEventPublisher
 from app.metrics import METRICS_REGISTRY
 from app.session_manager import (
     SessionCreatePayload,
+    SessionCapacityError,
     SessionManager,
     SessionUpdatePayload,
 )
+from app.warm_pool import WarmPoolReservation, WarmPoolSnapshot, WarmPoolState, WarmPoolStateError
 from core.models import (
     SessionEventType,
     SessionProxySettings,
     SessionStatus,
     SessionVncDetails,
 )
+
+
+class _StubBrowserHandle:
+    """Test double mimicking :class:`BrowserSessionHandle`."""
+
+    def __init__(self, *, ws_endpoint: str, pid: int) -> None:
+        self.ws_endpoint = ws_endpoint
+        self.pid = pid
+        self.shutdown_calls: list[dict[str, object]] = []
+        self.launch_env: dict[str, str] = {}
+
+    async def shutdown(self, *, force: bool, timeout: float = 5.0) -> None:
+        """Record shutdown invocations for assertions."""
+
+        self.shutdown_calls.append({"force": force, "timeout": timeout})
+
+
+class _StubWarmPoolManager:
+    """In-memory warm pool stub returning deterministic handles."""
+
+    def __init__(self, *, workstations: list[str] | None = None) -> None:
+        self._workstations = workstations or ["ws-1", "ws-2", "ws-3"]
+        self._slots: dict[str, dict[str, object]] = {}
+        self._counter = 0
+        self.started = False
+        self.reservations: list[str] = []
+        self.cancellations: list[str] = []
+        self.busy: list[str] = []
+        self.releases: list[str] = []
+        for workstation in self._workstations:
+            self._slots[workstation] = {
+                "state": WarmPoolState.IDLE,
+                "fingerprint": f"fp-{workstation}",
+                "proxy": None,
+                "handle": self._make_handle(workstation),
+            }
+
+    async def start(self) -> None:
+        """Mark the stub as initialised."""
+
+        self.started = True
+
+    async def reserve_slot(self, workstation_id: str | None = None) -> WarmPoolReservation:
+        """Transition an idle slot into the reserved state."""
+
+        if workstation_id is None:
+            workstation_id = self._first_idle()
+        slot = self._require_slot(workstation_id)
+        if slot["state"] is not WarmPoolState.IDLE:
+            raise WarmPoolStateError(f"workstation '{workstation_id}' is not idle")
+        slot["state"] = WarmPoolState.RESERVED
+        snapshot = WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=slot["proxy"],
+            state=WarmPoolState.RESERVED,
+        )
+        env = {
+            "CAMOUFOX_WORKSTATION_ID": workstation_id,
+            "CAMOUFOX_FINGERPRINT_ID": slot["fingerprint"],
+        }
+        handle = slot["handle"]
+        assert isinstance(handle, _StubBrowserHandle)
+        handle.launch_env = dict(env)
+        self.reservations.append(workstation_id)
+        return WarmPoolReservation(snapshot=snapshot, handle=handle, environment=env)
+
+    async def mark_busy(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Record that a reserved slot is now busy."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] is not WarmPoolState.RESERVED:
+            raise WarmPoolStateError(f"workstation '{workstation_id}' is not reserved")
+        slot["state"] = WarmPoolState.BUSY
+        self.busy.append(workstation_id)
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=slot["proxy"],
+            state=WarmPoolState.BUSY,
+        )
+
+    async def cancel_reservation(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Return a reserved slot to the idle state without recycling."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] is not WarmPoolState.RESERVED:
+            raise WarmPoolStateError(f"workstation '{workstation_id}' is not reserved")
+        slot["state"] = WarmPoolState.IDLE
+        self.cancellations.append(workstation_id)
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=slot["proxy"],
+            state=WarmPoolState.IDLE,
+        )
+
+    async def release_slot(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Recycle a busy slot back into the idle pool."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] not in {WarmPoolState.BUSY, WarmPoolState.RESERVED}:
+            raise WarmPoolStateError(
+                f"workstation '{workstation_id}' cannot be recycled from {slot['state'].value}"
+            )
+        slot["state"] = WarmPoolState.RECYCLING
+        handle = slot["handle"]
+        assert isinstance(handle, _StubBrowserHandle)
+        await handle.shutdown(force=True)
+        slot["handle"] = self._make_handle(workstation_id)
+        slot["state"] = WarmPoolState.IDLE
+        self.releases.append(workstation_id)
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=slot["proxy"],
+            state=WarmPoolState.IDLE,
+        )
+
+    def _make_handle(self, workstation_id: str) -> _StubBrowserHandle:
+        handle = _StubBrowserHandle(
+            ws_endpoint=f"ws://warm/{workstation_id}/{self._counter}",
+            pid=4400 + self._counter,
+        )
+        self._counter += 1
+        return handle
+
+    def _require_slot(self, workstation_id: str) -> dict[str, object]:
+        try:
+            return self._slots[workstation_id]
+        except KeyError as exc:  # pragma: no cover - configuration guard
+            raise WarmPoolStateError(f"unknown workstation '{workstation_id}'") from exc
+
+    def _first_idle(self) -> str:
+        for workstation_id, slot in self._slots.items():
+            if slot["state"] is WarmPoolState.IDLE:
+                return workstation_id
+        raise WarmPoolStateError("no idle warm workstations available")
 
 
 @pytest.fixture
@@ -28,31 +169,25 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-@pytest.fixture
-def stub_launch_browser(
-    monkeypatch: pytest.MonkeyPatch,
-) -> list["_StubBrowserHandle"]:
-    """Patch ``launch_browser`` to return deterministic stub handles."""
+def _build_manager(
+    settings: RunnerSettings,
+    publisher: InMemorySessionEventPublisher,
+    *,
+    clock: Callable[[], datetime] | None = None,
+    vnc_controller: "_StubVncController" | None = None,
+    warm_pool: _StubWarmPoolManager | None = None,
+) -> tuple[SessionManager, _StubWarmPoolManager]:
+    """Instantiate a session manager backed by the warm pool stub."""
 
-    handles: list[_StubBrowserHandle] = []
-
-    async def _fake_launch(
-        settings: RunnerSettings,
-        *,
-        browser: str,
-        headless: bool,
-        env: dict[str, str] | None = None,
-    ) -> "_StubBrowserHandle":
-        handle = _StubBrowserHandle(
-            ws_endpoint=f"ws://stub/{browser}/{len(handles)}",
-            pid=4300 + len(handles),
-        )
-        handles.append(handle)
-        handle.launch_env = env or {}
-        return handle
-
-    monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
-    return handles
+    warm_pool = warm_pool or _StubWarmPoolManager()
+    manager = SessionManager(
+        settings,
+        publisher,
+        clock=clock,
+        vnc_controller=vnc_controller,
+        warm_pool_manager=warm_pool,
+    )
+    return manager, warm_pool
 
 
 @pytest.fixture
@@ -64,7 +199,6 @@ def stub_vnc_controller() -> _StubVncController:
 
 @pytest.mark.anyio("asyncio")
 async def test_create_session_emits_event_and_vnc_stub(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """``create_session`` should store the session and publish a CREATED event."""
@@ -78,7 +212,7 @@ async def test_create_session_emits_event_and_vnc_stub(
         vnc_token_ttl_seconds=60,
     )
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, warm_pool = _build_manager(
         settings,
         publisher,
         clock=lambda: clock_now,
@@ -100,6 +234,9 @@ async def test_create_session_emits_event_and_vnc_stub(
     assert session.vnc.token is None
     assert session.vnc.token_ttl_seconds is None
     assert str(session.vnc.http_url).startswith("http://stub-vnc/")
+    warm_meta = session.metadata.get("warm_pool", {})
+    assert warm_meta["workstation_id"] == warm_pool.reservations[0]
+    assert warm_meta["fingerprint_id"].startswith("fp-")
     events = await publisher.drain()
     assert len(events) == 1
     assert events[0].type is SessionEventType.CREATED
@@ -108,15 +245,35 @@ async def test_create_session_emits_event_and_vnc_stub(
 
 
 @pytest.mark.anyio("asyncio")
+async def test_create_session_raises_when_warm_pool_exhausted(
+    stub_vnc_controller: _StubVncController,
+) -> None:
+    """Pool exhaustion should surface as a capacity error."""
+
+    publisher = InMemorySessionEventPublisher()
+    warm_pool = _StubWarmPoolManager(workstations=["ws-only"])
+    await warm_pool.reserve_slot("ws-only")
+    await warm_pool.mark_busy("ws-only")
+    manager, _ = _build_manager(
+        RunnerSettings(runner_id="runner-capacity", camoufox_path="/usr/bin/camoufox"),
+        publisher,
+        vnc_controller=stub_vnc_controller,
+        warm_pool=warm_pool,
+    )
+
+    with pytest.raises(SessionCapacityError):
+        await manager.create_session(SessionCreatePayload())
+
+
+@pytest.mark.anyio("asyncio")
 async def test_update_session_merges_labels_and_publishes_update(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """Updates should merge labels and emit ``session.updated`` events."""
 
     clock_now = datetime(2024, 2, 2, 12, 0, 0, tzinfo=UTC)
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, _ = _build_manager(
         RunnerSettings(runner_id="runner-test", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=lambda: clock_now,
@@ -143,14 +300,13 @@ async def test_update_session_merges_labels_and_publishes_update(
 
 @pytest.mark.anyio("asyncio")
 async def test_create_session_strips_user_vnc_token(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """User-supplied VNC tokens must be removed before persisting sessions."""
 
     clock_now = datetime(2024, 4, 4, 12, 0, 0, tzinfo=UTC)
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, _ = _build_manager(
         RunnerSettings(
             runner_id="runner-token", camoufox_path="/usr/bin/camoufox"
         ),
@@ -176,14 +332,13 @@ async def test_create_session_strips_user_vnc_token(
 
 @pytest.mark.anyio("asyncio")
 async def test_update_session_strips_user_vnc_token(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """Updates attempting to inject VNC tokens are sanitised."""
 
     clock_now = datetime(2024, 5, 5, 12, 0, 0, tzinfo=UTC)
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, _ = _build_manager(
         RunnerSettings(
             runner_id="runner-update", camoufox_path="/usr/bin/camoufox"
         ),
@@ -213,14 +368,13 @@ async def test_update_session_strips_user_vnc_token(
 
 @pytest.mark.anyio("asyncio")
 async def test_end_session_sets_terminal_state_and_event(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """``end_session`` should mark the session as DEAD and send ENDED event."""
 
     clock_now = datetime(2024, 3, 3, 12, 0, 0, tzinfo=UTC)
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, warm_pool = _build_manager(
         RunnerSettings(runner_id="runner-test", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=lambda: clock_now,
@@ -232,6 +386,7 @@ async def test_end_session_sets_terminal_state_and_event(
 
     assert ended.status is SessionStatus.DEAD
     assert ended.ended_at == clock_now
+    assert warm_pool.releases == [session.metadata["warm_pool"]["workstation_id"]]
     events = await publisher.drain()
     assert [event.type for event in events] == [SessionEventType.CREATED, SessionEventType.ENDED]
     assert events[-1].reason == "completed"
@@ -239,13 +394,12 @@ async def test_end_session_sets_terminal_state_and_event(
 
 @pytest.mark.anyio("asyncio")
 async def test_metrics_track_active_sessions_and_prewarm_failures(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """Metrics should reflect active sessions and retain bounded prewarm errors."""
 
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, _ = _build_manager(
         RunnerSettings(
             runner_id="runner-metrics",
             camoufox_path="/usr/bin/camoufox",
@@ -269,7 +423,6 @@ async def test_metrics_track_active_sessions_and_prewarm_failures(
 
 @pytest.mark.anyio("asyncio")
 async def test_prometheus_metrics_follow_session_and_vnc_lifecycle(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """Prometheus gauges should mirror active sessions and VNC allocations."""
@@ -279,7 +432,7 @@ async def test_prometheus_metrics_follow_session_and_vnc_lifecycle(
         return 0.0 if value is None else value
 
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, _ = _build_manager(
         RunnerSettings(runner_id="runner-prom", camoufox_path="/usr/bin/camoufox"),
         publisher,
         vnc_controller=stub_vnc_controller,
@@ -301,14 +454,13 @@ async def test_prometheus_metrics_follow_session_and_vnc_lifecycle(
 
 @pytest.mark.anyio("asyncio")
 async def test_touch_session_updates_last_seen_and_publishes_update(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """``touch_session`` should extend TTL and emit a heartbeat update."""
 
     clock = _StubClock(datetime(2024, 6, 6, 12, 0, 0, tzinfo=UTC))
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, _ = _build_manager(
         RunnerSettings(runner_id="runner-touch", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=clock,
@@ -332,14 +484,13 @@ async def test_touch_session_updates_last_seen_and_publishes_update(
 
 @pytest.mark.anyio("asyncio")
 async def test_reap_expired_sessions_marks_session_dead_and_records_metrics(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """Idle sessions should transition to DEAD with an ``idle-timeout`` reason."""
 
     clock = _StubClock(datetime(2024, 7, 7, 12, 0, 0, tzinfo=UTC))
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, warm_pool = _build_manager(
         RunnerSettings(runner_id="runner-reap", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=clock,
@@ -369,6 +520,7 @@ async def test_reap_expired_sessions_marks_session_dead_and_records_metrics(
     assert events[-1].reason == "idle-timeout"
     metrics = await manager.get_metrics()
     assert metrics.reaper_expired_sessions == 1
+    assert warm_pool.releases == [session.metadata["warm_pool"]["workstation_id"]]
     assert metrics.reaper_total_runs == 1
     assert metrics.next_idle_expiry_at is None
     assert (
@@ -383,14 +535,13 @@ async def test_reap_expired_sessions_marks_session_dead_and_records_metrics(
 
 @pytest.mark.anyio("asyncio")
 async def test_reap_skips_recently_touched_session(
-    stub_launch_browser: list["_StubBrowserHandle"],
     stub_vnc_controller: _StubVncController,
 ) -> None:
     """Touching a session should postpone its idle deadline for reaper runs."""
 
     clock = _StubClock(datetime(2024, 8, 8, 12, 0, 0, tzinfo=UTC))
     publisher = InMemorySessionEventPublisher()
-    manager = SessionManager(
+    manager, _ = _build_manager(
         RunnerSettings(runner_id="runner-skip", camoufox_path="/usr/bin/camoufox"),
         publisher,
         clock=clock,
@@ -417,23 +568,6 @@ async def test_reap_skips_recently_touched_session(
         metrics_after_touch.next_idle_expiry_at
         == touched.last_seen_at + timedelta(seconds=40)
     )
-
-
-class _StubBrowserHandle:
-    """Test double mimicking :class:`BrowserSessionHandle`."""
-
-    def __init__(self, *, ws_endpoint: str, pid: int | None = 4312) -> None:
-        self.ws_endpoint = ws_endpoint
-        self.pid = pid
-        self.shutdown_calls: list[dict[str, object]] = []
-        self.launch_env: dict[str, str] = {}
-
-    async def shutdown(self, *, force: bool, timeout: float = 5.0) -> None:
-        """Record shutdown invocations for assertions."""
-
-        self.shutdown_calls.append({"force": force, "timeout": timeout})
-
-
 class _StubClock:
     """Mutable clock fixture to deterministically advance time in tests."""
 
@@ -493,69 +627,40 @@ class _StubVncController:
 
 
 @pytest.mark.anyio("asyncio")
-async def test_create_session_launches_browser(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Browser launch helper should provide the ws endpoint and metadata."""
+async def test_create_session_uses_warm_pool_handle() -> None:
+    """Sessions should reuse warm pool handles and enrich metadata."""
 
-    stub_handle = _StubBrowserHandle(ws_endpoint="ws://playwright.test/session")
-    launch_calls: list[tuple[str, bool]] = []
-
-    async def _fake_launch(
-        settings: RunnerSettings,
-        *,
-        browser: str,
-        headless: bool,
-        env: dict[str, str] | None = None,
-    ):
-        launch_calls.append((browser, headless))
-        stub_handle.launch_env = env or {}
-        return stub_handle
-
-    monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
     publisher = InMemorySessionEventPublisher()
-    stub_vnc = _StubVncController()
-    manager = SessionManager(
+    warm_pool = _StubWarmPoolManager(workstations=["ws-meta"])
+    manager, warm_pool = _build_manager(
         RunnerSettings(runner_id="runner-browser", camoufox_path="/usr/bin/camoufox"),
         publisher,
-        vnc_controller=stub_vnc,
+        warm_pool=warm_pool,
     )
 
     session = await manager.create_session(
         SessionCreatePayload(headless=True, metadata={"flow": "launch-test"})
     )
 
-    assert launch_calls == [("camoufox", True)]
-    assert session.ws_endpoint == "ws://playwright.test/session"
-    assert session.metadata["flow"] == "launch-test"
-    assert session.metadata["runner_browser_pid"] == stub_handle.pid
+    warm_info = session.metadata["warm_pool"]
+    assert warm_info["workstation_id"] == "ws-meta"
+    assert warm_pool.busy == ["ws-meta"]
     stored_handle = manager._browser_handles[session.id]
-    assert stored_handle is stub_handle
+    assert stored_handle.ws_endpoint.startswith("ws://warm/ws-meta/")
     events = await publisher.drain()
     assert [event.type for event in events] == [SessionEventType.CREATED]
 
 
 @pytest.mark.anyio("asyncio")
-async def test_update_session_cleans_up_browser(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Transitioning to DEAD should teardown the launched Playwright process."""
+async def test_update_session_cleans_up_browser() -> None:
+    """Transitioning to DEAD should recycle the warm workstation and clear state."""
 
-    stub_handle = _StubBrowserHandle(ws_endpoint="ws://playwright.test/cleanup")
-
-    async def _fake_launch(
-        settings: RunnerSettings,
-        *,
-        browser: str,
-        headless: bool,
-        env: dict[str, str] | None = None,
-    ):
-        stub_handle.launch_env = env or {}
-        return stub_handle
-
-    monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
     publisher = InMemorySessionEventPublisher()
-    stub_vnc = _StubVncController()
-    manager = SessionManager(
+    warm_pool = _StubWarmPoolManager(workstations=["ws-cleanup"])
+    manager, warm_pool = _build_manager(
         RunnerSettings(runner_id="runner-cleanup", camoufox_path="/usr/bin/camoufox"),
         publisher,
-        vnc_controller=stub_vnc,
+        warm_pool=warm_pool,
     )
     session = await manager.create_session(SessionCreatePayload())
 
@@ -566,8 +671,8 @@ async def test_update_session_cleans_up_browser(monkeypatch: pytest.MonkeyPatch)
 
     assert updated.status is SessionStatus.DEAD
     assert updated.ws_endpoint is None
-    assert stub_handle.shutdown_calls == [{"force": True, "timeout": 5.0}]
     assert session.id not in manager._browser_handles
+    assert warm_pool.releases == ["ws-cleanup"]
     events = await publisher.drain()
     assert [event.type for event in events] == [
         SessionEventType.CREATED,
@@ -577,31 +682,24 @@ async def test_update_session_cleans_up_browser(monkeypatch: pytest.MonkeyPatch)
 
 
 @pytest.mark.anyio("asyncio")
-async def test_create_session_rolls_back_on_launch_failure(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Session creation should not persist state when browser launch fails."""
+async def test_create_session_rolls_back_on_mark_busy_failure() -> None:
+    """Session creation should not persist state when warm slot activation fails."""
 
-    async def _failing_launch(
-        settings: RunnerSettings,
-        *,
-        browser: str,
-        headless: bool,
-        env: dict[str, str] | None = None,
-    ):
-        raise RuntimeError("launch boom")
+    class _FailingWarmPool(_StubWarmPoolManager):
+        async def mark_busy(self, workstation_id: str) -> WarmPoolSnapshot:  # type: ignore[override]
+            raise WarmPoolStateError("slot lost")
 
-    monkeypatch.setattr("app.session_manager.launch_browser", _failing_launch)
     publisher = InMemorySessionEventPublisher()
-    stub_vnc = _StubVncController()
-    manager = SessionManager(
+    warm_pool = _FailingWarmPool(workstations=["ws-fail"])
+    manager, warm_pool = _build_manager(
         RunnerSettings(runner_id="runner-fail", camoufox_path="/usr/bin/camoufox"),
         publisher,
-        vnc_controller=stub_vnc,
+        warm_pool=warm_pool,
     )
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(SessionCapacityError):
         await manager.create_session(SessionCreatePayload())
 
     assert manager._browser_handles == {}
+    assert warm_pool.busy == []
     assert await publisher.drain() == []

--- a/services/runner/tests/test_warm_pool.py
+++ b/services/runner/tests/test_warm_pool.py
@@ -122,8 +122,43 @@ async def test_start_provisions_slots_with_env_and_prewarm(tmp_path: Path) -> No
     assert nav_calls[0][2] == str(settings.start_url)
     assert sleep_calls == [1.5]
 
-    reserved = await manager.reserve_slot()
-    assert reserved.state is WarmPoolState.RESERVED
+    reservation = await manager.reserve_slot()
+    assert reservation.snapshot.state is WarmPoolState.RESERVED
+    assert reservation.environment["CAMOUFOX_WORKSTATION_ID"] == "ws-1"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_cancel_reservation_returns_slot_to_idle(tmp_path: Path) -> None:
+    """Cancelling a reservation should return the workstation to idle."""
+
+    settings = RunnerSettings(runner_id="runner", camoufox_path="/usr/bin/camoufox")
+    config = WarmPoolConfig(workstations=[WorkstationConfigEntry(id="ws-1")])
+
+    async def launcher(
+        settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        env: dict[str, str],
+    ) -> _StubHandle:
+        del settings, browser, headless
+        handle = _StubHandle(0)
+        handle.launch_env = dict(env)
+        return handle
+
+    manager = WarmPoolManager(
+        settings,
+        warm_pool_config=config,
+        launcher=launcher,  # type: ignore[arg-type]
+    )
+
+    await manager.start()
+    reservation = await manager.reserve_slot("ws-1")
+    assert reservation.snapshot.state is WarmPoolState.RESERVED
+    snapshot = await manager.cancel_reservation("ws-1")
+    assert snapshot.state is WarmPoolState.IDLE
+    follow_up = await manager.reserve_slot("ws-1")
+    assert follow_up.snapshot.state is WarmPoolState.RESERVED
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- reserve warm pool slots when creating sessions and reuse existing browser handles and metadata
- wire the warm pool manager into the runner dependencies and surface capacity exhaustion as HTTP 429
- extend warm pool lifecycle helpers and refresh the unit tests to cover reservations, recycling, and API integration

## Testing
- `PYTHONPATH=. poetry run pytest tests/test_session_manager.py -q` (pass)
- `PYTHONPATH=. poetry run pytest -q` (pass)

## Security
- No security concerns introduced; changes stay within internal session management workflows.

------
https://chatgpt.com/codex/tasks/task_e_68de4b7dba88832aa1a8e119bda47682