### PR TITLE
Add workstation API endpoints to gateway

### DIFF
--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -17,6 +17,10 @@
   - `PATCH /sessions/commands/{id}` — проксирование частичного обновления на Runner с обновлением регистра.
   - `DELETE /sessions/commands/{id}` — удаление сессии через Runner с очисткой локального регистра.
   - `GET /runners` — список зарегистрированных раннеров с признаком здоровья и последним heartbeat.
+  - `GET /workstations` — перечень рабочих станций с последними событиями.
+  - `GET /workstations/{id}` — конкретная рабочая станция по идентификатору.
+  - `POST /workstations` — регистрация/обновление метаданных рабочей станции без события.
+  - `POST /workstations/events` — приём `WorkstationEvent` и фиксация последнего состояния/причины.
 - Streaming:
   - `GET /events` — SSE-канал, ретранслирующий `SessionEvent` (кеш последнего события на подписчика);
     поддерживает аутентификацию через заголовок `Authorization` или query-параметр
@@ -34,7 +38,9 @@
 - `Session` теперь хранит прямой `ws_endpoint` от runner'а и проксируемый `ws_public_endpoint`; Gateway больше не перезаписывает
   прямой URL в REST-ответах, чтобы внутренние клиенты могли подключаться без прокси.
 - `SessionRegistry`/`RunnerRegistry` — простые in-memory контейнеры с `asyncio.Lock` для потокобезопасности.
+- `WorkstationRegistry` — in-memory карта рабочих станций, сохраняет `WorkstationRecord` с последним событием.
 - `InMemorySessionEventBridge` (из core) хранит последнее событие и раздаёт подписчикам.
+- `WorkstationRecord`/`WorkstationUpsertPayload` — gateway-модели для REST, совместимы с `core.WorkstationMeta`/`WorkstationEvent` и сохраняют идентификаторы/состояние.
 
 ## Decisions
 - JWKS кэшируется в памяти и повторно запрашивается при отсутствии нужного `kid` (устойчивость к ротации ключей).
@@ -42,6 +48,7 @@
 - Runner-инстансы больше не присылают пред-выданные VNC токены; `VncTokenService.enrich_vnc_details` всегда монтирует подпись, если поле `token` отсутствует, перезаписывая TTL на конфигурационный.
 - Переиспользуем подход из beta-контроллера: для каждого раннера можно настроить шаблоны публичных VNC-URL (HTTP/WS) и при регистрации сессии мы переписываем внутренние адреса на общую точку входа, что позволяет использовать ограниченное число наружных портов.
 - SSE реализовано через `StreamingResponse`, WebSocket — нативный FastAPI роутер; для обоих каналов используется единый event bridge.
+- Маршруты `/workstations` валидируют payload через `WorkstationUpsertPayload`/`WorkstationEvent` и возвращают `WorkstationRecord`, сохраняя идентификаторы и состояние даже при мета-апдейтах.
 - Эндпоинты мутаций (`POST /sessions`, `/sessions/{id}/proxy`, `/sessions/{id}/touch`, `DELETE /sessions/{id}`)
   после успешного завершения формируют `SessionEvent` и отправляют его в bridge, чтобы UI обновлялся даже при изменениях,
   инициированных самим Gateway.
@@ -108,3 +115,4 @@
 - 2025-10-15 · gpt-5-codex · Добавлена конфигурация доверенных CIDR/заголовков, обход аутентификации для внутренних вызовов
   и покрывающие unit-тесты HTTP/SSE/WS.
 - 2025-10-16 · gpt-5-codex · Уточнена документация зависимостей безопасности и обработка пустых env-карт для доверенных CIDR.
+- 2025-10-17 · gpt-5-codex · Добавлены registry/роуты для рабочих станций, модели `WorkstationRecord`/`WorkstationUpsertPayload` и unit-тесты API контрактов.

--- a/services/gateway/app/deps/__init__.py
+++ b/services/gateway/app/deps/__init__.py
@@ -12,6 +12,7 @@ from ..services.runner_health import RunnerHealthClient
 from ..services.runner_registry import RunnerRegistry
 from ..services.runner_ws_proxy import RunnerWebSocketProxy
 from ..services.session_registry import SessionRegistry
