### PR TITLE
Add integration tests for workstations API

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -21,6 +21,11 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
     runner-а: `runner_active_sessions`, `runner_reaper_runs_total`,
     `runner_reaper_expired_sessions_total`, `runner_reaper_last_run_timestamp`,
     `runner_vnc_allocations`, `runner_vnc_allocation_requests_total`.
+  - `GET /workstations` — возвращает снимки состояния warm-пула (idle/reserved/busy).
+  - `POST /workstations/reserve` — резервирует слот (по ID или первый idle) и отдаёт launch env.
+  - `POST /workstations/{id}/busy` — переводит слот из reserved в busy.
+  - `POST /workstations/{id}/cancel` — откатывает неудачное резервирование в idle.
+  - `POST /workstations/{id}/release` — рециклирует busy слот обратно в idle.
 - **Event transport**
   - `SessionEventPublisher.publish(SessionEvent)` — protocol for pushing lifecycle events downstream. Default implementation stores events in memory (`InMemorySessionEventPublisher`) but can be swapped for HTTP/SSE bridges via `CallbackSessionEventPublisher`.
   - `HttpSessionEventPublisher` — при наличии `RunnerSettings.event_endpoint` POST-ит события на `gateway /events`.
@@ -45,6 +50,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 ## Decisions
 - **In-memory publisher**: Стандартный транспорт построен на `InMemorySessionEventPublisher` и считается продукционным решением; при необходимости можно оборачивать его через `CallbackSessionEventPublisher` для сторонних интеграций без отказа от in-memory ядра.
 - **HTTP publisher toggle**: `get_event_publisher` читает `RunnerSettings.event_endpoint` и, если URL задан, использует `HttpSessionEventPublisher`, публикующий события в Gateway через `POST /events`.
+- **Workstation events**: маршруты `/workstations` используют `WorkstationEventPublisher` (по умолчанию `InMemoryWorkstationEventPublisher`) и транслируют `WorkstationEvent` для синхронизации warm-пула с Gateway/UI.
 - **Camoufox stub dependency**: Для unit-тестов в CI runner использует локальный путь-зависимость `packages/camoufox`, реализующую CLI/API-совместимый stub. Это позволяет выполнять `poetry install` без доступа к проприетарному пакету.
 - **Process-backed VNC controller**: Non-headless sessions allocate Xvfb/x11vnc/websockify helpers via `ProcessVncController`. The controller maintains a bounded pool of displays and ports, composes public HTTP/WS URLs from `RunnerSettings`, and tears down helpers whenever sessions terminate or switch to headless mode.
 - **Gateway-signed VNC tokens**: Runner never persists VNC `token` or `token_ttl_seconds`; any user-supplied values are stripped and synthetic descriptors leave them `None` so that the gateway can issue signed credentials.
@@ -91,6 +97,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - `poetry run ruff check .`
 - Таргетно: `PYTHONPATH=. poetry run pytest services/runner/tests/test_config_warm_pool.py -q`
 - Таргетно: `PYTHONPATH=. poetry run pytest services/runner/tests/test_warm_pool.py -q`
+- Таргетно: `PYTHONPATH=. poetry run pytest services/runner/tests/test_workstations_api.py -q`
 
 ## Changelog (for agents)
 - 2024-09-22 · OpenAI ChatGPT · Расширен `/health`, добавлены метрики/история prewarm, новые настройки и модульные тесты.
@@ -107,3 +114,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-15 · gpt-5-codex · Добавлены warm pool-конфиги (JSON), загрузка при старте, новые настройки и модульные тесты на валидацию/парсинг.
 - 2025-10-16 · gpt-5-codex · Реализован ``WarmPoolManager`` с управлением состояниями, recycle, преднавигацией и юнит-тестами на ключевые сценарии.
 - 2025-10-17 · gpt-5-codex · Интегрирован warm pool в `SessionManager`/API, добавлен отклик 429 при нехватке слотов и покрытие тестами.
+- 2025-10-18 · gpt-5-codex · Добавлены REST-эндпоинты `/workstations*`, in-memory издатель `WorkstationEvent` и интеграционные тесты API.

