### PR TITLE
Add workstation event streaming from runner to gateway

### DIFF
--- a/packages/core/AGENT_NOTES.md
+++ b/packages/core/AGENT_NOTES.md
@@ -8,7 +8,8 @@
 ## Interfaces
 - Python API (`core.__all__`): `Runner`, `Session`, `SessionEvent`, перечисления
   состояний, настройки прокси/VNC, `AbstractSessionEventBridge`,
-  `InMemorySessionEventBridge`.
+  `InMemorySessionEventBridge`, а также `AbstractWorkstationEventBridge` и
+  `InMemoryWorkstationEventBridge`.
 - Событийный мост: абстрактные методы `publish(event)` и `subscribe()` возвращают
   асинхронный итератор событий, повторяя будущий контракт Gateway ↔ UI.
 - Поддерживается опция `subscribe(replay_latest=True)` для мгновенного
@@ -64,7 +65,7 @@
 - `WorkstationEvent` требует `occurred_at` с tzinfo и непустую `reason` при наличии.
 
 ## Known Gaps / TODO
-- [ ] Провести нагрузочное тестирование in-memory моста под массовыми подписками,
+- [ ] Провести нагрузочное тестирование in-memory мостов под массовыми подписками,
       когда появятся целевые SLO по задержкам от команды эксплуатации.
 
 ## How to Test
@@ -90,3 +91,5 @@
 - 2025-10-14 · gpt-5-codex — Расширен `Session` полем `ws_public_endpoint` и обновлены тесты сериализации.
 - 2025-10-15 · ChatGPT — Добавлены модели и события рабочей станции, расширен контракт `Session`
   workstation-полями, обновлены тесты сериализации/валидации.
+- 2025-10-18 · gpt-5-codex — Добавлены мосты событий рабочих станций и экспорт в `core.__all__`,
+  обновлены тесты фан-аута и документация.