+from ..services.workstation_registry import WorkstationRegistry
 
 
 def get_session_registry(request: Request) -> SessionRegistry:
@@ -56,6 +57,12 @@ def get_runner_ws_proxy(request: Request) -> RunnerWebSocketProxy:
     return request.app.state.runner_ws_proxy  # type: ignore[attr-defined]
 
 
+def get_workstation_registry(request: Request) -> WorkstationRegistry:
+    """Return the workstation registry stored in the application state."""
+
+    return request.app.state.workstation_registry  # type: ignore[attr-defined]
+
+
 def get_session_registry_ws(websocket: WebSocket) -> SessionRegistry:
     """Return the session registry for WebSocket dependency injection."""
 
@@ -85,4 +92,5 @@ __all__ = [
     "get_session_registry_ws",
     "get_runner_registry_ws",
     "get_runner_ws_proxy_ws",
+    "get_workstation_registry",
 ]

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -10,7 +10,7 @@ from core import InMemorySessionEventBridge
 from fastapi import FastAPI
 
 from .config import GatewaySettings
-from .routers import events_router, runners_router, sessions_router
+from .routers import events_router, runners_router, sessions_router, workstations_router
 from .security import KeycloakAuthenticator, VncTokenService
 from .services.discovery import (
     RunnerDiscoveryService,
@@ -21,6 +21,7 @@ from .services.runner_health import RunnerHealthClient
 from .services.runner_registry import RunnerRegistry
 from .services.runner_ws_proxy import RunnerWebSocketProxy
 from .services.session_registry import SessionRegistry
+from .services.workstation_registry import WorkstationRegistry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,6 +43,7 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
     app.state.runner_client = RunnerCommandClient()
     app.state.runner_health_client = RunnerHealthClient()
     app.state.runner_ws_proxy = RunnerWebSocketProxy()
+    app.state.workstation_registry = WorkstationRegistry()
     app.state.runner_discovery = RunnerDiscoveryService(
         settings=config,
         runner_registry=app.state.runner_registry,
@@ -51,6 +53,7 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
     app.include_router(sessions_router)
     app.include_router(runners_router)
     app.include_router(events_router)
+    app.include_router(workstations_router)
 
     _LOGGER.debug(
         "Gateway application initialised",

--- a/services/gateway/app/models/__init__.py
+++ b/services/gateway/app/models/__init__.py
@@ -1,1 +1,10 @@
 """Pydantic request/response models specific to the gateway."""
+
+from .session_launch import SessionLaunchPayload
+from .workstations import WorkstationRecord, WorkstationUpsertPayload
+
+__all__ = [
+    "SessionLaunchPayload",
+    "WorkstationRecord",
+    "WorkstationUpsertPayload",
+]

--- a/services/gateway/app/models/workstations.py
+++ b/services/gateway/app/models/workstations.py
@@ -1,0 +1,135 @@
+"""Pydantic models describing workstation contracts exposed by the gateway."""
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from core import (
+    WorkstationEvent,
+    WorkstationEventType,
+    WorkstationMeta,
+    WorkstationState,
+)
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class WorkstationRecord(BaseModel):
+    """Representation of a workstation tracked by the gateway API.
+
+    Attributes:
+        workstation: Full snapshot of the workstation metadata preserved in
+            the registry.
+        last_event_id: Identifier of the most recent workstation event applied
+            to the record. ``None`` when no events have been processed yet.
+        last_event_type: Type of the latest event that touched the workstation
+            (for example ``workstation.created``).
+        last_event_occurred_at: Timestamp describing when the latest event was
+            emitted by the upstream runner.
+        last_event_reason: Optional human readable reason supplied with the
+            latest event.
+
+    Example:
+        >>> metadata = WorkstationMeta(
+        ...     id="ws-1",
+        ...     fingerprint_id="fp-1",
+        ...     state=WorkstationState.AVAILABLE,
+        ... )
+        >>> WorkstationRecord.from_metadata(metadata).workstation.id
+        'ws-1'
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    workstation: WorkstationMeta = Field(
+        description="Metadata snapshot describing the workstation",
+    )
+    last_event_id: UUID | None = Field(
+        default=None,
+        description="Identifier of the most recent workstation event",
+    )
+    last_event_type: WorkstationEventType | None = Field(
+        default=None,
+        description="Type of the most recent workstation event",
+    )
+    last_event_occurred_at: datetime | None = Field(
+        default=None,
+        description="Timestamp when the latest workstation event occurred",
+    )
+    last_event_reason: str | None = Field(
+        default=None,
+        description="Optional human readable reason associated with the latest event",
+    )
+
+    @classmethod
+    def from_metadata(cls, metadata: WorkstationMeta) -> "WorkstationRecord":
+        """Create a record initialised from standalone workstation metadata.
+
+        Args:
+            metadata: Metadata snapshot reported by the runner or discovery
+                component.
+
+        Returns:
+            WorkstationRecord: Immutable record containing ``metadata`` and no
+            associated event information.
+        """
+
+        return cls(workstation=metadata)
+
+    def with_metadata(self, metadata: WorkstationMeta) -> "WorkstationRecord":
+        """Return a new record with ``metadata`` applied and event data preserved.
+
+        Args:
+            metadata: Updated workstation metadata snapshot to persist.
+
+        Returns:
+            WorkstationRecord: Copy of the record with the metadata replaced
+            while keeping the latest event attributes untouched.
+        """
+
+        return self.model_copy(update={"workstation": metadata})
+
+    def with_event(self, event: WorkstationEvent) -> "WorkstationRecord":
+        """Return a new record updated with ``event`` details.
+
+        Args:
+            event: Workstation event emitted by a runner.
+
+        Returns:
+            WorkstationRecord: Copy of the record where both the metadata and
+            last event attributes reflect ``event``.
+        """
+
+        return self.model_copy(
+            update={
+                "workstation": event.workstation,
+                "last_event_id": event.id,
+                "last_event_type": event.type,
+                "last_event_occurred_at": event.occurred_at,
+                "last_event_reason": event.reason,
+            }
+        )
+
+
+class WorkstationUpsertPayload(BaseModel):
+    """Request payload for registering or updating workstation metadata.
+
+    Attributes:
+        workstation: Metadata snapshot describing the workstation that should
+            be stored or replaced in the registry.
+
+    Example:
+        >>> WorkstationUpsertPayload(
+        ...     workstation=WorkstationMeta(
+        ...         id="ws-1",
+        ...         fingerprint_id="fp-1",
+        ...         state=WorkstationState.AVAILABLE,
+        ...     )
+        ... ).workstation.state
+        <WorkstationState.AVAILABLE: 'available'>
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workstation: WorkstationMeta = Field(
+        description="Metadata snapshot reported by the runner",
+    )

--- a/services/gateway/app/routers/__init__.py
+++ b/services/gateway/app/routers/__init__.py
@@ -3,9 +3,11 @@
 from .events import router as events_router
 from .runners import router as runners_router
 from .sessions import router as sessions_router
+from .workstations import router as workstations_router
 
 __all__ = [
     "sessions_router",
     "runners_router",
     "events_router",
+    "workstations_router",
 ]

--- a/services/gateway/app/routers/workstations.py
+++ b/services/gateway/app/routers/workstations.py
@@ -1,0 +1,132 @@
+"""Workstation management endpoints exposed by the gateway."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from core import WorkstationEvent
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from ..deps import get_workstation_registry
+from ..deps.security import get_current_user
+from ..models.workstations import WorkstationRecord, WorkstationUpsertPayload
+from ..security import AuthenticatedUser
+from ..services.workstation_registry import WorkstationRegistry
+
+router = APIRouter(prefix="/workstations", tags=["workstations"])
+
+
+@router.get(
+    "",
+    response_model=list[WorkstationRecord],
+    summary="List workstations",
+    response_description="Array of workstation records tracked by the gateway",
+)
+async def list_workstations(
+    registry: Annotated[WorkstationRegistry, Depends(get_workstation_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> list[WorkstationRecord]:
+    """Return all workstation records currently known to the gateway.
+
+    Args:
+        registry: Registry providing access to workstation snapshots.
+        user: Authenticated principal requesting the data. Included to keep the
+            dependency chain consistent with other routers and audit logging.
+
+    Returns:
+        list[WorkstationRecord]: Collection of workstation records sorted by
+        insertion order.
+
+    Example:
+        >>> await list_workstations(registry, user)  # doctest: +SKIP
+    """
+
+    return await registry.list()
+
+
+@router.get(
+    "/{workstation_id}",
+    response_model=WorkstationRecord,
+    summary="Get workstation",
+    response_description="Workstation record identified by the path parameter",
+)
+async def get_workstation(
+    workstation_id: str,
+    registry: Annotated[WorkstationRegistry, Depends(get_workstation_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> WorkstationRecord:
+    """Return a single workstation record by identifier.
+
+    Args:
+        workstation_id: Identifier of the workstation to retrieve.
+        registry: Registry that stores workstation metadata snapshots.
+        user: Authenticated principal issuing the request.
+
+    Returns:
+        WorkstationRecord: Snapshot matching ``workstation_id``.
+
+    Raises:
+        HTTPException: If the workstation is missing from the registry.
+    """
+
+    try:
+        return await registry.get(workstation_id)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Workstation not found",
+        ) from exc
+
+
+@router.post(
+    "",
+    response_model=WorkstationRecord,
+    status_code=status.HTTP_201_CREATED,
+    summary="Register workstation",
+    response_description="Stored workstation record",
+)
+async def upsert_workstation(
+    payload: WorkstationUpsertPayload,
+    registry: Annotated[WorkstationRegistry, Depends(get_workstation_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> WorkstationRecord:
+    """Insert or replace workstation metadata without recording an event.
+
+    Args:
+        payload: Request body containing the workstation metadata snapshot.
+        registry: Registry responsible for persisting workstation data.
+        user: Authenticated principal issuing the request.
+
+    Returns:
+        WorkstationRecord: Stored record reflecting the provided metadata.
+    """
+
+    return await registry.upsert_metadata(payload.workstation)
+
+
+@router.post(
+    "/events",
+    response_model=WorkstationRecord,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Apply workstation event",
+    response_description="Workstation record after the event has been applied",
+)
+async def apply_workstation_event(
+    event: WorkstationEvent,
+    registry: Annotated[WorkstationRegistry, Depends(get_workstation_registry)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> WorkstationRecord:
+    """Apply a workstation lifecycle event emitted by a runner.
+
+    Args:
+        event: Workstation lifecycle event sent by a runner.
+        registry: Registry that will incorporate the event into stored
+            snapshots.
+        user: Authenticated principal issuing the request.
+
+    Returns:
+        WorkstationRecord: Updated workstation record including details from
+        ``event``.
+    """
+
+    return await registry.apply_event(event)

--- a/services/gateway/app/services/workstation_registry.py
+++ b/services/gateway/app/services/workstation_registry.py
@@ -1,0 +1,125 @@
+"""Concurrency-safe registry storing workstation metadata and events."""
+
+from __future__ import annotations
+
+import asyncio
+
+from core import WorkstationEvent, WorkstationMeta, WorkstationState
+
+from ..models.workstations import WorkstationRecord
+
+
+class WorkstationRegistry:
+    """In-memory registry that keeps track of workstation snapshots.
+
+    The registry is designed for lightweight deployments of the gateway where
+    workstation metadata can be kept in process memory. Access is guarded by an
+    :class:`asyncio.Lock` to guarantee deterministic updates even when multiple
+    requests attempt to mutate the same workstation concurrently.
+
+    Attributes:
+        _records: Mapping of workstation identifiers to their latest
+            :class:`WorkstationRecord` representation.
+        _lock: Asynchronous mutex serialising registry operations.
+    """
+
+    def __init__(self) -> None:
+        """Initialise an empty registry ready to accept workstation records."""
+
+        self._records: dict[str, WorkstationRecord] = {}
+        self._lock = asyncio.Lock()
+
+    async def list(self) -> list[WorkstationRecord]:
+        """Return all known workstation records in insertion order.
+
+        Returns:
+            list[WorkstationRecord]: Copy of the current registry contents. The
+            returned list is detached from internal state allowing callers to
+            iterate without holding the lock.
+
+        Example:
+            >>> registry = WorkstationRegistry()
+            >>> await registry.list()
+            []
+        """
+
+        async with self._lock:
+            return list(self._records.values())
+
+    async def get(self, workstation_id: str) -> WorkstationRecord:
+        """Return a single workstation record by identifier.
+
+        Args:
+            workstation_id: Identifier of the workstation to resolve.
+
+        Returns:
+            WorkstationRecord: Snapshot describing the requested workstation.
+
+        Raises:
+            KeyError: If the workstation has not been registered yet.
+        """
+
+        async with self._lock:
+            try:
+                return self._records[workstation_id]
+            except KeyError as exc:  # pragma: no cover - defensive branch
+                raise KeyError("Workstation not found") from exc
+
+    async def upsert_metadata(self, metadata: WorkstationMeta) -> WorkstationRecord:
+        """Insert or replace workstation metadata without altering event fields.
+
+        Args:
+            metadata: Metadata snapshot to persist in the registry.
+
+        Returns:
+            WorkstationRecord: Stored record reflecting ``metadata`` combined
+            with any previously observed event attributes.
+
+        Example:
+            >>> registry = WorkstationRegistry()
+            >>> await registry.upsert_metadata(
+            ...     WorkstationMeta(
+            ...         id="ws-1",
+            ...         fingerprint_id="fp-1",
+            ...         state=WorkstationState.AVAILABLE,
+            ...     )
+            ... )
+            WorkstationRecord(...)
+        """
+
+        async with self._lock:
+            existing = self._records.get(metadata.id)
+            record = (
+                existing.with_metadata(metadata)
+                if existing is not None
+                else WorkstationRecord.from_metadata(metadata)
+            )
+            self._records[metadata.id] = record
+            return record
+
+    async def apply_event(self, event: WorkstationEvent) -> WorkstationRecord:
+        """Apply ``event`` to the registry and return the updated record.
+
+        Args:
+            event: Event payload emitted by a runner describing workstation
+                lifecycle changes.
+
+        Returns:
+            WorkstationRecord: Updated record including the event metadata and
+            last-event bookkeeping fields.
+
+        Example:
+            >>> registry = WorkstationRegistry()
+            >>> await registry.apply_event(event)  # doctest: +SKIP
+
+        """
+
+        async with self._lock:
+            existing = self._records.get(event.workstation.id)
+            record = (
+                existing.with_event(event)
+                if existing is not None
+                else WorkstationRecord.from_metadata(event.workstation).with_event(event)
+            )
+            self._records[event.workstation.id] = record
+            return record

--- a/services/gateway/pyproject.toml
+++ b/services/gateway/pyproject.toml
@@ -13,6 +13,7 @@ httpx = "^0.27.2"
 pydantic = "^2.8.2"
 anyio = "^4.4.0"
 "camou-core" = { path = "../../packages/core", develop = true }
+prometheus-client = "^0.20.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"

--- a/services/gateway/tests/test_workstations.py
+++ b/services/gateway/tests/test_workstations.py
@@ -1,0 +1,133 @@
+"""Tests covering the workstation management API surface."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app import create_app
+from app.config import GatewaySettings
+from app.deps.security import get_authenticator, get_current_user
+from app.security import AuthenticatedUser
+
+
+@pytest.fixture()
+def gateway_app() -> FastAPI:
+    """Return a FastAPI application configured for workstation tests."""
+
+    settings = GatewaySettings(
+        discovery_mode="static",
+        runners=[],
+        jwt_jwks_url="http://jwks.local",
+        vnc_token_ttl_seconds=60,
+        vnc_token_secret="unit-test-secret",
+    )
+    app = create_app(settings)
+    user = AuthenticatedUser(subject="tester", email="tester@example.com")
+
+    async def _user_override() -> AuthenticatedUser:
+        return user
+
+    class _DummyAuthenticator:
+        async def authenticate(self, token: str) -> AuthenticatedUser:
+            return user
+
+    dummy_auth = _DummyAuthenticator()
+    app.state.authenticator = dummy_auth
+    app.dependency_overrides[get_current_user] = _user_override
+    app.dependency_overrides[get_authenticator] = lambda: dummy_auth
+    return app
+
+
+@pytest.fixture()
+def gateway_client(gateway_app: FastAPI) -> TestClient:
+    """Return a synchronous test client bound to ``gateway_app``."""
+
+    client = TestClient(gateway_app)
+    yield client
+    client.close()
+
+
+def test_workstation_metadata_roundtrip(gateway_client: TestClient) -> None:
+    """Gateway stores and returns workstation metadata snapshots."""
+
+    payload = {
+        "workstation": {
+            "id": "ws-1",
+            "fingerprint_id": "fp-1",
+            "state": "available",
+            "metadata": {"region": "eu-central"},
+            "proxy_summary": "corp proxy",
+        }
+    }
+    response = gateway_client.post("/workstations", json=payload)
+    assert response.status_code == 201
+    body = response.json()
+    assert body["workstation"]["id"] == "ws-1"
+    assert body["workstation"]["state"] == "available"
+    assert body["last_event_id"] is None
+
+    response = gateway_client.get("/workstations")
+    assert response.status_code == 200
+    items = response.json()
+    assert len(items) == 1
+    assert items[0]["workstation"]["fingerprint_id"] == "fp-1"
+
+    response = gateway_client.get("/workstations/ws-1")
+    assert response.status_code == 200
+    assert response.json()["workstation"]["metadata"]["region"] == "eu-central"
+
+
+def test_workstation_events_update_registry(gateway_client: TestClient) -> None:
+    """Workstation events update the stored snapshot and record event metadata."""
+
+    event_id = str(uuid4())
+    occurred_at = datetime.now(tz=UTC).isoformat()
+    event_payload = {
+        "id": event_id,
+        "type": "workstation.updated",
+        "occurred_at": occurred_at,
+        "reason": "assigned to session",
+        "workstation": {
+            "id": "ws-evt",
+            "fingerprint_id": "fp-evt",
+            "state": "assigned",
+        },
+    }
+    response = gateway_client.post("/workstations/events", json=event_payload)
+    assert response.status_code == 202
+    body = response.json()
+    assert body["last_event_id"] == event_id
+    assert body["workstation"]["state"] == "assigned"
+    assert body["last_event_reason"] == "assigned to session"
+
+    response = gateway_client.get("/workstations/ws-evt")
+    assert response.status_code == 200
+    record = response.json()
+    assert record["last_event_id"] == event_id
+    assert record["workstation"]["fingerprint_id"] == "fp-evt"
+
+    update_payload = {
+        "workstation": {
+            "id": "ws-evt",
+            "fingerprint_id": "fp-evt",
+            "state": "available",
+            "metadata": {"note": "clean"},
+        }
+    }
+    response = gateway_client.post("/workstations", json=update_payload)
+    assert response.status_code == 201
+    updated = response.json()
+    assert updated["workstation"]["state"] == "available"
+    assert updated["last_event_id"] == event_id
+
+
+def test_get_missing_workstation_returns_404(gateway_client: TestClient) -> None:
+    """Gateway reports ``404`` when the workstation does not exist."""
+
+    response = gateway_client.get("/workstations/missing")
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add a workstation registry plus request/response models that preserve WorkstationMeta and event identifiers
- expose REST endpoints for listing, retrieving, and updating workstations and cover them with unit tests and documentation updates
- declare prometheus-client in the gateway dependencies for contract synchronization tests

## Testing
- `poetry run pytest -q` (46 passed in 2.57s)

## Security
- no changes

------
https://chatgpt.com/codex/tasks/task_e_68de65bd38e4832aa8e145223706f7e8