--- a/services/runner/app/dependencies/__init__.py
+++ b/services/runner/app/dependencies/__init__.py
@@ -5,6 +5,8 @@ from .session_manager import (
     get_runner_settings,
     get_session_manager,
     get_vnc_controller,
+    get_warm_pool_manager,
+    get_workstation_event_publisher,
 )
 
 __all__ = [
@@ -12,4 +14,6 @@ __all__ = [
     "get_runner_settings",
     "get_session_manager",
     "get_vnc_controller",
+    "get_warm_pool_manager",
+    "get_workstation_event_publisher",
 ]

--- a/services/runner/app/dependencies/session_manager.py
+++ b/services/runner/app/dependencies/session_manager.py
@@ -9,7 +9,9 @@ from ..config import RunnerSettings
 from ..events import (
     HttpSessionEventPublisher,
     InMemorySessionEventPublisher,
+    InMemoryWorkstationEventPublisher,
     SessionEventPublisher,
+    WorkstationEventPublisher,
 )
 from ..session_manager import SessionManager
 from ..warm_pool import WarmPoolManager
@@ -33,6 +35,13 @@ def get_event_publisher() -> SessionEventPublisher:
     if settings.event_endpoint is not None:
         return HttpSessionEventPublisher(str(settings.event_endpoint))
     return InMemorySessionEventPublisher()
+
+
+@lru_cache
+def get_workstation_event_publisher() -> WorkstationEventPublisher:
+    """Return an in-memory publisher for workstation lifecycle events."""
+
+    return InMemoryWorkstationEventPublisher()
 
 
 @lru_cache
@@ -71,6 +80,7 @@ def get_warm_pool_manager() -> WarmPoolManager:
 __all__ = [
     "get_event_publisher",
     "get_runner_settings",
+    "get_workstation_event_publisher",
     "get_warm_pool_manager",
     "get_session_manager",
     "get_vnc_controller",

--- a/services/runner/app/events.py
+++ b/services/runner/app/events.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+"""Event publisher abstractions for session and workstation lifecycles."""
+
 from typing import Protocol
 
 import anyio
 import httpx
-from core.models import SessionEvent
+from core.models import SessionEvent, WorkstationEvent
 
 
 class SessionEventPublisher(Protocol):
@@ -39,6 +41,35 @@ class InMemorySessionEventPublisher:
 
     async def drain(self) -> list[SessionEvent]:
         """Return and clear the buffered events in FIFO order."""
+
+        async with self._lock:
+            drained = list(self._events)
+            self._events.clear()
+            return drained
+
+
+class WorkstationEventPublisher(Protocol):
+    """Protocol describing transports for workstation lifecycle events."""
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Forward ``event`` to downstream consumers."""
+
+
+class InMemoryWorkstationEventPublisher:
+    """Collect workstation events in FIFO order for deterministic tests."""
+
+    def __init__(self) -> None:
+        self._events: list[WorkstationEvent] = []
+        self._lock = anyio.Lock()
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Append ``event`` to the buffer in a concurrency-safe manner."""
+
+        async with self._lock:
+            self._events.append(event)
+
+    async def drain(self) -> list[WorkstationEvent]:
+        """Return and clear buffered events atomically."""
 
         async with self._lock:
             drained = list(self._events)
@@ -131,5 +162,7 @@ __all__ = [
     "CallbackSessionEventPublisher",
     "HttpSessionEventPublisher",
     "InMemorySessionEventPublisher",
+    "InMemoryWorkstationEventPublisher",
     "SessionEventPublisher",
+    "WorkstationEventPublisher",
 ]

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -2,16 +2,27 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Any
 from uuid import UUID
 
-from core.models import Session
+from core.models import (
+    Session,
+    WorkstationEvent,
+    WorkstationEventType,
+    WorkstationMeta,
+    WorkstationState,
+)
 from fastapi import Depends, FastAPI, HTTPException, Response, status
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
 from .config import RunnerSettings
-from .dependencies import get_runner_settings, get_session_manager
+from .dependencies import (
+    get_runner_settings,
+    get_session_manager,
+    get_warm_pool_manager,
+    get_workstation_event_publisher,
+)
 from .metrics import METRICS_REGISTRY
 from .session_manager import (
     SessionCreatePayload,
@@ -20,6 +31,9 @@ from .session_manager import (
     SessionNotFoundError,
     SessionUpdatePayload,
 )
+from .warm_pool import WarmPoolManager, WarmPoolSnapshot, WarmPoolState, WarmPoolStateError
+from .events import WorkstationEventPublisher
+from pydantic import BaseModel, Field
 
 app = FastAPI(title="Ghost Browsers Runner", version="0.1.0")
 
@@ -55,6 +69,19 @@ def _normalise_base_url(url: Any | None) -> str | None:
 
 RunnerSettingsDep = Annotated[RunnerSettings, Depends(get_runner_settings)]
 SessionManagerDep = Annotated[SessionManager, Depends(get_session_manager)]
+WarmPoolManagerDep = Annotated[WarmPoolManager, Depends(get_warm_pool_manager)]
+WorkstationEventPublisherDep = Annotated[
+    WorkstationEventPublisher, Depends(get_workstation_event_publisher)
+]
+
+_WARM_TO_PUBLIC_STATE: dict[WarmPoolState, WorkstationState] = {
+    WarmPoolState.IDLE: WorkstationState.AVAILABLE,
+    WarmPoolState.RESERVED: WorkstationState.PROVISIONING,
+    WarmPoolState.BUSY: WorkstationState.ASSIGNED,
+    WarmPoolState.RECYCLING: WorkstationState.PROVISIONING,
+    WarmPoolState.DRAINING: WorkstationState.UNAVAILABLE,
+    WarmPoolState.ERROR: WorkstationState.UNAVAILABLE,
+}
 
 
 def _isoformat_or_none(value: datetime | None) -> str | None:
@@ -74,6 +101,78 @@ def _isoformat_or_none(value: datetime | None) -> str | None:
     if value is None:
         return None
     return value.isoformat()
+
+
+def _serialise_snapshot(snapshot: WarmPoolSnapshot) -> dict[str, Any]:
+    """Return a JSON payload describing the warm workstation snapshot."""
+
+    return {
+        "workstation_id": snapshot.workstation_id,
+        "fingerprint_id": snapshot.fingerprint_id,
+        "proxy_url": snapshot.proxy_url,
+        "state": snapshot.state.value,
+    }
+
+
+def _translate_state_error(exc: WarmPoolStateError) -> HTTPException:
+    """Translate warm pool state errors into FastAPI HTTP exceptions."""
+
+    message = str(exc)
+    lowered = message.lower()
+    status_code = status.HTTP_409_CONFLICT
+    if "unknown workstation" in lowered:
+        status_code = status.HTTP_404_NOT_FOUND
+    return HTTPException(status_code=status_code, detail=message)
+
+
+def _build_workstation_meta(
+    snapshot: WarmPoolSnapshot,
+    *,
+    metadata: dict[str, Any] | None = None,
+) -> WorkstationMeta:
+    """Construct :class:`WorkstationMeta` for event payloads."""
+
+    merged_metadata: dict[str, Any] = {}
+    if metadata:
+        merged_metadata.update(metadata)
+    if snapshot.proxy_url:
+        merged_metadata.setdefault("proxy_url", snapshot.proxy_url)
+    fingerprint = snapshot.fingerprint_id or "unknown"
+    return WorkstationMeta(
+        id=snapshot.workstation_id,
+        fingerprint_id=fingerprint,
+        state=_WARM_TO_PUBLIC_STATE.get(snapshot.state, WorkstationState.UNAVAILABLE),
+        proxy_summary=snapshot.proxy_url,
+        metadata=merged_metadata,
+    )
+
+
+async def _publish_workstation_event(
+    publisher: WorkstationEventPublisher,
+    snapshot: WarmPoolSnapshot,
+    *,
+    reason: str,
+    metadata: dict[str, Any] | None = None,
+    event_type: WorkstationEventType = WorkstationEventType.UPDATED,
+) -> None:
+    """Publish a workstation lifecycle event through ``publisher``."""
+
+    event = WorkstationEvent(
+        type=event_type,
+        workstation=_build_workstation_meta(snapshot, metadata=metadata),
+        occurred_at=datetime.now(UTC),
+        reason=reason,
+    )
+    await publisher.publish(event)
+
+
+class WorkstationReservationRequest(BaseModel):
+    """Input model used by :func:`reserve_workstation`."""
+
+    workstation_id: str | None = Field(
+        default=None,
+        description="Identifier of the workstation to reserve when specified.",
+    )
 
 
 @app.get("/health", summary="Runner health probe")
@@ -119,6 +218,112 @@ async def health(
             },
         },
     }
+
+
+@app.get("/workstations", summary="List warm workstation slots")
+async def list_workstations(manager: WarmPoolManagerDep) -> list[dict[str, Any]]:
+    """Return snapshots describing all configured warm workstations."""
+
+    return [_serialise_snapshot(snapshot) for snapshot in manager.list_slots()]
+
+
+@app.post(
+    "/workstations/reserve",
+    summary="Reserve an idle workstation",
+)
+async def reserve_workstation(
+    payload: WorkstationReservationRequest,
+    warm_pool: WarmPoolManagerDep,
+    publisher: WorkstationEventPublisherDep,
+) -> dict[str, Any]:
+    """Reserve a warm workstation slot and publish an event."""
+
+    try:
+        reservation = await warm_pool.reserve_slot(payload.workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    snapshot = reservation.snapshot
+    environment = dict(reservation.environment)
+    await _publish_workstation_event(
+        publisher,
+        snapshot,
+        reason="reserved",
+        metadata={"launch_env": environment},
+    )
+    return {
+        "snapshot": _serialise_snapshot(snapshot),
+        "environment": environment,
+    }
+
+
+@app.post(
+    "/workstations/{workstation_id}/busy",
+    summary="Mark a reserved workstation as busy",
+)
+async def mark_workstation_busy(
+    workstation_id: str,
+    warm_pool: WarmPoolManagerDep,
+    publisher: WorkstationEventPublisherDep,
+) -> dict[str, Any]:
+    """Transition ``workstation_id`` from reserved to busy state."""
+
+    try:
+        snapshot = await warm_pool.mark_busy(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    await _publish_workstation_event(
+        publisher,
+        snapshot,
+        reason="busy",
+    )
+    return {"snapshot": _serialise_snapshot(snapshot)}
+
+
+@app.post(
+    "/workstations/{workstation_id}/cancel",
+    summary="Cancel a workstation reservation",
+)
+async def cancel_workstation_reservation(
+    workstation_id: str,
+    warm_pool: WarmPoolManagerDep,
+    publisher: WorkstationEventPublisherDep,
+) -> dict[str, Any]:
+    """Return ``workstation_id`` to idle when reservation setup fails."""
+
+    try:
+        snapshot = await warm_pool.cancel_reservation(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    await _publish_workstation_event(
+        publisher,
+        snapshot,
+        reason="cancelled",
+    )
+    return {"snapshot": _serialise_snapshot(snapshot)}
+
+
+@app.post(
+    "/workstations/{workstation_id}/release",
+    summary="Release a busy workstation",
+)
+async def release_workstation(
+    workstation_id: str,
+    warm_pool: WarmPoolManagerDep,
+    publisher: WorkstationEventPublisherDep,
+) -> dict[str, Any]:
+    """Recycle ``workstation_id`` back to the idle pool and emit an event."""
+
+    try:
+        snapshot = await warm_pool.release_slot(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    await _publish_workstation_event(
+        publisher,
+        snapshot,
+        reason="released",
+        event_type=WorkstationEventType.RELEASED,
+    )
+    return {"snapshot": _serialise_snapshot(snapshot)}
 
 
 @app.post(

--- a/services/runner/tests/test_workstations_api.py
+++ b/services/runner/tests/test_workstations_api.py
@@ -1,0 +1,476 @@
+"""Integration tests covering the warm workstation management API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from app.dependencies.session_manager import (
+    get_warm_pool_manager,
+    get_workstation_event_publisher,
+)
+from app.events import InMemoryWorkstationEventPublisher
+from app.main import app
+from app.warm_pool import (
+    WarmPoolReservation,
+    WarmPoolSnapshot,
+    WarmPoolState,
+    WarmPoolStateError,
+)
+from core.models import WorkstationEventType, WorkstationState
+from httpx import AsyncClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Force pytest-anyio to use asyncio for FastAPI integration tests."""
+
+    return "asyncio"
+
+
+class _StubWarmHandle:
+    """Minimal placeholder representing a warm workstation browser handle."""
+
+    def __init__(self, workstation_id: str) -> None:
+        self.workstation_id = workstation_id
+
+
+class _StubWarmPoolManager:
+    """Async test double implementing the warm pool interface."""
+
+    def __init__(self, *, workstations: list[str] | None = None) -> None:
+        self._workstations = workstations or ["ws-1", "ws-2", "ws-3"]
+        self._slots: dict[str, dict[str, Any]] = {
+            workstation: {
+                "state": WarmPoolState.IDLE,
+                "fingerprint": f"fp-{workstation}",
+                "proxy": None,
+            }
+            for workstation in self._workstations
+        }
+        self.reservations: list[str] = []
+        self.busy: list[str] = []
+        self.cancellations: list[str] = []
+        self.releases: list[str] = []
+
+    async def start(self) -> None:
+        """Real manager initialises slots; stub does nothing."""
+
+        return None
+
+    def list_slots(self) -> list[WarmPoolSnapshot]:
+        """Return current slot snapshots for the warm pool."""
+
+        return [
+            WarmPoolSnapshot(
+                workstation_id=workstation,
+                fingerprint_id=slot["fingerprint"],
+                proxy_url=slot["proxy"],
+                state=slot["state"],
+            )
+            for workstation, slot in self._slots.items()
+        ]
+
+    async def reserve_slot(
+        self, workstation_id: str | None = None
+    ) -> WarmPoolReservation:
+        """Reserve the requested workstation or the first idle slot."""
+
+        target = workstation_id or self._first_idle()
+        slot = self._require_slot(target)
+        if slot["state"] is not WarmPoolState.IDLE:
+            raise WarmPoolStateError(f"workstation '{target}' is not idle")
+        slot["state"] = WarmPoolState.RESERVED
+        self.reservations.append(target)
+        snapshot = WarmPoolSnapshot(
+            workstation_id=target,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=slot["proxy"],
+            state=WarmPoolState.RESERVED,
+        )
+        env = {
+            "CAMOUFOX_WORKSTATION_ID": target,
+            "CAMOUFOX_FINGERPRINT_ID": slot["fingerprint"],
+        }
+        return WarmPoolReservation(
+            snapshot=snapshot,
+            handle=_StubWarmHandle(target),
+            environment=env,
+        )
+
+    async def mark_busy(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Mark a reserved workstation as busy."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] is not WarmPoolState.RESERVED:
+            raise WarmPoolStateError(f"workstation '{workstation_id}' is not reserved")
+        slot["state"] = WarmPoolState.BUSY
+        self.busy.append(workstation_id)
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=slot["proxy"],
+            state=WarmPoolState.BUSY,
+        )
+
+    async def cancel_reservation(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Return a reserved workstation to idle."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] is not WarmPoolState.RESERVED:
+            raise WarmPoolStateError(f"workstation '{workstation_id}' is not reserved")
+        slot["state"] = WarmPoolState.IDLE
+        self.cancellations.append(workstation_id)
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=slot["proxy"],
+            state=WarmPoolState.IDLE,
+        )
+
+    async def release_slot(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Recycle a busy workstation back to idle."""
+
+        slot = self._require_slot(workstation_id)
+        if slot["state"] not in {WarmPoolState.BUSY, WarmPoolState.RESERVED}:
+            raise WarmPoolStateError(
+                f"workstation '{workstation_id}' cannot be recycled from {slot['state'].value}"
+            )
+        slot["state"] = WarmPoolState.IDLE
+        self.releases.append(workstation_id)
+        return WarmPoolSnapshot(
+            workstation_id=workstation_id,
+            fingerprint_id=slot["fingerprint"],
+            proxy_url=slot["proxy"],
+            state=WarmPoolState.IDLE,
+        )
+
+    def _require_slot(self, workstation_id: str) -> dict[str, Any]:
+        try:
+            return self._slots[workstation_id]
+        except KeyError as exc:
+            raise WarmPoolStateError(
+                f"unknown workstation '{workstation_id}'"
+            ) from exc
+
+    def _first_idle(self) -> str:
+        for workstation_id, slot in self._slots.items():
+            if slot["state"] is WarmPoolState.IDLE:
+                return workstation_id
+        raise WarmPoolStateError("no idle warm workstations available")
+
+
+async def _override_dependencies(
+    warm_pool: _StubWarmPoolManager,
+    publisher: InMemoryWorkstationEventPublisher,
+) -> None:
+    """Replace warm pool and event publisher dependencies for the test scope."""
+
+    get_warm_pool_manager.cache_clear()
+    get_workstation_event_publisher.cache_clear()
+    app.dependency_overrides[get_warm_pool_manager] = lambda: warm_pool
+    app.dependency_overrides[get_workstation_event_publisher] = lambda: publisher
+
+
+def _reset_overrides() -> None:
+    """Clear FastAPI dependency overrides set for integration tests."""
+
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reserve_workstation_success() -> None:
+    """``POST /workstations/reserve`` should reserve a slot and emit an event."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-alpha"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post(
+                "/workstations/reserve", json={"workstation_id": "ws-alpha"}
+            )
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["snapshot"]["workstation_id"] == "ws-alpha"
+    assert body["snapshot"]["state"] == WarmPoolState.RESERVED.value
+    assert body["environment"] == {
+        "CAMOUFOX_WORKSTATION_ID": "ws-alpha",
+        "CAMOUFOX_FINGERPRINT_ID": "fp-ws-alpha",
+    }
+    assert warm_pool.reservations == ["ws-alpha"]
+    events = await publisher.drain()
+    assert len(events) == 1
+    event = events[0]
+    assert event.type is WorkstationEventType.UPDATED
+    assert event.reason == "reserved"
+    assert event.workstation.id == "ws-alpha"
+    assert event.workstation.state is WorkstationState.PROVISIONING
+    assert event.workstation.metadata["launch_env"] == body["environment"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reserve_workstation_conflict_when_not_idle() -> None:
+    """Reserving an already reserved workstation should return HTTP 409."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-beta"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            first = await client.post(
+                "/workstations/reserve", json={"workstation_id": "ws-beta"}
+            )
+            assert first.status_code == 200
+            response = await client.post(
+                "/workstations/reserve", json={"workstation_id": "ws-beta"}
+            )
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 409
+    assert "not idle" in response.json()["detail"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reserve_workstation_unknown_identifier() -> None:
+    """Unknown workstations should surface as HTTP 404 responses."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-known"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post(
+                "/workstations/reserve", json={"workstation_id": "ws-missing"}
+            )
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 404
+    assert response.json()["detail"].startswith("unknown workstation")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_mark_workstation_busy_success() -> None:
+    """``POST /workstations/{id}/busy`` should transition to busy and emit an event."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-busy"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            reserve = await client.post(
+                "/workstations/reserve", json={"workstation_id": "ws-busy"}
+            )
+            assert reserve.status_code == 200
+            response = await client.post("/workstations/ws-busy/busy")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["snapshot"]["state"] == WarmPoolState.BUSY.value
+    assert warm_pool.busy == ["ws-busy"]
+    events = await publisher.drain()
+    assert [event.reason for event in events][-1] == "busy"
+    assert events[-1].workstation.state is WorkstationState.ASSIGNED
+
+
+@pytest.mark.anyio("asyncio")
+async def test_mark_workstation_busy_conflict_when_idle() -> None:
+    """Marking a workstation busy without a reservation should fail with 409."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-idle"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post("/workstations/ws-idle/busy")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 409
+    assert "not reserved" in response.json()["detail"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_mark_workstation_busy_unknown_identifier() -> None:
+    """Busy endpoint should return 404 for unknown workstations."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-catalog"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post("/workstations/ws-absent/busy")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 404
+    assert response.json()["detail"].startswith("unknown workstation")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_cancel_reservation_success() -> None:
+    """Cancelling a reservation should return the workstation to idle."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-cancel"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            reserve = await client.post(
+                "/workstations/reserve", json={"workstation_id": "ws-cancel"}
+            )
+            assert reserve.status_code == 200
+            response = await client.post("/workstations/ws-cancel/cancel")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["snapshot"]["state"] == WarmPoolState.IDLE.value
+    assert warm_pool.cancellations == ["ws-cancel"]
+    events = await publisher.drain()
+    assert events[-1].reason == "cancelled"
+    assert events[-1].workstation.state is WorkstationState.AVAILABLE
+
+
+@pytest.mark.anyio("asyncio")
+async def test_cancel_reservation_conflict_when_idle() -> None:
+    """Cancelling a workstation without a reservation should raise HTTP 409."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-free"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post("/workstations/ws-free/cancel")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 409
+    assert "not reserved" in response.json()["detail"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_cancel_reservation_unknown_identifier() -> None:
+    """Cancel endpoint should surface unknown workstations as HTTP 404."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-list"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post("/workstations/ws-missing/cancel")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 404
+    assert response.json()["detail"].startswith("unknown workstation")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_release_workstation_success() -> None:
+    """Releasing a busy workstation should recycle the slot and emit events."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-release"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            reserve = await client.post(
+                "/workstations/reserve", json={"workstation_id": "ws-release"}
+            )
+            assert reserve.status_code == 200
+            busy = await client.post("/workstations/ws-release/busy")
+            assert busy.status_code == 200
+            response = await client.post("/workstations/ws-release/release")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 200
+    assert response.json()["snapshot"]["state"] == WarmPoolState.IDLE.value
+    assert warm_pool.releases == ["ws-release"]
+    events = await publisher.drain()
+    assert events[-1].reason == "released"
+    assert events[-1].type is WorkstationEventType.RELEASED
+    assert events[-1].workstation.state is WorkstationState.AVAILABLE
+
+
+@pytest.mark.anyio("asyncio")
+async def test_release_workstation_conflict_when_idle() -> None:
+    """Releasing an idle workstation should report HTTP 409."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-idle-release"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post("/workstations/ws-idle-release/release")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 409
+    assert "cannot be recycled" in response.json()["detail"]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_release_workstation_unknown_identifier() -> None:
+    """Release endpoint should return HTTP 404 for unknown identifiers."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-known-release"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.post("/workstations/ws-ghost/release")
+    finally:
+        _reset_overrides()
+
+    assert response.status_code == 404
+    assert response.json()["detail"].startswith("unknown workstation")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_workstation_event_stream_tracks_full_lifecycle() -> None:
+    """A full reserve → busy → release flow should emit ordered events."""
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-flow"])
+    publisher = InMemoryWorkstationEventPublisher()
+    await _override_dependencies(warm_pool, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            await client.post("/workstations/reserve", json={"workstation_id": "ws-flow"})
+            await client.post("/workstations/ws-flow/busy")
+            await client.post("/workstations/ws-flow/release")
+    finally:
+        _reset_overrides()
+
+    events = await publisher.drain()
+    assert [event.reason for event in events] == ["reserved", "busy", "released"]
+    assert [event.type for event in events] == [
+        WorkstationEventType.UPDATED,
+        WorkstationEventType.UPDATED,
+        WorkstationEventType.RELEASED,
+    ]
+    assert [event.workstation.state for event in events] == [
+        WorkstationState.PROVISIONING,
+        WorkstationState.ASSIGNED,
+        WorkstationState.AVAILABLE,
+    ]


### PR DESCRIPTION
## Summary
- expose warm pool workstations endpoints on the runner and publish workstation lifecycle events
- add an in-memory workstation event publisher dependency for overrides in tests
- cover /workstations success, conflict, and unknown-id scenarios with async integration tests and document the workflow in AGENT_NOTES

## Testing
- PYTHONPATH=. poetry run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de65c5e020832aa8d10fc1b212195e