--- a/packages/core/core/__init__.py
+++ b/packages/core/core/__init__.py
@@ -32,7 +32,9 @@ from .models import (
 )
 from .websocket_bridge import (
     AbstractSessionEventBridge,
+    AbstractWorkstationEventBridge,
     InMemorySessionEventBridge,
+    InMemoryWorkstationEventBridge,
 )
 
 __all__ = [
@@ -46,7 +48,9 @@ __all__ = [
     "StartUrlWait",
     "SessionVncDetails",
     "AbstractSessionEventBridge",
+    "AbstractWorkstationEventBridge",
     "InMemorySessionEventBridge",
+    "InMemoryWorkstationEventBridge",
     "WorkstationEvent",
     "WorkstationEventType",
     "WorkstationMeta",

--- a/packages/core/core/websocket_bridge.py
+++ b/packages/core/core/websocket_bridge.py
@@ -1,10 +1,9 @@
-"""Asynchronous utilities for propagating session events via WebSockets.
+"""Asynchronous utilities for propagating session and workstation events.
 
-Ghost Browsers standardises on an in-memory fan-out bridge for session
-events. The bridge is production-backed by `asyncio` primitives and does
-not depend on external brokers, which keeps local development and
-container deployments self-contained. This module defines the abstract
-API and exposes the in-memory implementation that all services share.
+Ghost Browsers standardises on in-memory fan-out bridges backed by
+``asyncio`` primitives rather than external brokers. The same pattern is
+reused for session and workstation events so downstream services can
+subscribe using a consistent API regardless of event type.
 """
 
 from __future__ import annotations
@@ -14,7 +13,7 @@ from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from typing import AsyncGenerator
 
-from .models import SessionEvent
+from .models import SessionEvent, WorkstationEvent
 
 
 class AbstractSessionEventBridge(ABC):
@@ -102,6 +101,63 @@ class InMemorySessionEventBridge(AbstractSessionEventBridge):
             await queue.put(latest)
 
         async def iterator() -> AsyncGenerator[SessionEvent, None]:
+            try:
+                while True:
+                    yield await queue.get()
+            finally:
+                async with self._lock:
+                    self._subscribers.discard(queue)
+
+        return iterator()
+
+
+class AbstractWorkstationEventBridge(ABC):
+    """Common interface for broadcasting workstation events to subscribers."""
+
+    @abstractmethod
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Publish a workstation event to all subscribers."""
+
+    @abstractmethod
+    async def subscribe(
+        self, *, replay_latest: bool = False
+    ) -> AsyncIterator[WorkstationEvent]:
+        """Return an async iterator yielding workstation events."""
+
+
+class InMemoryWorkstationEventBridge(AbstractWorkstationEventBridge):
+    """In-memory bridge that fans out workstation events to subscribers."""
+
+    def __init__(self) -> None:
+        """Initialise the bridge with no subscribers."""
+
+        self._subscribers: set[asyncio.Queue[WorkstationEvent]] = set()
+        self._lock = asyncio.Lock()
+        self._latest_event: WorkstationEvent | None = None
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Broadcast ``event`` to all currently subscribed consumers."""
+
+        async with self._lock:
+            queues = list(self._subscribers)
+            self._latest_event = event
+        for queue in queues:
+            await queue.put(event)
+
+    async def subscribe(
+        self, *, replay_latest: bool = False
+    ) -> AsyncIterator[WorkstationEvent]:
+        """Register a subscriber and return an iterator of workstation events."""
+
+        queue: asyncio.Queue[WorkstationEvent] = asyncio.Queue()
+        async with self._lock:
+            self._subscribers.add(queue)
+            latest = self._latest_event
+
+        if replay_latest and latest is not None:
+            await queue.put(latest)
+
+        async def iterator() -> AsyncGenerator[WorkstationEvent, None]:
             try:
                 while True:
                     yield await queue.get()

--- a/packages/core/tests/test_models.py
+++ b/packages/core/tests/test_models.py
@@ -16,6 +16,7 @@ import pytest
 
 from core import (
     InMemorySessionEventBridge,
+    InMemoryWorkstationEventBridge,
     Runner,
     RunnerState,
     Session,
@@ -318,6 +319,64 @@ def test_inmemory_bridge_replay_latest_on_subscribe() -> None:
         event = SessionEvent(
             session=build_session(status=SessionStatus.READY),
             occurred_at=datetime.now(tz=timezone.utc),
+        )
+
+        await bridge.publish(event)
+        stream = await bridge.subscribe(replay_latest=True)
+
+        replayed = await stream.__anext__()
+        assert replayed is event
+
+        await stream.aclose()
+
+    asyncio.run(run())
+
+
+def test_inmemory_workstation_bridge_fanout() -> None:
+    """Workstation events should be delivered to all subscribers."""
+
+    async def run() -> None:
+        bridge = InMemoryWorkstationEventBridge()
+        event = WorkstationEvent(
+            workstation=WorkstationMeta(
+                id="ws-1",
+                fingerprint_id="fp-1",
+                state=WorkstationState.AVAILABLE,
+            ),
+            occurred_at=datetime.now(tz=timezone.utc),
+            type=WorkstationEventType.UPDATED,
+        )
+
+        stream_one = await bridge.subscribe()
+        stream_two = await bridge.subscribe()
+
+        task_one = asyncio.create_task(stream_one.__anext__())
+        task_two = asyncio.create_task(stream_two.__anext__())
+
+        await bridge.publish(event)
+
+        assert await task_one is event
+        assert await task_two is event
+
+        await stream_one.aclose()
+        await stream_two.aclose()
+
+    asyncio.run(run())
+
+
+def test_inmemory_workstation_bridge_replay_latest() -> None:
+    """Replaying the latest workstation event should be supported."""
+
+    async def run() -> None:
+        bridge = InMemoryWorkstationEventBridge()
+        event = WorkstationEvent(
+            workstation=WorkstationMeta(
+                id="ws-2",
+                fingerprint_id="fp-2",
+                state=WorkstationState.ASSIGNED,
+            ),
+            occurred_at=datetime.now(tz=timezone.utc),
+            type=WorkstationEventType.UPDATED,
         )
 
         await bridge.publish(event)

--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -24,6 +24,10 @@
   - `WS /events/ws` — WebSocket с тем же потоком событий.
   - `WS /sessions/{id}/ws` — прокси Playwright WebSocket каналов; требует Bearer токен в заголовке или параметре `token`.
   - `POST /events` — приём `SessionEvent` от Runner (HTTP transport) с публикацией через общий bridge.
+  - `POST /workstations/events` — приём `WorkstationEvent` от Runner; ретранслируется в SSE/WS-каналы рабочих станций.
+  - `GET /workstations/events` — SSE-канал `WorkstationEvent` (replay последнего события);
+    авторизация идентична `/events`.
+  - `WS /workstations/events/ws` — WebSocket-поток событий рабочих станций.
 - «Внутренние» HTTP/WS запросы могут авторизоваться по источнику IP: CIDR из `GATEWAY_TRUSTED_CIDRS` и (опционально)
   заголовок `GATEWAY_TRUSTED_HEADER` с оригинальным клиентским IP. Совпадение выдаёт синтетического пользователя
   `internal:<ip>` и логирует стратегию `auth_strategy=internal-bypass`.
@@ -35,6 +39,7 @@
   прямой URL в REST-ответах, чтобы внутренние клиенты могли подключаться без прокси.
 - `SessionRegistry`/`RunnerRegistry` — простые in-memory контейнеры с `asyncio.Lock` для потокобезопасности.
 - `InMemorySessionEventBridge` (из core) хранит последнее событие и раздаёт подписчикам.
+- `InMemoryWorkstationEventBridge` обслуживает поток `WorkstationEvent` для UI/интеграций.
 
 ## Decisions
 - JWKS кэшируется в памяти и повторно запрашивается при отсутствии нужного `kid` (устойчивость к ротации ключей).
@@ -42,6 +47,7 @@
 - Runner-инстансы больше не присылают пред-выданные VNC токены; `VncTokenService.enrich_vnc_details` всегда монтирует подпись, если поле `token` отсутствует, перезаписывая TTL на конфигурационный.
 - Переиспользуем подход из beta-контроллера: для каждого раннера можно настроить шаблоны публичных VNC-URL (HTTP/WS) и при регистрации сессии мы переписываем внутренние адреса на общую точку входа, что позволяет использовать ограниченное число наружных портов.
 - SSE реализовано через `StreamingResponse`, WebSocket — нативный FastAPI роутер; для обоих каналов используется единый event bridge.
+- Отдельный in-memory bridge обслуживает события рабочих станций (`WorkstationEvent`), маршруты `/workstations/events*` используют тот же подход replay_latest и авторизацию, что и сессионные каналы.
 - Эндпоинты мутаций (`POST /sessions`, `/sessions/{id}/proxy`, `/sessions/{id}/touch`, `DELETE /sessions/{id}`)
   после успешного завершения формируют `SessionEvent` и отправляют его в bridge, чтобы UI обновлялся даже при изменениях,
   инициированных самим Gateway.
@@ -108,3 +114,5 @@
 - 2025-10-15 · gpt-5-codex · Добавлена конфигурация доверенных CIDR/заголовков, обход аутентификации для внутренних вызовов
   и покрывающие unit-тесты HTTP/SSE/WS.
 - 2025-10-16 · gpt-5-codex · Уточнена документация зависимостей безопасности и обработка пустых env-карт для доверенных CIDR.
+- 2025-10-18 · gpt-5-codex · Добавлены HTTP/SSE/WS эндпоинты `workstations/events*`, второй bridge для
+  `WorkstationEvent` и покрывающие тесты доставки/аутентификации.

--- a/services/gateway/app/deps/__init__.py
+++ b/services/gateway/app/deps/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastapi import Request, WebSocket
 
-from core import AbstractSessionEventBridge
+from core import AbstractSessionEventBridge, AbstractWorkstationEventBridge
 
 from ..security import VncTokenService
 from ..services.runner_client import RunnerCommandClient
@@ -30,6 +30,12 @@ def get_event_bridge(request: Request) -> AbstractSessionEventBridge:
     """Return the event bridge shared across routers."""
 
     return request.app.state.event_bridge  # type: ignore[attr-defined]
+
+
+def get_workstation_event_bridge(request: Request) -> AbstractWorkstationEventBridge:
+    """Return the workstation event bridge shared across routers."""
+
+    return request.app.state.workstation_event_bridge  # type: ignore[attr-defined]
 
 
 def get_vnc_token_service(request: Request) -> VncTokenService:
@@ -74,10 +80,19 @@ def get_runner_ws_proxy_ws(websocket: WebSocket) -> RunnerWebSocketProxy:
     return websocket.app.state.runner_ws_proxy  # type: ignore[attr-defined]
 
 
+def get_workstation_event_bridge_ws(
+    websocket: WebSocket,
+) -> AbstractWorkstationEventBridge:
+    """Return the workstation bridge for WebSocket dependency injection."""
+
+    return websocket.app.state.workstation_event_bridge  # type: ignore[attr-defined]
+
+
 __all__ = [
     "get_session_registry",
     "get_runner_registry",
     "get_event_bridge",
+    "get_workstation_event_bridge",
     "get_vnc_token_service",
     "get_runner_command_client",
     "get_runner_health_client",
@@ -85,4 +100,5 @@ __all__ = [
     "get_session_registry_ws",
     "get_runner_registry_ws",
     "get_runner_ws_proxy_ws",
+    "get_workstation_event_bridge_ws",
 ]

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -1,4 +1,9 @@
-"""Application factory for the Camou Gateway service."""
+"""Application factory and lifespan management for the Camou Gateway service.
+
+The module exposes :func:`create_app` which constructs the FastAPI
+application, wires dependency singletons into ``app.state`` and configures the
+lifespan context responsible for runner discovery and health polling.
+"""
 
 from __future__ import annotations
 
@@ -6,11 +11,16 @@ import logging
 from contextlib import asynccontextmanager
 
 import anyio
-from core import InMemorySessionEventBridge
+from core import InMemorySessionEventBridge, InMemoryWorkstationEventBridge
 from fastapi import FastAPI
 
 from .config import GatewaySettings
-from .routers import events_router, runners_router, sessions_router
+from .routers import (
+    events_router,
+    runners_router,
+    sessions_router,
+    workstation_events_router,
+)
 from .security import KeycloakAuthenticator, VncTokenService
 from .services.discovery import (
     RunnerDiscoveryService,
@@ -34,6 +44,7 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
     app.state.session_registry = SessionRegistry()
     app.state.runner_registry = RunnerRegistry(config.runners)
     app.state.event_bridge = InMemorySessionEventBridge()
+    app.state.workstation_event_bridge = InMemoryWorkstationEventBridge()
     app.state.vnc_tokens = VncTokenService(
         secret=config.vnc_token_secret,
         ttl_seconds=config.vnc_token_ttl_seconds,
@@ -51,6 +62,7 @@ def create_app(settings: GatewaySettings | None = None) -> FastAPI:
     app.include_router(sessions_router)
     app.include_router(runners_router)
     app.include_router(events_router)
+    app.include_router(workstation_events_router)
 
     _LOGGER.debug(
         "Gateway application initialised",

--- a/services/gateway/app/routers/__init__.py
+++ b/services/gateway/app/routers/__init__.py
@@ -1,6 +1,7 @@
 """REST and realtime routers exposed by the gateway."""
 
 from .events import router as events_router
+from .events import workstation_router as workstation_events_router
 from .runners import router as runners_router
 from .sessions import router as sessions_router
 
@@ -8,4 +9,5 @@ __all__ = [
     "sessions_router",
     "runners_router",
     "events_router",
+    "workstation_events_router",
 ]

--- a/services/gateway/app/routers/events.py
+++ b/services/gateway/app/routers/events.py
@@ -1,18 +1,28 @@
-"""Realtime event streaming endpoints."""
+"""Realtime HTTP and WebSocket endpoints for session and workstation events."""
 
 from __future__ import annotations
 
 from typing import Annotated
 
-from core import AbstractSessionEventBridge, SessionEvent
+from core import (
+    AbstractSessionEventBridge,
+    AbstractWorkstationEventBridge,
+    SessionEvent,
+    WorkstationEvent,
+)
 from fastapi import APIRouter, Depends, Response, WebSocket, WebSocketDisconnect, status
 from fastapi.responses import StreamingResponse
 
-from ..deps import get_event_bridge
+from ..deps import (
+    get_event_bridge,
+    get_workstation_event_bridge,
+    get_workstation_event_bridge_ws,
+)
 from ..deps.security import authenticate_websocket, get_authenticator, get_current_user
 from ..security import AuthenticatedUser, KeycloakAuthenticator
 
 router = APIRouter(prefix="/events", tags=["events"])
+workstation_router = APIRouter(prefix="/workstations/events", tags=["workstations"])
 
 
 @router.post("", status_code=status.HTTP_202_ACCEPTED)
@@ -68,6 +78,60 @@ async def websocket_events(
     await authenticate_websocket(websocket, authenticator)
     await websocket.accept()
     bridge: AbstractSessionEventBridge = websocket.app.state.event_bridge  # type: ignore[attr-defined]
+    subscription = await bridge.subscribe(replay_latest=True)
+    try:
+        async for event in subscription:
+            await websocket.send_json(event.model_dump(mode="json"))
+    except WebSocketDisconnect:  # pragma: no cover - handshake drop
+        pass
+    finally:
+        await subscription.aclose()
+
+
+@workstation_router.post("", status_code=status.HTTP_202_ACCEPTED)
+async def publish_workstation_event(
+    event: WorkstationEvent,
+    bridge: Annotated[AbstractWorkstationEventBridge, Depends(get_workstation_event_bridge)],
+) -> Response:
+    """Accept a :class:`WorkstationEvent` and broadcast it downstream."""
+
+    await bridge.publish(event)
+    return Response(status_code=status.HTTP_202_ACCEPTED)
+
+
+@workstation_router.get("", response_class=StreamingResponse)
+async def stream_workstation_events(
+    bridge: Annotated[AbstractWorkstationEventBridge, Depends(get_workstation_event_bridge)],
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> StreamingResponse:
+    """Provide a Server-Sent Events stream for workstation events."""
+
+    del user
+
+    async def iterator() -> str:
+        subscription = await bridge.subscribe(replay_latest=True)
+        try:
+            async for event in subscription:
+                payload = event.model_dump_json(by_alias=True)
+                yield f"data: {payload}\n\n"
+        finally:
+            await subscription.aclose()
+
+    return StreamingResponse(iterator(), media_type="text/event-stream")
+
+
+@workstation_router.websocket("/ws")
+async def websocket_workstation_events(
+    websocket: WebSocket,
+    authenticator: Annotated[KeycloakAuthenticator, Depends(get_authenticator)],
+    bridge: Annotated[
+        AbstractWorkstationEventBridge, Depends(get_workstation_event_bridge_ws)
+    ],
+) -> None:
+    """Relay workstation events over a WebSocket connection."""
+
+    await authenticate_websocket(websocket, authenticator)
+    await websocket.accept()
     subscription = await bridge.subscribe(replay_latest=True)
     try:
         async for event in subscription:

--- a/services/gateway/tests/test_gateway.py
+++ b/services/gateway/tests/test_gateway.py
@@ -36,6 +36,10 @@ from core import (
     SessionEventType,
     SessionStatus,
     SessionVncDetails,
+    WorkstationEvent,
+    WorkstationEventType,
+    WorkstationMeta,
+    WorkstationState,
 )  # noqa: E402
 
 
@@ -528,6 +532,43 @@ async def test_sse_event_forwarding(gateway_app: FastAPI) -> None:
 
 
 @pytest.mark.anyio("asyncio")
+async def test_workstation_sse_event_forwarding(gateway_app: FastAPI) -> None:
+    """Workstation bridge events should be exposed via SSE."""
+
+    from app.routers.events import publish_workstation_event, stream_workstation_events
+
+    bridge = gateway_app.state.workstation_event_bridge
+    now = datetime.now(tz=UTC)
+    event = WorkstationEvent(
+        workstation=WorkstationMeta(
+            id="ws-1",
+            fingerprint_id="fp-1",
+            state=WorkstationState.AVAILABLE,
+        ),
+        occurred_at=now,
+        type=WorkstationEventType.UPDATED,
+        reason="reserved",
+    )
+
+    response = await stream_workstation_events(
+        bridge=bridge,
+        user=AuthenticatedUser(subject="tester", email="tester@example.com"),
+    )
+    assert isinstance(response, StreamingResponse)
+
+    iterator = response.body_iterator
+    consumer = asyncio.create_task(iterator.__anext__())
+    await asyncio.sleep(0)
+    result = await publish_workstation_event(event=event, bridge=bridge)
+    assert result.status_code == 202
+    chunk = await asyncio.wait_for(consumer, timeout=1)
+    text = chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+    payload = json.loads(text.removeprefix("data:").strip())
+    assert payload["workstation"]["id"] == "ws-1"
+    await iterator.aclose()
+
+
+@pytest.mark.anyio("asyncio")
 async def test_mutation_endpoints_emit_session_events(gateway_app: FastAPI) -> None:
     """Gateway-managed mutations should notify subscribers via the bridge."""
 
@@ -598,6 +639,30 @@ def test_websocket_event_forwarding(gateway_client: TestClient) -> None:
         assert response.status_code == 202
         message = websocket.receive_json()
         assert message["session"]["id"] == str(session.id)
+
+
+def test_workstation_websocket_forwarding(gateway_client: TestClient) -> None:
+    """Workstation events should be delivered over the WebSocket bridge."""
+
+    now = datetime.now(tz=UTC)
+    event = WorkstationEvent(
+        workstation=WorkstationMeta(
+            id="ws-99",
+            fingerprint_id="fp-99",
+            state=WorkstationState.AVAILABLE,
+        ),
+        occurred_at=now,
+        type=WorkstationEventType.UPDATED,
+    )
+
+    with gateway_client.websocket_connect("/workstations/events/ws?token=stub") as websocket:
+        response = gateway_client.post(
+            "/workstations/events",
+            json=event.model_dump(mode="json", by_alias=True),
+        )
+        assert response.status_code == 202
+        message = websocket.receive_json()
+        assert message["workstation"]["id"] == "ws-99"
 
 
 @pytest.mark.anyio

--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -24,6 +24,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - **Event transport**
   - `SessionEventPublisher.publish(SessionEvent)` — protocol for pushing lifecycle events downstream. Default implementation stores events in memory (`InMemorySessionEventPublisher`) but can be swapped for HTTP/SSE bridges via `CallbackSessionEventPublisher`.
   - `HttpSessionEventPublisher` — при наличии `RunnerSettings.event_endpoint` POST-ит события на `gateway /events`.
+  - `WorkstationEventPublisher.publish(WorkstationEvent)` — отдельный транспорт для событий прогретых рабочих станций. In-memory реализация используется по умолчанию, HTTP-вариант активируется настройкой `WORKSTATION_EVENT_ENDPOINT`.
 
 ## Data & Models
 - Uses `core.Session`, `SessionEvent`, `SessionProxySettings`, `SessionVncDetails`, and related enums.
@@ -45,6 +46,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 ## Decisions
 - **In-memory publisher**: Стандартный транспорт построен на `InMemorySessionEventPublisher` и считается продукционным решением; при необходимости можно оборачивать его через `CallbackSessionEventPublisher` для сторонних интеграций без отказа от in-memory ядра.
 - **HTTP publisher toggle**: `get_event_publisher` читает `RunnerSettings.event_endpoint` и, если URL задан, использует `HttpSessionEventPublisher`, публикующий события в Gateway через `POST /events`.
+- **Workstation event transport**: `WarmPoolManager` эмитирует `WorkstationEvent` при старте, резервации, занятии, рециклинге, ошибках и drain. Транспорт подменяется через `get_workstation_event_publisher` (in-memory по умолчанию, HTTP — при `WORKSTATION_EVENT_ENDPOINT`).
 - **Camoufox stub dependency**: Для unit-тестов в CI runner использует локальный путь-зависимость `packages/camoufox`, реализующую CLI/API-совместимый stub. Это позволяет выполнять `poetry install` без доступа к проприетарному пакету.
 - **Process-backed VNC controller**: Non-headless sessions allocate Xvfb/x11vnc/websockify helpers via `ProcessVncController`. The controller maintains a bounded pool of displays and ports, composes public HTTP/WS URLs from `RunnerSettings`, and tears down helpers whenever sessions terminate or switch to headless mode.
 - **Gateway-signed VNC tokens**: Runner never persists VNC `token` or `token_ttl_seconds`; any user-supplied values are stripped and synthetic descriptors leave them `None` so that the gateway can issue signed credentials.
@@ -107,3 +109,5 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-15 · gpt-5-codex · Добавлены warm pool-конфиги (JSON), загрузка при старте, новые настройки и модульные тесты на валидацию/парсинг.
 - 2025-10-16 · gpt-5-codex · Реализован ``WarmPoolManager`` с управлением состояниями, recycle, преднавигацией и юнит-тестами на ключевые сценарии.
 - 2025-10-17 · gpt-5-codex · Интегрирован warm pool в `SessionManager`/API, добавлен отклик 429 при нехватке слотов и покрытие тестами.
+- 2025-10-18 · gpt-5-codex · Добавлена публикация событий рабочих станций (WarmPoolManager → WorkstationEventPublisher),
+  новые настройки и тесты на фан-аут/ошибки/HTTP транспорт.

--- a/services/runner/app/config/settings.py
+++ b/services/runner/app/config/settings.py
@@ -28,8 +28,10 @@ class RunnerSettings(BaseModel):
     Attributes:
         runner_id: Identifier advertised to the gateway/UI for every session.
         camoufox_path: Absolute path to the Camoufox binary.
-        event_endpoint: Optional HTTP(S) endpoint used by the event publisher
-            stub. When absent, events are kept in-memory.
+        event_endpoint: Optional HTTP(S) endpoint used by the session event
+            publisher stub. When absent, events are kept in-memory.
+        workstation_event_endpoint: Optional HTTP(S) endpoint that receives
+            workstation lifecycle events.
         slot_limit: Maximum number of concurrently active sessions.
         warm_pool_config_path: Optional path to a JSON file describing the warm
             workstation pool.
@@ -67,6 +69,7 @@ class RunnerSettings(BaseModel):
     runner_id: str = Field(default="runner-local", min_length=1)
     camoufox_path: Path = Field(default=Path("/usr/bin/camoufox"))
     event_endpoint: AnyUrl | None = Field(default=None)
+    workstation_event_endpoint: AnyUrl | None = Field(default=None)
     slot_limit: PositiveInt = Field(default=4, ge=1)
     warm_pool_config_path: Path | None = Field(
         default=None,
@@ -144,6 +147,8 @@ class RunnerSettings(BaseModel):
             source["camoufox_path"] = Path(env["CAMOUFOX_PATH"])
         if "EVENT_ENDPOINT" in env:
             source["event_endpoint"] = env["EVENT_ENDPOINT"]
+        if "WORKSTATION_EVENT_ENDPOINT" in env:
+            source["workstation_event_endpoint"] = env["WORKSTATION_EVENT_ENDPOINT"]
         if "SLOT_LIMIT" in env:
             source["slot_limit"] = int(env["SLOT_LIMIT"])
         if "WARM_POOL_CONFIG_PATH" in env:

--- a/services/runner/app/dependencies/session_manager.py
+++ b/services/runner/app/dependencies/session_manager.py
@@ -1,4 +1,4 @@
-"""Dependency wiring for the session manager and publishers."""
+"""Dependency wiring for session management and event publishers."""
 
 from __future__ import annotations
 
@@ -12,8 +12,13 @@ from ..events import (
     SessionEventPublisher,
 )
 from ..session_manager import SessionManager
-from ..warm_pool import WarmPoolManager
 from ..vnc import ProcessVncController, VncController, VncUnavailableError
+from ..warm_pool import WarmPoolManager
+from ..workstation_events import (
+    HttpWorkstationEventPublisher,
+    InMemoryWorkstationEventPublisher,
+    WorkstationEventPublisher,
+)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -33,6 +38,16 @@ def get_event_publisher() -> SessionEventPublisher:
     if settings.event_endpoint is not None:
         return HttpSessionEventPublisher(str(settings.event_endpoint))
     return InMemorySessionEventPublisher()
+
+
+@lru_cache
+def get_workstation_event_publisher() -> WorkstationEventPublisher:
+    """Return the workstation event publisher configured for the runner."""
+
+    settings = get_runner_settings()
+    if settings.workstation_event_endpoint is not None:
+        return HttpWorkstationEventPublisher(str(settings.workstation_event_endpoint))
+    return InMemoryWorkstationEventPublisher()
 
 
 @lru_cache
@@ -65,12 +80,16 @@ def get_session_manager() -> SessionManager:
 def get_warm_pool_manager() -> WarmPoolManager:
     """Return a cached :class:`WarmPoolManager` built from runner settings."""
 
-    return WarmPoolManager(get_runner_settings())
+    return WarmPoolManager(
+        get_runner_settings(),
+        workstation_event_publisher=get_workstation_event_publisher(),
+    )
 
 
 __all__ = [
     "get_event_publisher",
     "get_runner_settings",
+    "get_workstation_event_publisher",
     "get_warm_pool_manager",
     "get_session_manager",
     "get_vnc_controller",

--- a/services/runner/app/warm_pool.py
+++ b/services/runner/app/warm_pool.py
@@ -4,14 +4,23 @@ The runner keeps a dedicated pool of pre-warmed Camoufox instances so that
 interactive workloads can be attached with minimal latency.  The
 ``WarmPoolManager`` coordinates lifecycle transitions, isolates state between
 workstations, and optionally performs a navigation step so that browser tabs
-are primed before sessions are assigned.
+are primed before sessions are assigned.  Each lifecycle transition produces a
+``WorkstationEvent`` so downstream services receive timely updates.
 
 Example:
     >>> from app.config import RunnerSettings, WarmPoolConfig, WorkstationConfigEntry
+    >>> from app.workstation_events import InMemoryWorkstationEventPublisher
     >>> settings = RunnerSettings(runner_id="runner", camoufox_path="/usr/bin/camoufox")
-    >>> config = WarmPoolConfig(workstations=[WorkstationConfigEntry(id="ws-1")])
+    >>> config = WarmPoolConfig(
+    ...     workstations=[WorkstationConfigEntry(id="ws-1", fingerprint_id="fp-1")]
+    ... )
     >>> async def main() -> None:
-    ...     manager = WarmPoolManager(settings, warm_pool_config=config)
+    ...     publisher = InMemoryWorkstationEventPublisher()
+    ...     manager = WarmPoolManager(
+    ...         settings,
+    ...         warm_pool_config=config,
+    ...         workstation_event_publisher=publisher,
+    ...     )
     ...     await manager.start()
     ...     slot = await manager.reserve_slot()
     ...     await manager.mark_busy(slot.workstation_id)
@@ -29,8 +38,12 @@ import tempfile
 from asyncio import Lock
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
+from typing import Any
+
+from core import WorkstationEvent, WorkstationEventType, WorkstationMeta, WorkstationState
 
 from .browser import BrowserLaunchError, BrowserSessionHandle, launch_browser
 from .config import (
@@ -38,6 +51,10 @@ from .config import (
     WarmPoolConfig,
     WorkstationConfigEntry,
     load_warm_pool_config,
+)
+from .workstation_events import (
+    InMemoryWorkstationEventPublisher,
+    WorkstationEventPublisher,
 )
 
 __all__ = [
@@ -168,6 +185,7 @@ class WarmPoolManager:
         temp_dir_factory: Callable[[str], Path] | None = None,
         max_retries: int = 3,
         retry_base_delay: float = 0.5,
+        workstation_event_publisher: WorkstationEventPublisher | None = None,
     ) -> None:
         self._settings = settings
         self._launcher = launcher
@@ -180,6 +198,9 @@ class WarmPoolManager:
         self._config = warm_pool_config
         self._slots: dict[str, _WarmSlot] = {}
         self._draining = False
+        self._event_publisher = (
+            workstation_event_publisher or InMemoryWorkstationEventPublisher()
+        )
 
     async def start(self) -> None:
         """Load configuration and provision all workstations in the pool."""
@@ -203,6 +224,13 @@ class WarmPoolManager:
                         "state": slot.state.value,
                     },
                 )
+                await self._publish_workstation_event(
+                    self._create_workstation_event(
+                        slot,
+                        event_type=WorkstationEventType.CREATED,
+                        reason="provisioned",
+                    )
+                )
             except WarmPoolProvisioningError:
                 LOGGER.exception(
                     "Failed to provision warm pool slot",
@@ -210,6 +238,13 @@ class WarmPoolManager:
                         "workstation_id": entry.id,
                         "fingerprint_id": slot.fingerprint_id,
                     },
+                )
+                await self._publish_workstation_event(
+                    self._create_workstation_event(
+                        slot,
+                        event_type=WorkstationEventType.UPDATED,
+                        reason=self._format_last_error(slot),
+                    )
                 )
 
     async def reserve_slot(
@@ -244,11 +279,17 @@ class WarmPoolManager:
                 )
             slot.state = WarmPoolState.RESERVED
             snapshot = slot.snapshot()
-            return WarmPoolReservation(
-                snapshot=snapshot,
-                handle=slot.handle,
-                environment=dict(slot.last_launch_env),
+            event = self._create_workstation_event(
+                slot,
+                event_type=WorkstationEventType.UPDATED,
+                reason="reserved",
             )
+        await self._publish_workstation_event(event)
+        return WarmPoolReservation(
+            snapshot=snapshot,
+            handle=slot.handle,
+            environment=dict(slot.last_launch_env),
+        )
 
     async def mark_busy(self, workstation_id: str) -> WarmPoolSnapshot:
         """Transition a ``reserved`` slot into the ``busy`` state."""
@@ -260,7 +301,14 @@ class WarmPoolManager:
                     f"workstation '{workstation_id}' is not reserved"
                 )
             slot.state = WarmPoolState.BUSY
-            return slot.snapshot()
+            snapshot = slot.snapshot()
+            event = self._create_workstation_event(
+                slot,
+                event_type=WorkstationEventType.UPDATED,
+                reason="marked busy",
+            )
+        await self._publish_workstation_event(event)
+        return snapshot
 
     async def cancel_reservation(self, workstation_id: str) -> WarmPoolSnapshot:
         """Return a ``reserved`` slot back to ``idle`` without recycling."""
@@ -272,7 +320,14 @@ class WarmPoolManager:
                     f"workstation '{workstation_id}' is not reserved"
                 )
             slot.state = WarmPoolState.IDLE
-            return slot.snapshot()
+            snapshot = slot.snapshot()
+            event = self._create_workstation_event(
+                slot,
+                event_type=WorkstationEventType.UPDATED,
+                reason="reservation cancelled",
+            )
+        await self._publish_workstation_event(event)
+        return snapshot
 
     async def release_slot(self, workstation_id: str) -> WarmPoolSnapshot:
         """Recycle a slot after a busy session finishes."""
@@ -284,21 +339,39 @@ class WarmPoolManager:
                     f"workstation '{workstation_id}' cannot be recycled from {slot.state.value}"
                 )
             slot.state = WarmPoolState.RECYCLING
-            await self._teardown_slot(slot)
-            slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
-            try:
-                await self._provision_slot(slot)
-            except WarmPoolProvisioningError:
-                LOGGER.exception(
-                    "Warm pool slot recycle failed",
-                    extra={
-                        "workstation_id": slot.workstation.id,
-                        "fingerprint_id": slot.fingerprint_id,
-                    },
-                )
-                slot.state = WarmPoolState.ERROR
-                raise
-            return slot.snapshot()
+            event = self._create_workstation_event(
+                slot,
+                event_type=WorkstationEventType.UPDATED,
+                reason="recycling",
+            )
+        await self._publish_workstation_event(event)
+        await self._teardown_slot(slot)
+        slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
+        try:
+            await self._provision_slot(slot)
+        except WarmPoolProvisioningError:
+            LOGGER.exception(
+                "Warm pool slot recycle failed",
+                extra={
+                    "workstation_id": slot.workstation.id,
+                    "fingerprint_id": slot.fingerprint_id,
+                },
+            )
+            slot.state = WarmPoolState.ERROR
+            failure_event = self._create_workstation_event(
+                slot,
+                event_type=WorkstationEventType.UPDATED,
+                reason=self._format_last_error(slot),
+            )
+            await self._publish_workstation_event(failure_event)
+            raise
+        success_event = self._create_workstation_event(
+            slot,
+            event_type=WorkstationEventType.UPDATED,
+            reason="recycled",
+        )
+        await self._publish_workstation_event(success_event)
+        return slot.snapshot()
 
     async def drain(self) -> list[WarmPoolSnapshot]:
         """Stop accepting new reservations and tear down all slots."""
@@ -308,8 +381,14 @@ class WarmPoolManager:
         for slot in self._slots.values():
             async with slot.lock:
                 slot.state = WarmPoolState.DRAINING
+                event = self._create_workstation_event(
+                    slot,
+                    event_type=WorkstationEventType.RELEASED,
+                    reason="drain requested",
+                )
                 await self._teardown_slot(slot)
                 snapshots.append(slot.snapshot())
+            await self._publish_workstation_event(event)
         return snapshots
 
     def list_slots(self) -> list[WarmPoolSnapshot]:
@@ -505,4 +584,74 @@ class WarmPoolManager:
         """Allocate a dedicated temporary directory for ``workstation_id``."""
 
         return Path(tempfile.mkdtemp(prefix=f"warm-pool-{workstation_id}-"))
+
+    def _create_workstation_event(
+        self,
+        slot: _WarmSlot,
+        *,
+        event_type: WorkstationEventType,
+        reason: str | None = None,
+    ) -> WorkstationEvent:
+        """Build a :class:`WorkstationEvent` reflecting the slot state."""
+
+        metadata = self._build_workstation_metadata(slot)
+        meta = WorkstationMeta(
+            id=slot.workstation.id,
+            fingerprint_id=slot.fingerprint_id or slot.workstation.id,
+            state=self._map_state(slot.state),
+            proxy_summary=slot.proxy_url,
+            metadata=metadata,
+        )
+        return WorkstationEvent(
+            workstation=meta,
+            occurred_at=datetime.now(tz=UTC),
+            type=event_type,
+            reason=reason,
+        )
+
+    async def _publish_workstation_event(self, event: WorkstationEvent) -> None:
+        """Publish ``event`` via the configured workstation event transport."""
+
+        await self._event_publisher.publish(event)
+
+    @staticmethod
+    def _map_state(state: WarmPoolState) -> WorkstationState:
+        """Translate internal warm pool states to public workstation states."""
+
+        if state is WarmPoolState.IDLE:
+            return WorkstationState.AVAILABLE
+        if state in {WarmPoolState.RESERVED, WarmPoolState.BUSY}:
+            return WorkstationState.ASSIGNED
+        if state is WarmPoolState.RECYCLING:
+            return WorkstationState.PROVISIONING
+        return WorkstationState.UNAVAILABLE
+
+    def _build_workstation_metadata(self, slot: _WarmSlot) -> dict[str, Any]:
+        """Compose metadata payload shared with workstation events."""
+
+        metadata: dict[str, Any] = {}
+        if slot.workstation.label is not None:
+            metadata["label"] = slot.workstation.label
+        if slot.workstation.tags:
+            metadata["tags"] = list(slot.workstation.tags)
+        extras = {
+            key: value
+            for key, value in slot.workstation.model_extra.items()
+            if key not in {"fingerprint_id", "proxy", "proxy_url", "prefs_rel_path"}
+        }
+        if extras:
+            metadata.update(extras)
+        if slot.handle is not None:
+            metadata["ws_endpoint"] = slot.handle.ws_endpoint
+        if slot.last_error is not None:
+            metadata["last_error"] = self._format_last_error(slot)
+        return metadata
+
+    @staticmethod
+    def _format_last_error(slot: _WarmSlot) -> str:
+        """Return a stable description for the most recent slot error."""
+
+        if slot.last_error is None:
+            return "warm pool provisioning failed"
+        return str(slot.last_error)
 

--- a/services/runner/app/workstation_events.py
+++ b/services/runner/app/workstation_events.py
@@ -1,0 +1,121 @@
+"""Transport helpers for publishing workstation lifecycle events.
+
+The runner emits :class:`core.WorkstationEvent` objects whenever warm pool
+workstations change state.  This module mirrors the session event transport
+implementations so tests can observe emitted events and production
+installations can forward them to the gateway over HTTP.
+
+Example:
+    >>> publisher = InMemoryWorkstationEventPublisher()
+    >>> async def main() -> None:
+    ...     event = WorkstationEvent(...)
+    ...     await publisher.publish(event)
+    ...     drained = await publisher.drain()
+    ...     assert drained[0] is event
+    >>> # anyio.run(main)  # doctest: +SKIP
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Protocol
+
+import anyio
+import httpx
+from core import WorkstationEvent
+
+__all__ = [
+    "WorkstationEventPublisher",
+    "InMemoryWorkstationEventPublisher",
+    "CallbackWorkstationEventPublisher",
+    "HttpWorkstationEventPublisher",
+]
+
+
+class WorkstationEventPublisher(Protocol):
+    """Protocol implemented by workstation event transports."""
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Persist or forward a workstation lifecycle event."""
+
+
+class InMemoryWorkstationEventPublisher:
+    """Store workstation events in memory for assertions during tests.
+
+    The publisher mirrors :class:`InMemorySessionEventPublisher` and appends
+    events to an internal FIFO list guarded by an :class:`anyio.Lock` to
+    preserve ordering when invoked concurrently.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[WorkstationEvent] = []
+        self._lock = anyio.Lock()
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Append ``event`` to the in-memory buffer."""
+
+        async with self._lock:
+            self._events.append(event)
+
+    async def drain(self) -> list[WorkstationEvent]:
+        """Return and clear the buffered events in FIFO order."""
+
+        async with self._lock:
+            drained = list(self._events)
+            self._events.clear()
+            return drained
+
+
+class CallbackWorkstationEventPublisher:
+    """Proxy workstation events to an arbitrary asynchronous callback."""
+
+    def __init__(self, callback: Callable[[WorkstationEvent], Awaitable[None]]) -> None:
+        self._callback = callback
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Forward ``event`` to the configured callback."""
+
+        await self._callback(event)
+
+
+class HttpWorkstationEventPublisher:
+    """Publish workstation events to the gateway over HTTP.
+
+    Args:
+        endpoint: Absolute URL of the gateway endpoint accepting
+            :class:`WorkstationEvent` payloads.
+        client: Optional :class:`httpx.AsyncClient` to reuse across requests.
+        timeout: Request timeout applied when instantiating ad-hoc clients.
+    """
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+        timeout: float = 5.0,
+    ) -> None:
+        self._endpoint = endpoint
+        self._client = client
+        self._timeout = timeout
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Serialise ``event`` and POST it to the configured endpoint."""
+
+        payload = event.model_dump(mode="json", by_alias=True)
+        if self._client is not None:
+            response = await self._client.post(
+                self._endpoint,
+                json=payload,
+                timeout=self._timeout,
+            )
+            response.raise_for_status()
+            return
+
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self._endpoint,
+                json=payload,
+                timeout=self._timeout,
+            )
+            response.raise_for_status()

--- a/services/runner/tests/test_events.py
+++ b/services/runner/tests/test_events.py
@@ -1,4 +1,4 @@
-"""Unit tests covering session event publisher transports."""
+"""Unit tests covering session and workstation event publisher transports."""
 
 from __future__ import annotations
 
@@ -12,9 +12,23 @@ import pytest
 from app.dependencies.session_manager import (
     get_event_publisher,
     get_runner_settings,
+    get_workstation_event_publisher,
 )
 from app.events import HttpSessionEventPublisher
-from core import Session, SessionEvent, SessionEventType, SessionStatus
+from app.workstation_events import (
+    HttpWorkstationEventPublisher,
+    InMemoryWorkstationEventPublisher,
+)
+from core import (
+    Session,
+    SessionEvent,
+    SessionEventType,
+    SessionStatus,
+    WorkstationEvent,
+    WorkstationEventType,
+    WorkstationMeta,
+    WorkstationState,
+)
 
 
 @pytest.mark.anyio("asyncio")
@@ -53,6 +67,62 @@ async def test_http_session_event_publisher_posts_payload() -> None:
     assert captured["json"]["session"]["id"] == str(session.id)
 
 
+@pytest.mark.anyio("asyncio")
+async def test_http_workstation_event_publisher_posts_payload() -> None:
+    """Workstation events should be POSTed to the configured endpoint."""
+
+    captured: dict[str, Any] = {}
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["json"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(status_code=202)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(_handler))
+    publisher = HttpWorkstationEventPublisher(
+        "https://gateway.local/workstations/events",
+        client=client,
+    )
+
+    event = WorkstationEvent(
+        workstation=WorkstationMeta(
+            id="ws-1",
+            fingerprint_id="fp-1",
+            state=WorkstationState.AVAILABLE,
+        ),
+        occurred_at=datetime.now(tz=UTC),
+        type=WorkstationEventType.UPDATED,
+        reason="reserved",
+    )
+
+    await publisher.publish(event)
+    await client.aclose()
+
+    assert captured["url"] == "https://gateway.local/workstations/events"
+    assert captured["json"]["workstation"]["id"] == "ws-1"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_inmemory_workstation_event_publisher_drain() -> None:
+    """In-memory workstation publisher should store and drain events FIFO."""
+
+    publisher = InMemoryWorkstationEventPublisher()
+    event = WorkstationEvent(
+        workstation=WorkstationMeta(
+            id="ws-2",
+            fingerprint_id="fp-2",
+            state=WorkstationState.ASSIGNED,
+        ),
+        occurred_at=datetime.now(tz=UTC),
+        type=WorkstationEventType.UPDATED,
+    )
+
+    await publisher.publish(event)
+    drained = await publisher.drain()
+
+    assert drained == [event]
+
+
 def test_get_event_publisher_prefers_http_when_endpoint_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -68,4 +138,23 @@ def test_get_event_publisher_prefers_http_when_endpoint_configured(
     finally:
         monkeypatch.delenv("EVENT_ENDPOINT")
         get_event_publisher.cache_clear()
+        get_runner_settings.cache_clear()
+
+
+def test_get_workstation_event_publisher_prefers_http(monkeypatch: pytest.MonkeyPatch) -> None:
+    """WORKSTATION_EVENT_ENDPOINT should activate the HTTP publisher."""
+
+    get_runner_settings.cache_clear()
+    get_workstation_event_publisher.cache_clear()
+    monkeypatch.setenv(
+        "WORKSTATION_EVENT_ENDPOINT",
+        "https://gateway.local/workstations/events",
+    )
+
+    try:
+        publisher = get_workstation_event_publisher()
+        assert isinstance(publisher, HttpWorkstationEventPublisher)
+    finally:
+        monkeypatch.delenv("WORKSTATION_EVENT_ENDPOINT")
+        get_workstation_event_publisher.cache_clear()
         get_runner_settings.cache_clear()

--- a/services/runner/tests/test_warm_pool.py
+++ b/services/runner/tests/test_warm_pool.py
@@ -9,6 +9,8 @@ import pytest
 from app.browser import BrowserLaunchError
 from app.config import RunnerSettings, WarmPoolConfig, WorkstationConfigEntry
 from app.warm_pool import WarmPoolManager, WarmPoolSnapshot, WarmPoolState, WarmPoolStateError
+from app.workstation_events import InMemoryWorkstationEventPublisher
+from core import WorkstationEventType, WorkstationState
 
 
 class _StubHandle:
@@ -93,6 +95,7 @@ async def test_start_provisions_slots_with_env_and_prewarm(tmp_path: Path) -> No
         path.mkdir()
         return path
 
+    publisher = InMemoryWorkstationEventPublisher()
     manager = WarmPoolManager(
         settings,
         warm_pool_config=config,
@@ -100,9 +103,17 @@ async def test_start_provisions_slots_with_env_and_prewarm(tmp_path: Path) -> No
         navigator=navigator,
         sleep=sleep,
         temp_dir_factory=temp_dir_factory,
+        workstation_event_publisher=publisher,
     )
 
     await manager.start()
+
+    created_events = await publisher.drain()
+    assert len(created_events) == 1
+    created = created_events[0]
+    assert created.type is WorkstationEventType.CREATED
+    assert created.workstation.state is WorkstationState.AVAILABLE
+    assert created.reason == "provisioned"
 
     slots = manager.list_slots()
     assert len(slots) == 1
@@ -126,6 +137,12 @@ async def test_start_provisions_slots_with_env_and_prewarm(tmp_path: Path) -> No
     assert reservation.snapshot.state is WarmPoolState.RESERVED
     assert reservation.environment["CAMOUFOX_WORKSTATION_ID"] == "ws-1"
 
+    reserved_events = await publisher.drain()
+    assert len(reserved_events) == 1
+    reserved = reserved_events[0]
+    assert reserved.reason == "reserved"
+    assert reserved.workstation.state is WorkstationState.ASSIGNED
+
 
 @pytest.mark.anyio("asyncio")
 async def test_cancel_reservation_returns_slot_to_idle(tmp_path: Path) -> None:
@@ -146,19 +163,27 @@ async def test_cancel_reservation_returns_slot_to_idle(tmp_path: Path) -> None:
         handle.launch_env = dict(env)
         return handle
 
+    publisher = InMemoryWorkstationEventPublisher()
     manager = WarmPoolManager(
         settings,
         warm_pool_config=config,
         launcher=launcher,  # type: ignore[arg-type]
+        workstation_event_publisher=publisher,
     )
 
     await manager.start()
+    await publisher.drain()
     reservation = await manager.reserve_slot("ws-1")
     assert reservation.snapshot.state is WarmPoolState.RESERVED
+    await publisher.drain()
     snapshot = await manager.cancel_reservation("ws-1")
     assert snapshot.state is WarmPoolState.IDLE
+    cancel_events = await publisher.drain()
+    assert cancel_events[-1].reason == "reservation cancelled"
+    assert cancel_events[-1].workstation.state is WorkstationState.AVAILABLE
     follow_up = await manager.reserve_slot("ws-1")
     assert follow_up.snapshot.state is WarmPoolState.RESERVED
+    await publisher.drain()
 
 
 @pytest.mark.anyio("asyncio")
@@ -185,6 +210,7 @@ async def test_launch_failures_trigger_retries(tmp_path: Path) -> None:
     async def sleep(delay: float) -> None:
         sleep_calls.append(delay)
 
+    publisher = InMemoryWorkstationEventPublisher()
     manager = WarmPoolManager(
         settings,
         warm_pool_config=config,
@@ -192,9 +218,16 @@ async def test_launch_failures_trigger_retries(tmp_path: Path) -> None:
         sleep=sleep,
         max_retries=3,
         retry_base_delay=0.1,
+        workstation_event_publisher=publisher,
     )
 
     await manager.start()
+    failure_events = await publisher.drain()
+    assert failure_events
+    failed = failure_events[0]
+    assert failed.type is WorkstationEventType.UPDATED
+    assert failed.workstation.state is WorkstationState.UNAVAILABLE
+    assert failed.reason == "boom"
 
     slots = manager.list_slots()
     assert slots[0].state is WarmPoolState.ERROR
@@ -243,18 +276,23 @@ async def test_recycle_relaunches_with_same_fingerprint(tmp_path: Path) -> None:
         temp_roots.append(path)
         return path
 
+    publisher = InMemoryWorkstationEventPublisher()
     manager = WarmPoolManager(
         settings,
         warm_pool_config=config,
         launcher=launcher,  # type: ignore[arg-type]
         temp_dir_factory=temp_dir_factory,
+        workstation_event_publisher=publisher,
     )
 
     await manager.start()
+    await publisher.drain()
     assert handles
 
     await manager.reserve_slot("ws-1")
+    await publisher.drain()
     await manager.mark_busy("ws-1")
+    await publisher.drain()
     recycled = await manager.release_slot("ws-1")
 
     assert recycled.state is WarmPoolState.IDLE
@@ -264,6 +302,11 @@ async def test_recycle_relaunches_with_same_fingerprint(tmp_path: Path) -> None:
     assert env_history[1]["CAMOUFOX_FINGERPRINT_ID"] == "fp-keep"
     assert not temp_roots[0].exists()
     assert temp_roots[1].exists()
+
+    recycle_events = await publisher.drain()
+    assert [event.reason for event in recycle_events] == ["recycling", "recycled"]
+    assert recycle_events[0].workstation.state is WorkstationState.PROVISIONING
+    assert recycle_events[1].workstation.state is WorkstationState.AVAILABLE
 
 
 @pytest.mark.anyio("asyncio")
@@ -291,13 +334,16 @@ async def test_drain_transitions_slots_and_prevents_reservations(tmp_path: Path)
         handles.append(handle)
         return handle
 
+    publisher = InMemoryWorkstationEventPublisher()
     manager = WarmPoolManager(
         settings,
         warm_pool_config=config,
         launcher=launcher,  # type: ignore[arg-type]
+        workstation_event_publisher=publisher,
     )
 
     await manager.start()
+    await publisher.drain()
     drain_snapshots = await manager.drain()
 
     assert all(snapshot.state is WarmPoolState.DRAINING for snapshot in drain_snapshots)
@@ -306,4 +352,9 @@ async def test_drain_transitions_slots_and_prevents_reservations(tmp_path: Path)
 
     with pytest.raises(WarmPoolStateError):
         await manager.reserve_slot()
+
+    drain_events = await publisher.drain()
+    assert all(event.type is WorkstationEventType.RELEASED for event in drain_events)
+    assert {event.workstation.id for event in drain_events} == {"ws-1", "ws-2"}
+    assert all(event.workstation.state is WorkstationState.UNAVAILABLE for event in drain_events)
 


### PR DESCRIPTION
## Summary
- add a dedicated workstation event publisher module and emit WorkstationEvent updates from WarmPoolManager
- extend runner settings and dependencies to configure HTTP or in-memory transports for workstation events
- introduce workstation SSE/WS endpoints and bridges in the gateway and core, with updated tests and documentation

## Testing
- poetry run pytest -q (packages/core)
- PYTHONPATH=. poetry run pytest -q (services/runner)
- poetry run pytest -q (services/gateway)

## Security
- no security issues identified

------
https://chatgpt.com/codex/tasks/task_e_68de65b1cb3c832a89424fa60d04192e