### PR TITLE
Add workstation router and streaming events for warm pool

### DIFF
--- a/packages/core/core/models.py
+++ b/packages/core/core/models.py
@@ -779,7 +779,8 @@ class Session(BaseModel):
             and self.workstation.fingerprint_id != self.workstation_fingerprint_id
         ):
             raise ValueError(
-                "workstation.fingerprint_id must match workstation_fingerprint_id when both are provided"
+                "workstation.fingerprint_id must match "
+                "workstation_fingerprint_id when both are provided"
             )
 
         return self
@@ -902,13 +903,16 @@ class WorkstationEventType(str, Enum):
     """Event types describing workstation lifecycle transitions.
 
     Example:
-        >>> WorkstationEventType.UPDATED.value
-        'workstation.updated'
+        >>> WorkstationEventType.STATE_CHANGED.value
+        'workstation.state_changed'
     """
 
     CREATED = "workstation.created"
     UPDATED = "workstation.updated"
     RELEASED = "workstation.released"
+    STATE_CHANGED = "workstation.state_changed"
+    ERROR = "workstation.error"
+    RECYCLED = "workstation.recycled"
 
 
 class WorkstationEvent(BaseModel):

--- a/packages/core/tests/test_models.py
+++ b/packages/core/tests/test_models.py
@@ -13,7 +13,6 @@ from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
-
 from core import (
     InMemorySessionEventBridge,
     Runner,

--- a/packages/core/tests/test_models_validation.py
+++ b/packages/core/tests/test_models_validation.py
@@ -6,9 +6,6 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
-
-from pydantic import ValidationError
-
 from core.models import (
     Runner,
     RunnerState,
@@ -23,6 +20,7 @@ from core.models import (
     WorkstationMeta,
     WorkstationState,
 )
+from pydantic import ValidationError
 
 
 def _build_session(status: SessionStatus = SessionStatus.INIT) -> Session:

--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -21,11 +21,14 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
     runner-а: `runner_active_sessions`, `runner_reaper_runs_total`,
     `runner_reaper_expired_sessions_total`, `runner_reaper_last_run_timestamp`,
     `runner_vnc_allocations`, `runner_vnc_allocation_requests_total`.
-  - `GET /workstations` — возвращает снимки состояния warm-пула (idle/reserved/busy).
-  - `POST /workstations/reserve` — резервирует слот (по ID или первый idle) и отдаёт launch env.
-  - `POST /workstations/{id}/busy` — переводит слот из reserved в busy.
+  - `GET /workstations` — возвращает `WorkstationListResponse` с массивом `WorkstationSnapshotModel` (``workstation_id``, fingerprint, proxy, state).
+  - `POST /workstations/reserve` — принимает `WorkstationReservationRequest`, возвращает `WorkstationReservationResponse` (snapshot + launch env).
+  - `POST /workstations/{id}/busy` — переводит слот из reserved в busy, возвращает `WorkstationActionResponse`.
   - `POST /workstations/{id}/cancel` — откатывает неудачное резервирование в idle.
-  - `POST /workstations/{id}/release` — рециклирует busy слот обратно в idle.
+  - `POST /workstations/{id}/release` — рециклирует busy слот обратно в idle и возвращает новый snapshot.
+  - `POST /workstations/{id}/restart` — форсирует recycle браузера без участия сессий.
+  - `POST /workstations/{id}/drain` — помечает рабочую станцию как недоступную (state=`draining`).
+  - `POST /workstations/{id}/enable` — восстанавливает drained/error слот (перезапускает браузер).
 - **Event transport**
   - `SessionEventPublisher.publish(SessionEvent)` — protocol for pushing lifecycle events downstream. Default implementation stores events in memory (`InMemorySessionEventPublisher`) but can be swapped for HTTP/SSE bridges via `CallbackSessionEventPublisher`.
   - `HttpSessionEventPublisher` — при наличии `RunnerSettings.event_endpoint` POST-ит события на `gateway /events`.
@@ -46,11 +49,15 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
   (разрешены `extra`, чтобы операторы могли добавлять свои атрибуты). JSON-файл читается
   при старте через `load_warm_pool_config`, I/O и ошибки сериализации/валидации оборачиваются
   в `WarmPoolConfigError`.
+- REST-роутер `app.routers.workstations` использует Pydantic-модели `WorkstationSnapshotModel`,
+  `WorkstationListResponse`, `WorkstationReservationRequest/Response` и `WorkstationActionResponse`
+  для документирования и сериализации warm-пула.
 
 ## Decisions
 - **In-memory publisher**: Стандартный транспорт построен на `InMemorySessionEventPublisher` и считается продукционным решением; при необходимости можно оборачивать его через `CallbackSessionEventPublisher` для сторонних интеграций без отказа от in-memory ядра.
 - **HTTP publisher toggle**: `get_event_publisher` читает `RunnerSettings.event_endpoint` и, если URL задан, использует `HttpSessionEventPublisher`, публикующий события в Gateway через `POST /events`.
-- **Workstation events**: маршруты `/workstations` используют `WorkstationEventPublisher` (по умолчанию `InMemoryWorkstationEventPublisher`) и транслируют `WorkstationEvent` для синхронизации warm-пула с Gateway/UI.
+- **Workstation events**: `WarmPoolManager` публикует `workstation.state_changed|recycled|error` при любых переходах слота; маршруты `/workstations` только вызывают методы менеджера.
+- **SSE/WS обёртки**: `SseWorkstationEventPublisher` и `WebSocketWorkstationEventPublisher` форматируют события для стриминга в Gateway/UI.
 - **Camoufox stub dependency**: Для unit-тестов в CI runner использует локальный путь-зависимость `packages/camoufox`, реализующую CLI/API-совместимый stub. Это позволяет выполнять `poetry install` без доступа к проприетарному пакету.
 - **Process-backed VNC controller**: Non-headless sessions allocate Xvfb/x11vnc/websockify helpers via `ProcessVncController`. The controller maintains a bounded pool of displays and ports, composes public HTTP/WS URLs from `RunnerSettings`, and tears down helpers whenever sessions terminate or switch to headless mode.
 - **Gateway-signed VNC tokens**: Runner never persists VNC `token` or `token_ttl_seconds`; any user-supplied values are stripped and synthetic descriptors leave them `None` so that the gateway can issue signed credentials.
@@ -115,3 +122,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-16 · gpt-5-codex · Реализован ``WarmPoolManager`` с управлением состояниями, recycle, преднавигацией и юнит-тестами на ключевые сценарии.
 - 2025-10-17 · gpt-5-codex · Интегрирован warm pool в `SessionManager`/API, добавлен отклик 429 при нехватке слотов и покрытие тестами.
 - 2025-10-18 · gpt-5-codex · Добавлены REST-эндпоинты `/workstations*`, in-memory издатель `WorkstationEvent` и интеграционные тесты API.
+- 2025-10-19 · gpt-5-codex · Вынесены маршруты `/workstations` в отдельный роутер с Pydantic-моделями, WarmPoolManager публикует события state/error/recycled, добавлены SSE/WS-обёртки и интеграционные тесты.

--- a/services/runner/app/dependencies/session_manager.py
+++ b/services/runner/app/dependencies/session_manager.py
@@ -14,8 +14,8 @@ from ..events import (
     WorkstationEventPublisher,
 )
 from ..session_manager import SessionManager
-from ..warm_pool import WarmPoolManager
 from ..vnc import ProcessVncController, VncController, VncUnavailableError
+from ..warm_pool import WarmPoolManager
 
 LOGGER = logging.getLogger(__name__)
 
@@ -74,7 +74,10 @@ def get_session_manager() -> SessionManager:
 def get_warm_pool_manager() -> WarmPoolManager:
     """Return a cached :class:`WarmPoolManager` built from runner settings."""
 
-    return WarmPoolManager(get_runner_settings())
+    return WarmPoolManager(
+        get_runner_settings(),
+        event_publisher=get_workstation_event_publisher(),
+    )
 
 
 __all__ = [

--- a/services/runner/app/events.py
+++ b/services/runner/app/events.py
@@ -1,11 +1,10 @@
-"""Session event transport abstraction for the runner service."""
+"""Event publisher abstractions for session and workstation lifecycles."""
 
 from __future__ import annotations
 
+import json
 from collections.abc import Awaitable, Callable
-"""Event publisher abstractions for session and workstation lifecycles."""
-
-from typing import Protocol
+from typing import Any, Protocol
 
 import anyio
 import httpx
@@ -75,6 +74,86 @@ class InMemoryWorkstationEventPublisher:
             drained = list(self._events)
             self._events.clear()
             return drained
+
+
+class CallbackWorkstationEventPublisher:
+    """Proxy workstation events to an arbitrary asynchronous callback.
+
+    The wrapper mirrors :class:`CallbackSessionEventPublisher` but forwards
+    :class:`WorkstationEvent` payloads. It is primarily used by SSE and
+    WebSocket bridges that want to reuse the publisher protocol while
+    delegating delivery mechanics to framework-specific helpers.
+    """
+
+    def __init__(self, callback: Callable[[WorkstationEvent], Awaitable[None]]) -> None:
+        self._callback = callback
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Forward ``event`` to the configured callback."""
+
+        await self._callback(event)
+
+
+class SseWorkstationEventPublisher:
+    """Serialise workstation events to Server-Sent Events frames.
+
+    Args:
+        send: Coroutine used to emit encoded SSE payloads towards the client.
+            The callable receives a fully formatted SSE string including the
+            terminating blank line.
+        json_dumps: Optional callable used to serialise the event body. By
+            default :func:`json.dumps` is used.
+
+    Example:
+        >>> async def push(frame: str) -> None:
+        ...     sent_frames.append(frame)
+        >>> publisher = SseWorkstationEventPublisher(push)
+        >>> # await publisher.publish(event)  # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        send: Callable[[str], Awaitable[None]],
+        *,
+        json_dumps: Callable[[Any], str] | None = None,
+    ) -> None:
+        self._send = send
+        self._json_dumps = json_dumps or json.dumps
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Encode ``event`` as an SSE frame and push it downstream."""
+
+        payload = self._json_dumps(event.model_dump(mode="json", by_alias=True))
+        frame = f"event: {event.type.value}\ndata: {payload}\n\n"
+        await self._send(frame)
+
+
+class WebSocketWorkstationEventPublisher:
+    """Publish workstation events over an abstract WebSocket channel.
+
+    Args:
+        send: Coroutine used to transmit JSON-compatible dictionaries to the
+            connected WebSocket client.
+
+    Example:
+        >>> async def push(message: dict[str, Any]) -> None:
+        ...     delivered.append(message)
+        >>> publisher = WebSocketWorkstationEventPublisher(push)
+        >>> # await publisher.publish(event)  # doctest: +SKIP
+    """
+
+    def __init__(self, send: Callable[[dict[str, Any]], Awaitable[None]]) -> None:
+        self._send = send
+
+    async def publish(self, event: WorkstationEvent) -> None:
+        """Forward ``event`` as a JSON-compatible dictionary."""
+
+        await self._send(
+            {
+                "type": event.type.value,
+                "event": event.model_dump(mode="json", by_alias=True),
+            }
+        )
 
 
 class CallbackSessionEventPublisher:
@@ -159,10 +238,13 @@ class HttpSessionEventPublisher:
 
 
 __all__ = [
+    "CallbackWorkstationEventPublisher",
     "CallbackSessionEventPublisher",
     "HttpSessionEventPublisher",
     "InMemorySessionEventPublisher",
     "InMemoryWorkstationEventPublisher",
+    "SseWorkstationEventPublisher",
     "SessionEventPublisher",
+    "WebSocketWorkstationEventPublisher",
     "WorkstationEventPublisher",
 ]

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -2,17 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Annotated, Any
 from uuid import UUID
 
-from core.models import (
-    Session,
-    WorkstationEvent,
-    WorkstationEventType,
-    WorkstationMeta,
-    WorkstationState,
-)
+from core.models import Session
 from fastapi import Depends, FastAPI, HTTPException, Response, status
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
 
@@ -20,22 +14,19 @@ from .config import RunnerSettings
 from .dependencies import (
     get_runner_settings,
     get_session_manager,
-    get_warm_pool_manager,
-    get_workstation_event_publisher,
 )
 from .metrics import METRICS_REGISTRY
+from .routers import workstations_router
 from .session_manager import (
-    SessionCreatePayload,
     SessionCapacityError,
+    SessionCreatePayload,
     SessionManager,
     SessionNotFoundError,
     SessionUpdatePayload,
 )
-from .warm_pool import WarmPoolManager, WarmPoolSnapshot, WarmPoolState, WarmPoolStateError
-from .events import WorkstationEventPublisher
-from pydantic import BaseModel, Field
 
 app = FastAPI(title="Ghost Browsers Runner", version="0.1.0")
+app.include_router(workstations_router)
 
 
 def _normalise_base_url(url: Any | None) -> str | None:
@@ -69,19 +60,6 @@ def _normalise_base_url(url: Any | None) -> str | None:
 
 RunnerSettingsDep = Annotated[RunnerSettings, Depends(get_runner_settings)]
 SessionManagerDep = Annotated[SessionManager, Depends(get_session_manager)]
-WarmPoolManagerDep = Annotated[WarmPoolManager, Depends(get_warm_pool_manager)]
-WorkstationEventPublisherDep = Annotated[
-    WorkstationEventPublisher, Depends(get_workstation_event_publisher)
-]
-
-_WARM_TO_PUBLIC_STATE: dict[WarmPoolState, WorkstationState] = {
-    WarmPoolState.IDLE: WorkstationState.AVAILABLE,
-    WarmPoolState.RESERVED: WorkstationState.PROVISIONING,
-    WarmPoolState.BUSY: WorkstationState.ASSIGNED,
-    WarmPoolState.RECYCLING: WorkstationState.PROVISIONING,
-    WarmPoolState.DRAINING: WorkstationState.UNAVAILABLE,
-    WarmPoolState.ERROR: WorkstationState.UNAVAILABLE,
-}
 
 
 def _isoformat_or_none(value: datetime | None) -> str | None:
@@ -101,78 +79,6 @@ def _isoformat_or_none(value: datetime | None) -> str | None:
     if value is None:
         return None
     return value.isoformat()
-
-
-def _serialise_snapshot(snapshot: WarmPoolSnapshot) -> dict[str, Any]:
-    """Return a JSON payload describing the warm workstation snapshot."""
-
-    return {
-        "workstation_id": snapshot.workstation_id,
-        "fingerprint_id": snapshot.fingerprint_id,
-        "proxy_url": snapshot.proxy_url,
-        "state": snapshot.state.value,
-    }
-
-
-def _translate_state_error(exc: WarmPoolStateError) -> HTTPException:
-    """Translate warm pool state errors into FastAPI HTTP exceptions."""
-
-    message = str(exc)
-    lowered = message.lower()
-    status_code = status.HTTP_409_CONFLICT
-    if "unknown workstation" in lowered:
-        status_code = status.HTTP_404_NOT_FOUND
-    return HTTPException(status_code=status_code, detail=message)
-
-
-def _build_workstation_meta(
-    snapshot: WarmPoolSnapshot,
-    *,
-    metadata: dict[str, Any] | None = None,
-) -> WorkstationMeta:
-    """Construct :class:`WorkstationMeta` for event payloads."""
-
-    merged_metadata: dict[str, Any] = {}
-    if metadata:
-        merged_metadata.update(metadata)
-    if snapshot.proxy_url:
-        merged_metadata.setdefault("proxy_url", snapshot.proxy_url)
-    fingerprint = snapshot.fingerprint_id or "unknown"
-    return WorkstationMeta(
-        id=snapshot.workstation_id,
-        fingerprint_id=fingerprint,
-        state=_WARM_TO_PUBLIC_STATE.get(snapshot.state, WorkstationState.UNAVAILABLE),
-        proxy_summary=snapshot.proxy_url,
-        metadata=merged_metadata,
-    )
-
-
-async def _publish_workstation_event(
-    publisher: WorkstationEventPublisher,
-    snapshot: WarmPoolSnapshot,
-    *,
-    reason: str,
-    metadata: dict[str, Any] | None = None,
-    event_type: WorkstationEventType = WorkstationEventType.UPDATED,
-) -> None:
-    """Publish a workstation lifecycle event through ``publisher``."""
-
-    event = WorkstationEvent(
-        type=event_type,
-        workstation=_build_workstation_meta(snapshot, metadata=metadata),
-        occurred_at=datetime.now(UTC),
-        reason=reason,
-    )
-    await publisher.publish(event)
-
-
-class WorkstationReservationRequest(BaseModel):
-    """Input model used by :func:`reserve_workstation`."""
-
-    workstation_id: str | None = Field(
-        default=None,
-        description="Identifier of the workstation to reserve when specified.",
-    )
 
 
 @app.get("/health", summary="Runner health probe")
@@ -218,114 +124,6 @@ async def health(
             },
         },
     }
-
-
-@app.get("/workstations", summary="List warm workstation slots")
-async def list_workstations(manager: WarmPoolManagerDep) -> list[dict[str, Any]]:
-    """Return snapshots describing all configured warm workstations."""
-
-    return [_serialise_snapshot(snapshot) for snapshot in manager.list_slots()]
-
-
-@app.post(
-    "/workstations/reserve",
-    summary="Reserve an idle workstation",
-)
-async def reserve_workstation(
-    payload: WorkstationReservationRequest,
-    warm_pool: WarmPoolManagerDep,
-    publisher: WorkstationEventPublisherDep,
-) -> dict[str, Any]:
-    """Reserve a warm workstation slot and publish an event."""
-
-    try:
-        reservation = await warm_pool.reserve_slot(payload.workstation_id)
-    except WarmPoolStateError as exc:
-        raise _translate_state_error(exc) from exc
-    snapshot = reservation.snapshot
-    environment = dict(reservation.environment)
-    await _publish_workstation_event(
-        publisher,
-        snapshot,
-        reason="reserved",
-        metadata={"launch_env": environment},
-    )
-    return {
-        "snapshot": _serialise_snapshot(snapshot),
-        "environment": environment,
-    }
-
-
-@app.post(
-    "/workstations/{workstation_id}/busy",
-    summary="Mark a reserved workstation as busy",
-)
-async def mark_workstation_busy(
-    workstation_id: str,
-    warm_pool: WarmPoolManagerDep,
-    publisher: WorkstationEventPublisherDep,
-) -> dict[str, Any]:
-    """Transition ``workstation_id`` from reserved to busy state."""
-
-    try:
-        snapshot = await warm_pool.mark_busy(workstation_id)
-    except WarmPoolStateError as exc:
-        raise _translate_state_error(exc) from exc
-    await _publish_workstation_event(
-        publisher,
-        snapshot,
-        reason="busy",
-    )
-    return {"snapshot": _serialise_snapshot(snapshot)}
-
-
-@app.post(
-    "/workstations/{workstation_id}/cancel",
-    summary="Cancel a workstation reservation",
-)
-async def cancel_workstation_reservation(
-    workstation_id: str,
-    warm_pool: WarmPoolManagerDep,
-    publisher: WorkstationEventPublisherDep,
-) -> dict[str, Any]:
-    """Return ``workstation_id`` to idle when reservation setup fails."""
-
-    try:
-        snapshot = await warm_pool.cancel_reservation(workstation_id)
-    except WarmPoolStateError as exc:
-        raise _translate_state_error(exc) from exc
-    await _publish_workstation_event(
-        publisher,
-        snapshot,
-        reason="cancelled",
-    )
-    return {"snapshot": _serialise_snapshot(snapshot)}
-
-
-@app.post(
-    "/workstations/{workstation_id}/release",
-    summary="Release a busy workstation",
-)
-async def release_workstation(
-    workstation_id: str,
-    warm_pool: WarmPoolManagerDep,
-    publisher: WorkstationEventPublisherDep,
-) -> dict[str, Any]:
-    """Recycle ``workstation_id`` back to the idle pool and emit an event."""
-
-    try:
-        snapshot = await warm_pool.release_slot(workstation_id)
-    except WarmPoolStateError as exc:
-        raise _translate_state_error(exc) from exc
-    await _publish_workstation_event(
-        publisher,
-        snapshot,
-        reason="released",
-        event_type=WorkstationEventType.RELEASED,
-    )
-    return {"snapshot": _serialise_snapshot(snapshot)}
-
-
 @app.post(
     "/sessions",
     response_model=Session,

--- a/services/runner/app/routers/__init__.py
+++ b/services/runner/app/routers/__init__.py
@@ -1,0 +1,5 @@
+"""API routers exposed by the runner service."""
+
+from .workstations import router as workstations_router
+
+__all__ = ["workstations_router"]

--- a/services/runner/app/routers/workstations.py
+++ b/services/runner/app/routers/workstations.py
@@ -1,0 +1,252 @@
+"""FastAPI router exposing warm workstation management endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from ..dependencies import get_warm_pool_manager
+from ..warm_pool import (
+    WarmPoolManager,
+    WarmPoolReservation,
+    WarmPoolSnapshot,
+    WarmPoolState,
+    WarmPoolStateError,
+)
+
+__all__ = ["router"]
+
+router = APIRouter(prefix="/workstations", tags=["workstations"])
+
+WarmPoolManagerDep = Annotated[WarmPoolManager, Depends(get_warm_pool_manager)]
+
+
+class WorkstationSnapshotModel(BaseModel):
+    """Serialised representation of a warm pool workstation snapshot."""
+
+    workstation_id: str = Field(description="Identifier of the workstation slot")
+    fingerprint_id: str | None = Field(
+        default=None, description="Fingerprint assigned to the workstation"
+    )
+    proxy_url: str | None = Field(
+        default=None,
+        description="Proxy URL associated with the workstation when configured",
+    )
+    state: WarmPoolState = Field(description="Internal warm pool state of the workstation")
+
+    @classmethod
+    def from_snapshot(cls, snapshot: WarmPoolSnapshot) -> "WorkstationSnapshotModel":
+        """Create a response model from a :class:`WarmPoolSnapshot`."""
+
+        return cls(
+            workstation_id=snapshot.workstation_id,
+            fingerprint_id=snapshot.fingerprint_id,
+            proxy_url=snapshot.proxy_url,
+            state=snapshot.state,
+        )
+
+
+class WorkstationListResponse(BaseModel):
+    """Response model containing warm workstation snapshots."""
+
+    items: list[WorkstationSnapshotModel] = Field(
+        default_factory=list,
+        description="Collection of workstation snapshots in the warm pool",
+    )
+
+
+class WorkstationReservationRequest(BaseModel):
+    """Request payload for reserving an idle workstation."""
+
+    workstation_id: str | None = Field(
+        default=None,
+        description="Explicit workstation to reserve; pick the first idle slot when omitted",
+    )
+
+
+class WorkstationReservationResponse(BaseModel):
+    """Response model describing a successful workstation reservation."""
+
+    snapshot: WorkstationSnapshotModel = Field(
+        description="Snapshot captured immediately after reserving the workstation",
+    )
+    environment: dict[str, str] = Field(
+        description="Environment variables required to attach to the workstation",
+    )
+
+
+class WorkstationActionResponse(BaseModel):
+    """Response wrapper for actions that mutate a workstation state."""
+
+    snapshot: WorkstationSnapshotModel = Field(
+        description="Snapshot captured after applying the requested transition",
+    )
+
+
+def _translate_state_error(exc: WarmPoolStateError) -> HTTPException:
+    """Translate :class:`WarmPoolStateError` into an HTTPException."""
+
+    message = str(exc)
+    lowered = message.lower()
+    status_code = status.HTTP_409_CONFLICT
+    if "unknown workstation" in lowered:
+        status_code = status.HTTP_404_NOT_FOUND
+    return HTTPException(status_code=status_code, detail=message)
+
+
+def _serialise_reservation(reservation: WarmPoolReservation) -> WorkstationReservationResponse:
+    """Convert ``reservation`` into the public response model."""
+
+    snapshot_model = WorkstationSnapshotModel.from_snapshot(reservation.snapshot)
+    return WorkstationReservationResponse(
+        snapshot=snapshot_model,
+        environment=dict(reservation.environment),
+    )
+
+
+def _serialise_snapshot(snapshot: WarmPoolSnapshot) -> WorkstationActionResponse:
+    """Convert ``snapshot`` to a :class:`WorkstationActionResponse`."""
+
+    return WorkstationActionResponse(snapshot=WorkstationSnapshotModel.from_snapshot(snapshot))
+
+
+@router.get(
+    "",
+    response_model=WorkstationListResponse,
+    summary="List warm workstation slots",
+)
+async def list_workstations(manager: WarmPoolManagerDep) -> WorkstationListResponse:
+    """Return warm pool snapshots for all configured workstations."""
+
+    items = [
+        WorkstationSnapshotModel.from_snapshot(snapshot) for snapshot in manager.list_slots()
+    ]
+    return WorkstationListResponse(items=items)
+
+
+@router.post(
+    "/reserve",
+    response_model=WorkstationReservationResponse,
+    summary="Reserve an idle workstation",
+)
+async def reserve_workstation(
+    payload: WorkstationReservationRequest,
+    manager: WarmPoolManagerDep,
+) -> WorkstationReservationResponse:
+    """Reserve an idle workstation slot and expose its launch environment."""
+
+    try:
+        reservation = await manager.reserve_slot(payload.workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    return _serialise_reservation(reservation)
+
+
+@router.post(
+    "/{workstation_id}/busy",
+    response_model=WorkstationActionResponse,
+    summary="Mark a reserved workstation as busy",
+)
+async def mark_workstation_busy(
+    workstation_id: str,
+    manager: WarmPoolManagerDep,
+) -> WorkstationActionResponse:
+    """Transition ``workstation_id`` from reserved to busy state."""
+
+    try:
+        snapshot = await manager.mark_busy(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    return _serialise_snapshot(snapshot)
+
+
+@router.post(
+    "/{workstation_id}/cancel",
+    response_model=WorkstationActionResponse,
+    summary="Cancel a workstation reservation",
+)
+async def cancel_workstation_reservation(
+    workstation_id: str,
+    manager: WarmPoolManagerDep,
+) -> WorkstationActionResponse:
+    """Return ``workstation_id`` to idle when reservation setup fails."""
+
+    try:
+        snapshot = await manager.cancel_reservation(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    return _serialise_snapshot(snapshot)
+
+
+@router.post(
+    "/{workstation_id}/release",
+    response_model=WorkstationActionResponse,
+    summary="Release a busy workstation",
+)
+async def release_workstation(
+    workstation_id: str,
+    manager: WarmPoolManagerDep,
+) -> WorkstationActionResponse:
+    """Recycle ``workstation_id`` back to the idle pool."""
+
+    try:
+        snapshot = await manager.release_slot(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    return _serialise_snapshot(snapshot)
+
+
+@router.post(
+    "/{workstation_id}/restart",
+    response_model=WorkstationActionResponse,
+    summary="Restart a warm workstation",
+)
+async def restart_workstation(
+    workstation_id: str,
+    manager: WarmPoolManagerDep,
+) -> WorkstationActionResponse:
+    """Force a workstation to recycle its browser process."""
+
+    try:
+        snapshot = await manager.restart_slot(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    return _serialise_snapshot(snapshot)
+
+
+@router.post(
+    "/{workstation_id}/drain",
+    response_model=WorkstationActionResponse,
+    summary="Drain a warm workstation",
+)
+async def drain_workstation(
+    workstation_id: str,
+    manager: WarmPoolManagerDep,
+) -> WorkstationActionResponse:
+    """Stop using ``workstation_id`` for new reservations until re-enabled."""
+
+    try:
+        snapshot = await manager.drain_slot(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    return _serialise_snapshot(snapshot)
+
+
+@router.post(
+    "/{workstation_id}/enable",
+    response_model=WorkstationActionResponse,
+    summary="Enable a drained workstation",
+)
+async def enable_workstation(
+    workstation_id: str,
+    manager: WarmPoolManagerDep,
+) -> WorkstationActionResponse:
+    """Bring a drained workstation back into service."""
+
+    try:
+        snapshot = await manager.enable_slot(workstation_id)
+    except WarmPoolStateError as exc:
+        raise _translate_state_error(exc) from exc
+    return _serialise_snapshot(snapshot)

--- a/services/runner/app/warm_pool.py
+++ b/services/runner/app/warm_pool.py
@@ -29,8 +29,12 @@ import tempfile
 from asyncio import Lock
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
+from typing import Any
+
+from core.models import WorkstationEvent, WorkstationEventType, WorkstationMeta, WorkstationState
 
 from .browser import BrowserLaunchError, BrowserSessionHandle, launch_browser
 from .config import (
@@ -39,6 +43,7 @@ from .config import (
     WorkstationConfigEntry,
     load_warm_pool_config,
 )
+from .events import WorkstationEventPublisher
 
 __all__ = [
     "WarmPoolError",
@@ -54,6 +59,9 @@ __all__ = [
 LOGGER = logging.getLogger(__name__)
 
 
+_WARM_TO_PUBLIC_STATE: dict["WarmPoolState", WorkstationState] = {}
+
+
 class WarmPoolState(Enum):
     """Finite set of warm pool lifecycle states."""
 
@@ -63,6 +71,16 @@ class WarmPoolState(Enum):
     RECYCLING = "recycling"
     DRAINING = "draining"
     ERROR = "error"
+
+
+_WARM_TO_PUBLIC_STATE: dict[WarmPoolState, WorkstationState] = {
+    WarmPoolState.IDLE: WorkstationState.AVAILABLE,
+    WarmPoolState.RESERVED: WorkstationState.PROVISIONING,
+    WarmPoolState.BUSY: WorkstationState.ASSIGNED,
+    WarmPoolState.RECYCLING: WorkstationState.PROVISIONING,
+    WarmPoolState.DRAINING: WorkstationState.UNAVAILABLE,
+    WarmPoolState.ERROR: WorkstationState.UNAVAILABLE,
+}
 
 
 class WarmPoolError(RuntimeError):
@@ -168,6 +186,7 @@ class WarmPoolManager:
         temp_dir_factory: Callable[[str], Path] | None = None,
         max_retries: int = 3,
         retry_base_delay: float = 0.5,
+        event_publisher: WorkstationEventPublisher | None = None,
     ) -> None:
         self._settings = settings
         self._launcher = launcher
@@ -180,6 +199,111 @@ class WarmPoolManager:
         self._config = warm_pool_config
         self._slots: dict[str, _WarmSlot] = {}
         self._draining = False
+        self._event_publisher = event_publisher
+
+    def _build_workstation_meta(
+        self,
+        snapshot: WarmPoolSnapshot,
+        *,
+        metadata: dict[str, Any] | None = None,
+    ) -> WorkstationMeta:
+        """Return :class:`WorkstationMeta` derived from ``snapshot``."""
+
+        extra_metadata: dict[str, Any] = {"warm_pool_state": snapshot.state.value}
+        if snapshot.proxy_url:
+            extra_metadata.setdefault("proxy_url", snapshot.proxy_url)
+        if metadata:
+            extra_metadata.update(metadata)
+        fingerprint = snapshot.fingerprint_id or "unknown"
+        return WorkstationMeta(
+            id=snapshot.workstation_id,
+            fingerprint_id=fingerprint,
+            state=_WARM_TO_PUBLIC_STATE.get(snapshot.state, WorkstationState.UNAVAILABLE),
+            proxy_summary=snapshot.proxy_url,
+            metadata=extra_metadata,
+        )
+
+    async def _publish_event(
+        self,
+        slot: _WarmSlot,
+        snapshot: WarmPoolSnapshot,
+        *,
+        event_type: WorkstationEventType,
+        reason: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Publish ``snapshot`` using the configured workstation event transport."""
+
+        if self._event_publisher is None:
+            return
+        event = WorkstationEvent(
+            type=event_type,
+            workstation=self._build_workstation_meta(snapshot, metadata=metadata),
+            occurred_at=datetime.now(UTC),
+            reason=reason,
+        )
+        await self._event_publisher.publish(event)
+
+    async def _emit_state_change(
+        self,
+        slot: _WarmSlot,
+        snapshot: WarmPoolSnapshot,
+        *,
+        reason: str,
+        metadata: dict[str, Any] | None = None,
+    ) -> None:
+        """Emit a ``workstation.state_changed`` event for ``slot``."""
+
+        await self._publish_event(
+            slot,
+            snapshot,
+            event_type=WorkstationEventType.STATE_CHANGED,
+            reason=reason,
+            metadata=metadata,
+        )
+
+    async def _emit_recycled(
+        self,
+        slot: _WarmSlot,
+        snapshot: WarmPoolSnapshot,
+        *,
+        reason: str,
+    ) -> None:
+        """Emit a ``workstation.recycled`` event when a slot is re-provisioned."""
+
+        metadata: dict[str, Any] | None = None
+        if slot.last_launch_env:
+            metadata = {"launch_env": dict(slot.last_launch_env)}
+        await self._publish_event(
+            slot,
+            snapshot,
+            event_type=WorkstationEventType.RECYCLED,
+            reason=reason,
+            metadata=metadata,
+        )
+
+    async def _emit_error(
+        self,
+        slot: _WarmSlot,
+        snapshot: WarmPoolSnapshot,
+        *,
+        reason: str,
+    ) -> None:
+        """Emit a ``workstation.error`` event describing the last failure."""
+
+        metadata: dict[str, Any] | None = None
+        if slot.last_error is not None:
+            metadata = {
+                "error": str(slot.last_error),
+                "error_type": type(slot.last_error).__name__,
+            }
+        await self._publish_event(
+            slot,
+            snapshot,
+            event_type=WorkstationEventType.ERROR,
+            reason=reason,
+            metadata=metadata,
+        )
 
     async def start(self) -> None:
         """Load configuration and provision all workstations in the pool."""
@@ -203,6 +327,11 @@ class WarmPoolManager:
                         "state": slot.state.value,
                     },
                 )
+                await self._emit_state_change(
+                    slot,
+                    slot.snapshot(),
+                    reason="provisioned",
+                )
             except WarmPoolProvisioningError:
                 LOGGER.exception(
                     "Failed to provision warm pool slot",
@@ -210,6 +339,11 @@ class WarmPoolManager:
                         "workstation_id": entry.id,
                         "fingerprint_id": slot.fingerprint_id,
                     },
+                )
+                await self._emit_error(
+                    slot,
+                    slot.snapshot(),
+                    reason="provisioning-failed",
                 )
 
     async def reserve_slot(
@@ -244,11 +378,20 @@ class WarmPoolManager:
                 )
             slot.state = WarmPoolState.RESERVED
             snapshot = slot.snapshot()
-            return WarmPoolReservation(
-                snapshot=snapshot,
-                handle=slot.handle,
-                environment=dict(slot.last_launch_env),
-            )
+            handle = slot.handle
+            environment = dict(slot.last_launch_env)
+
+        await self._emit_state_change(
+            slot,
+            snapshot,
+            reason="reserved",
+            metadata={"launch_env": environment},
+        )
+        return WarmPoolReservation(
+            snapshot=snapshot,
+            handle=handle,
+            environment=environment,
+        )
 
     async def mark_busy(self, workstation_id: str) -> WarmPoolSnapshot:
         """Transition a ``reserved`` slot into the ``busy`` state."""
@@ -260,7 +403,10 @@ class WarmPoolManager:
                     f"workstation '{workstation_id}' is not reserved"
                 )
             slot.state = WarmPoolState.BUSY
-            return slot.snapshot()
+            snapshot = slot.snapshot()
+
+        await self._emit_state_change(slot, snapshot, reason="busy")
+        return snapshot
 
     async def cancel_reservation(self, workstation_id: str) -> WarmPoolSnapshot:
         """Return a ``reserved`` slot back to ``idle`` without recycling."""
@@ -272,45 +418,173 @@ class WarmPoolManager:
                     f"workstation '{workstation_id}' is not reserved"
                 )
             slot.state = WarmPoolState.IDLE
-            return slot.snapshot()
+            snapshot = slot.snapshot()
+
+        await self._emit_state_change(slot, snapshot, reason="reservation-cancelled")
+        return snapshot
 
     async def release_slot(self, workstation_id: str) -> WarmPoolSnapshot:
         """Recycle a slot after a busy session finishes."""
 
         slot = self._require_slot(workstation_id)
-        async with slot.lock:
-            if slot.state not in {WarmPoolState.BUSY, WarmPoolState.RESERVED}:
-                raise WarmPoolStateError(
-                    f"workstation '{workstation_id}' cannot be recycled from {slot.state.value}"
-                )
-            slot.state = WarmPoolState.RECYCLING
-            await self._teardown_slot(slot)
-            slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
-            try:
-                await self._provision_slot(slot)
-            except WarmPoolProvisioningError:
-                LOGGER.exception(
-                    "Warm pool slot recycle failed",
-                    extra={
-                        "workstation_id": slot.workstation.id,
-                        "fingerprint_id": slot.fingerprint_id,
-                    },
-                )
-                slot.state = WarmPoolState.ERROR
-                raise
-            return slot.snapshot()
+        recycling_snapshot: WarmPoolSnapshot | None = None
+        recycled_snapshot: WarmPoolSnapshot | None = None
+        error_snapshot: WarmPoolSnapshot | None = None
+        try:
+            async with slot.lock:
+                if slot.state not in {WarmPoolState.BUSY, WarmPoolState.RESERVED}:
+                    raise WarmPoolStateError(
+                        f"workstation '{workstation_id}' cannot be recycled from {slot.state.value}"
+                    )
+                slot.state = WarmPoolState.RECYCLING
+                recycling_snapshot = slot.snapshot()
+                await self._teardown_slot(slot)
+                slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
+                try:
+                    await self._provision_slot(slot)
+                except WarmPoolProvisioningError:
+                    LOGGER.exception(
+                        "Warm pool slot recycle failed",
+                        extra={
+                            "workstation_id": slot.workstation.id,
+                            "fingerprint_id": slot.fingerprint_id,
+                        },
+                    )
+                    slot.state = WarmPoolState.ERROR
+                    error_snapshot = slot.snapshot()
+                    raise
+                recycled_snapshot = slot.snapshot()
+        except WarmPoolProvisioningError:
+            if recycling_snapshot is not None:
+                await self._emit_state_change(slot, recycling_snapshot, reason="recycling")
+            if error_snapshot is not None:
+                await self._emit_error(slot, error_snapshot, reason="recycle-failed")
+            raise
+
+        assert recycling_snapshot is not None and recycled_snapshot is not None
+        await self._emit_state_change(slot, recycling_snapshot, reason="recycling")
+        await self._emit_recycled(slot, recycled_snapshot, reason="released")
+        return recycled_snapshot
 
     async def drain(self) -> list[WarmPoolSnapshot]:
         """Stop accepting new reservations and tear down all slots."""
 
         self._draining = True
         snapshots: list[WarmPoolSnapshot] = []
+        events: list[tuple[_WarmSlot, WarmPoolSnapshot]] = []
         for slot in self._slots.values():
             async with slot.lock:
                 slot.state = WarmPoolState.DRAINING
                 await self._teardown_slot(slot)
-                snapshots.append(slot.snapshot())
+                snapshot = slot.snapshot()
+                snapshots.append(snapshot)
+            events.append((slot, snapshot))
+        for slot, snapshot in events:
+            await self._emit_state_change(slot, snapshot, reason="drain")
         return snapshots
+
+    async def drain_slot(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Mark a single workstation as drained and unavailable."""
+
+        slot = self._require_slot(workstation_id)
+        async with slot.lock:
+            if slot.state not in {WarmPoolState.IDLE, WarmPoolState.ERROR}:
+                raise WarmPoolStateError(
+                    f"workstation '{workstation_id}' cannot be drained from {slot.state.value}"
+                )
+            slot.state = WarmPoolState.DRAINING
+            await self._teardown_slot(slot)
+            snapshot = slot.snapshot()
+
+        await self._emit_state_change(slot, snapshot, reason="drain-slot")
+        return snapshot
+
+    async def enable_slot(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Re-enable a previously drained workstation by re-provisioning it."""
+
+        slot = self._require_slot(workstation_id)
+        recycling_snapshot: WarmPoolSnapshot | None = None
+        enabled_snapshot: WarmPoolSnapshot | None = None
+        error_snapshot: WarmPoolSnapshot | None = None
+        try:
+            async with slot.lock:
+                if slot.state not in {WarmPoolState.DRAINING, WarmPoolState.ERROR}:
+                    raise WarmPoolStateError(
+                        f"workstation '{workstation_id}' cannot be enabled from {slot.state.value}"
+                    )
+                slot.state = WarmPoolState.RECYCLING
+                recycling_snapshot = slot.snapshot()
+                await self._teardown_slot(slot)
+                slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
+                try:
+                    await self._provision_slot(slot)
+                except WarmPoolProvisioningError:
+                    LOGGER.exception(
+                        "Warm pool slot enable failed",
+                        extra={
+                            "workstation_id": slot.workstation.id,
+                            "fingerprint_id": slot.fingerprint_id,
+                        },
+                    )
+                    slot.state = WarmPoolState.ERROR
+                    error_snapshot = slot.snapshot()
+                    raise
+                enabled_snapshot = slot.snapshot()
+        except WarmPoolProvisioningError:
+            if recycling_snapshot is not None:
+                await self._emit_state_change(slot, recycling_snapshot, reason="enable")
+            if error_snapshot is not None:
+                await self._emit_error(slot, error_snapshot, reason="enable-failed")
+            raise
+
+        assert recycling_snapshot is not None and enabled_snapshot is not None
+        await self._emit_state_change(slot, recycling_snapshot, reason="enable")
+        await self._emit_recycled(slot, enabled_snapshot, reason="enabled")
+        return enabled_snapshot
+
+    async def restart_slot(self, workstation_id: str) -> WarmPoolSnapshot:
+        """Forcefully recycle an idle workstation to refresh its environment."""
+
+        slot = self._require_slot(workstation_id)
+        recycling_snapshot: WarmPoolSnapshot | None = None
+        restarted_snapshot: WarmPoolSnapshot | None = None
+        error_snapshot: WarmPoolSnapshot | None = None
+        try:
+            async with slot.lock:
+                if slot.state not in {WarmPoolState.IDLE, WarmPoolState.ERROR}:
+                    raise WarmPoolStateError(
+                        "workstation "
+                        f"'{workstation_id}' cannot be restarted from {slot.state.value}"
+                    )
+                slot.state = WarmPoolState.RECYCLING
+                recycling_snapshot = slot.snapshot()
+                await self._teardown_slot(slot)
+                slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
+                try:
+                    await self._provision_slot(slot)
+                except WarmPoolProvisioningError:
+                    LOGGER.exception(
+                        "Warm pool slot restart failed",
+                        extra={
+                            "workstation_id": slot.workstation.id,
+                            "fingerprint_id": slot.fingerprint_id,
+                        },
+                    )
+                    slot.state = WarmPoolState.ERROR
+                    error_snapshot = slot.snapshot()
+                    raise
+                restarted_snapshot = slot.snapshot()
+        except WarmPoolProvisioningError:
+            if recycling_snapshot is not None:
+                await self._emit_state_change(slot, recycling_snapshot, reason="restart")
+            if error_snapshot is not None:
+                await self._emit_error(slot, error_snapshot, reason="restart-failed")
+            raise
+
+        assert recycling_snapshot is not None and restarted_snapshot is not None
+        await self._emit_state_change(slot, recycling_snapshot, reason="restart")
+        await self._emit_recycled(slot, restarted_snapshot, reason="restarted")
+        return restarted_snapshot
 
     def list_slots(self) -> list[WarmPoolSnapshot]:
         """Return snapshots for all known slots."""

--- a/services/runner/tests/test_config_warm_pool.py
+++ b/services/runner/tests/test_config_warm_pool.py
@@ -6,7 +6,6 @@ import json
 from pathlib import Path
 
 import pytest
-
 from app.config import (
     RunnerSettings,
     WarmPoolConfigError,

--- a/services/runner/tests/test_events.py
+++ b/services/runner/tests/test_events.py
@@ -1,4 +1,4 @@
-"""Unit tests covering session event publisher transports."""
+"""Integration tests covering session and workstation event publishers."""
 
 from __future__ import annotations
 
@@ -13,8 +13,21 @@ from app.dependencies.session_manager import (
     get_event_publisher,
     get_runner_settings,
 )
-from app.events import HttpSessionEventPublisher
-from core import Session, SessionEvent, SessionEventType, SessionStatus
+from app.events import (
+    HttpSessionEventPublisher,
+    SseWorkstationEventPublisher,
+    WebSocketWorkstationEventPublisher,
+)
+from core import (
+    Session,
+    SessionEvent,
+    SessionEventType,
+    SessionStatus,
+    WorkstationEvent,
+    WorkstationEventType,
+    WorkstationMeta,
+    WorkstationState,
+)
 
 
 @pytest.mark.anyio("asyncio")
@@ -69,3 +82,61 @@ def test_get_event_publisher_prefers_http_when_endpoint_configured(
         monkeypatch.delenv("EVENT_ENDPOINT")
         get_event_publisher.cache_clear()
         get_runner_settings.cache_clear()
+
+
+@pytest.mark.anyio("asyncio")
+async def test_sse_workstation_event_publisher_formats_frame() -> None:
+    """SSE publisher should encode workstation events as SSE frames."""
+
+    frames: list[str] = []
+
+    async def push(frame: str) -> None:
+        frames.append(frame)
+
+    publisher = SseWorkstationEventPublisher(push)
+    event = WorkstationEvent(
+        type=WorkstationEventType.STATE_CHANGED,
+        workstation=WorkstationMeta(
+            id="ws-1",
+            fingerprint_id="fp-1",
+            state=WorkstationState.AVAILABLE,
+        ),
+        occurred_at=datetime.now(tz=UTC),
+        reason="reserved",
+    )
+
+    await publisher.publish(event)
+
+    assert frames, "Frame should be emitted"
+    assert frames[0].startswith(f"event: {event.type.value}\n")
+    payload = frames[0].split("data: ", 1)[1].strip()
+    body = json.loads(payload)
+    assert body["workstation"]["id"] == "ws-1"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_websocket_workstation_event_publisher_forwards_payload() -> None:
+    """WebSocket publisher should forward JSON compatible payloads."""
+
+    messages: list[dict[str, Any]] = []
+
+    async def push(message: dict[str, Any]) -> None:
+        messages.append(message)
+
+    publisher = WebSocketWorkstationEventPublisher(push)
+    event = WorkstationEvent(
+        type=WorkstationEventType.RECYCLED,
+        workstation=WorkstationMeta(
+            id="ws-2",
+            fingerprint_id="fp-2",
+            state=WorkstationState.AVAILABLE,
+        ),
+        occurred_at=datetime.now(tz=UTC),
+        reason="restarted",
+    )
+
+    await publisher.publish(event)
+
+    assert messages, "Message should be emitted"
+    assert messages[0]["type"] == event.type.value
+    assert messages[0]["event"]["workstation"]["id"] == "ws-2"

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -10,8 +10,8 @@ from app.config import RunnerSettings
 from app.events import InMemorySessionEventPublisher
 from app.metrics import METRICS_REGISTRY
 from app.session_manager import (
-    SessionCreatePayload,
     SessionCapacityError,
+    SessionCreatePayload,
     SessionManager,
     SessionUpdatePayload,
 )

--- a/services/runner/tests/test_workstations_api.py
+++ b/services/runner/tests/test_workstations_api.py
@@ -2,23 +2,21 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections import defaultdict
+from pathlib import Path
 
 import pytest
+from app.browser import BrowserLaunchError
+from app.config import RunnerSettings, WarmPoolConfig, WorkstationConfigEntry
 from app.dependencies.session_manager import (
     get_warm_pool_manager,
     get_workstation_event_publisher,
 )
 from app.events import InMemoryWorkstationEventPublisher
 from app.main import app
-from app.warm_pool import (
-    WarmPoolReservation,
-    WarmPoolSnapshot,
-    WarmPoolState,
-    WarmPoolStateError,
-)
+from app.warm_pool import WarmPoolManager, WarmPoolState
 from core.models import WorkstationEventType, WorkstationState
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 
 @pytest.fixture
@@ -28,449 +26,323 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-class _StubWarmHandle:
-    """Minimal placeholder representing a warm workstation browser handle."""
+class _StubHandle:
+    """Minimal browser handle used by the warm pool during tests."""
 
     def __init__(self, workstation_id: str) -> None:
         self.workstation_id = workstation_id
+        self.shutdown_calls: list[dict[str, object]] = []
+
+    async def shutdown(self, *, force: bool, timeout: float = 5.0) -> None:
+        """Record shutdown invocations for assertions."""
+
+        self.shutdown_calls.append({"force": force, "timeout": timeout})
 
 
-class _StubWarmPoolManager:
-    """Async test double implementing the warm pool interface."""
+async def _build_warm_pool(
+    tmp_path: Path,
+    *,
+    workstations: list[str],
+    fail_next_launch: bool = False,
+) -> tuple[
+    WarmPoolManager,
+    InMemoryWorkstationEventPublisher,
+    list[_StubHandle],
+    list[dict[str, str]],
+]:
+    """Construct a warm pool manager wired with deterministic dependencies."""
 
-    def __init__(self, *, workstations: list[str] | None = None) -> None:
-        self._workstations = workstations or ["ws-1", "ws-2", "ws-3"]
-        self._slots: dict[str, dict[str, Any]] = {
-            workstation: {
-                "state": WarmPoolState.IDLE,
-                "fingerprint": f"fp-{workstation}",
-                "proxy": None,
-            }
-            for workstation in self._workstations
-        }
-        self.reservations: list[str] = []
-        self.busy: list[str] = []
-        self.cancellations: list[str] = []
-        self.releases: list[str] = []
+    publisher = InMemoryWorkstationEventPublisher()
+    settings = RunnerSettings()
+    config = WarmPoolConfig(
+        workstations=[WorkstationConfigEntry(id=identifier) for identifier in workstations]
+    )
+    handles: list[_StubHandle] = []
+    launch_env_history: list[dict[str, str]] = []
+    failure_counter = {"remaining": 0}
 
-    async def start(self) -> None:
-        """Real manager initialises slots; stub does nothing."""
+    async def launcher(
+        runner_settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        env: dict[str, str],
+    ) -> _StubHandle:
+        """Return synthetic handles while optionally simulating launch failures."""
 
-        return None
+        del runner_settings, browser, headless
+        if failure_counter["remaining"]:
+            failure_counter["remaining"] -= 1
+            raise BrowserLaunchError("synthetic launch failure")
+        launch_env_history.append(dict(env))
+        handle = _StubHandle(env["CAMOUFOX_WORKSTATION_ID"])
+        handles.append(handle)
+        return handle
 
-    def list_slots(self) -> list[WarmPoolSnapshot]:
-        """Return current slot snapshots for the warm pool."""
+    counters: defaultdict[str, int] = defaultdict(int)
 
-        return [
-            WarmPoolSnapshot(
-                workstation_id=workstation,
-                fingerprint_id=slot["fingerprint"],
-                proxy_url=slot["proxy"],
-                state=slot["state"],
-            )
-            for workstation, slot in self._slots.items()
-        ]
+    def temp_dir_factory(workstation_id: str) -> Path:
+        """Allocate unique temporary directories per workstation."""
 
-    async def reserve_slot(
-        self, workstation_id: str | None = None
-    ) -> WarmPoolReservation:
-        """Reserve the requested workstation or the first idle slot."""
+        index = counters[workstation_id]
+        counters[workstation_id] += 1
+        path = tmp_path / f"warm-{workstation_id}-{index}"
+        path.mkdir(parents=True, exist_ok=True)
+        return path
 
-        target = workstation_id or self._first_idle()
-        slot = self._require_slot(target)
-        if slot["state"] is not WarmPoolState.IDLE:
-            raise WarmPoolStateError(f"workstation '{target}' is not idle")
-        slot["state"] = WarmPoolState.RESERVED
-        self.reservations.append(target)
-        snapshot = WarmPoolSnapshot(
-            workstation_id=target,
-            fingerprint_id=slot["fingerprint"],
-            proxy_url=slot["proxy"],
-            state=WarmPoolState.RESERVED,
-        )
-        env = {
-            "CAMOUFOX_WORKSTATION_ID": target,
-            "CAMOUFOX_FINGERPRINT_ID": slot["fingerprint"],
-        }
-        return WarmPoolReservation(
-            snapshot=snapshot,
-            handle=_StubWarmHandle(target),
-            environment=env,
-        )
-
-    async def mark_busy(self, workstation_id: str) -> WarmPoolSnapshot:
-        """Mark a reserved workstation as busy."""
-
-        slot = self._require_slot(workstation_id)
-        if slot["state"] is not WarmPoolState.RESERVED:
-            raise WarmPoolStateError(f"workstation '{workstation_id}' is not reserved")
-        slot["state"] = WarmPoolState.BUSY
-        self.busy.append(workstation_id)
-        return WarmPoolSnapshot(
-            workstation_id=workstation_id,
-            fingerprint_id=slot["fingerprint"],
-            proxy_url=slot["proxy"],
-            state=WarmPoolState.BUSY,
-        )
-
-    async def cancel_reservation(self, workstation_id: str) -> WarmPoolSnapshot:
-        """Return a reserved workstation to idle."""
-
-        slot = self._require_slot(workstation_id)
-        if slot["state"] is not WarmPoolState.RESERVED:
-            raise WarmPoolStateError(f"workstation '{workstation_id}' is not reserved")
-        slot["state"] = WarmPoolState.IDLE
-        self.cancellations.append(workstation_id)
-        return WarmPoolSnapshot(
-            workstation_id=workstation_id,
-            fingerprint_id=slot["fingerprint"],
-            proxy_url=slot["proxy"],
-            state=WarmPoolState.IDLE,
-        )
-
-    async def release_slot(self, workstation_id: str) -> WarmPoolSnapshot:
-        """Recycle a busy workstation back to idle."""
-
-        slot = self._require_slot(workstation_id)
-        if slot["state"] not in {WarmPoolState.BUSY, WarmPoolState.RESERVED}:
-            raise WarmPoolStateError(
-                f"workstation '{workstation_id}' cannot be recycled from {slot['state'].value}"
-            )
-        slot["state"] = WarmPoolState.IDLE
-        self.releases.append(workstation_id)
-        return WarmPoolSnapshot(
-            workstation_id=workstation_id,
-            fingerprint_id=slot["fingerprint"],
-            proxy_url=slot["proxy"],
-            state=WarmPoolState.IDLE,
-        )
-
-    def _require_slot(self, workstation_id: str) -> dict[str, Any]:
-        try:
-            return self._slots[workstation_id]
-        except KeyError as exc:
-            raise WarmPoolStateError(
-                f"unknown workstation '{workstation_id}'"
-            ) from exc
-
-    def _first_idle(self) -> str:
-        for workstation_id, slot in self._slots.items():
-            if slot["state"] is WarmPoolState.IDLE:
-                return workstation_id
-        raise WarmPoolStateError("no idle warm workstations available")
+    manager = WarmPoolManager(
+        settings,
+        warm_pool_config=config,
+        launcher=launcher,  # type: ignore[arg-type]
+        temp_dir_factory=temp_dir_factory,
+        event_publisher=publisher,
+    )
+    await manager.start()
+    await publisher.drain()
+    if fail_next_launch:
+        failure_counter["remaining"] = 3
+    return manager, publisher, handles, launch_env_history
 
 
 async def _override_dependencies(
-    warm_pool: _StubWarmPoolManager,
-    publisher: InMemoryWorkstationEventPublisher,
+    manager: WarmPoolManager, publisher: InMemoryWorkstationEventPublisher
 ) -> None:
-    """Replace warm pool and event publisher dependencies for the test scope."""
+    """Override FastAPI dependencies for the duration of a test."""
 
     get_warm_pool_manager.cache_clear()
     get_workstation_event_publisher.cache_clear()
-    app.dependency_overrides[get_warm_pool_manager] = lambda: warm_pool
+    app.dependency_overrides[get_warm_pool_manager] = lambda: manager
     app.dependency_overrides[get_workstation_event_publisher] = lambda: publisher
 
 
 def _reset_overrides() -> None:
-    """Clear FastAPI dependency overrides set for integration tests."""
+    """Clear dependency overrides applied during a test run."""
 
     app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio("asyncio")
-async def test_reserve_workstation_success() -> None:
-    """``POST /workstations/reserve`` should reserve a slot and emit an event."""
+async def test_list_workstations_returns_snapshot(tmp_path: Path) -> None:
+    """``GET /workstations`` should expose configured warm pool slots."""
 
-    warm_pool = _StubWarmPoolManager(workstations=["ws-alpha"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
+    manager, publisher, _, _ = await _build_warm_pool(tmp_path, workstations=["ws-a", "ws-b"])
+    await _override_dependencies(manager, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.get("/workstations")
+    finally:
+        await manager.drain()
+        _reset_overrides()
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["items"][0]["workstation_id"] == "ws-a"
+    assert body["items"][0]["state"] == WarmPoolState.IDLE.value
+
+
+@pytest.mark.anyio("asyncio")
+async def test_reserve_workstation_emits_state_change(tmp_path: Path) -> None:
+    """Reserving a workstation should emit a state change event with launch env."""
+
+    manager, publisher, _, env_history = await _build_warm_pool(
+        tmp_path, workstations=["ws-alpha"]
+    )
+    await _override_dependencies(manager, publisher)
 
     try:
         async with AsyncClient(app=app, base_url="http://test") as client:
             response = await client.post(
-                "/workstations/reserve", json={"workstation_id": "ws-alpha"}
+                "/workstations/reserve",
+                json={"workstation_id": "ws-alpha"},
             )
     finally:
+        await manager.drain()
         _reset_overrides()
 
+    events = await publisher.drain()
     assert response.status_code == 200
     body = response.json()
-    assert body["snapshot"]["workstation_id"] == "ws-alpha"
     assert body["snapshot"]["state"] == WarmPoolState.RESERVED.value
-    assert body["environment"] == {
-        "CAMOUFOX_WORKSTATION_ID": "ws-alpha",
-        "CAMOUFOX_FINGERPRINT_ID": "fp-ws-alpha",
-    }
-    assert warm_pool.reservations == ["ws-alpha"]
+    assert events and events[0].type is WorkstationEventType.STATE_CHANGED
+    assert events[0].reason == "reserved"
+    assert events[0].workstation.state is WorkstationState.PROVISIONING
+    assert events[0].workstation.metadata["launch_env"]["CAMOUFOX_WORKSTATION_ID"] == "ws-alpha"
+    assert env_history and env_history[0]["CAMOUFOX_WORKSTATION_ID"] == "ws-alpha"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_mark_busy_emits_state_event(tmp_path: Path) -> None:
+    """Transition into BUSY should emit a workstation.state_changed event."""
+
+    manager, publisher, _, _ = await _build_warm_pool(tmp_path, workstations=["ws-1"])
+    await _override_dependencies(manager, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            await client.post("/workstations/reserve", json={"workstation_id": "ws-1"})
+            await publisher.drain()
+            response = await client.post("/workstations/ws-1/busy")
+    finally:
+        await manager.drain()
+        _reset_overrides()
+
     events = await publisher.drain()
-    assert len(events) == 1
-    event = events[0]
-    assert event.type is WorkstationEventType.UPDATED
-    assert event.reason == "reserved"
-    assert event.workstation.id == "ws-alpha"
-    assert event.workstation.state is WorkstationState.PROVISIONING
-    assert event.workstation.metadata["launch_env"] == body["environment"]
-
-
-@pytest.mark.anyio("asyncio")
-async def test_reserve_workstation_conflict_when_not_idle() -> None:
-    """Reserving an already reserved workstation should return HTTP 409."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-beta"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            first = await client.post(
-                "/workstations/reserve", json={"workstation_id": "ws-beta"}
-            )
-            assert first.status_code == 200
-            response = await client.post(
-                "/workstations/reserve", json={"workstation_id": "ws-beta"}
-            )
-    finally:
-        _reset_overrides()
-
-    assert response.status_code == 409
-    assert "not idle" in response.json()["detail"]
-
-
-@pytest.mark.anyio("asyncio")
-async def test_reserve_workstation_unknown_identifier() -> None:
-    """Unknown workstations should surface as HTTP 404 responses."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-known"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            response = await client.post(
-                "/workstations/reserve", json={"workstation_id": "ws-missing"}
-            )
-    finally:
-        _reset_overrides()
-
-    assert response.status_code == 404
-    assert response.json()["detail"].startswith("unknown workstation")
-
-
-@pytest.mark.anyio("asyncio")
-async def test_mark_workstation_busy_success() -> None:
-    """``POST /workstations/{id}/busy`` should transition to busy and emit an event."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-busy"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            reserve = await client.post(
-                "/workstations/reserve", json={"workstation_id": "ws-busy"}
-            )
-            assert reserve.status_code == 200
-            response = await client.post("/workstations/ws-busy/busy")
-    finally:
-        _reset_overrides()
-
     assert response.status_code == 200
-    assert response.json()["snapshot"]["state"] == WarmPoolState.BUSY.value
-    assert warm_pool.busy == ["ws-busy"]
+    assert events[0].type is WorkstationEventType.STATE_CHANGED
+    assert events[0].reason == "busy"
+    assert events[0].workstation.state is WorkstationState.ASSIGNED
+
+
+@pytest.mark.anyio("asyncio")
+async def test_cancel_reservation_emits_state_event(tmp_path: Path) -> None:
+    """Cancelling a reservation should emit a workstation.state_changed event."""
+
+    manager, publisher, _, _ = await _build_warm_pool(tmp_path, workstations=["ws-2"])
+    await _override_dependencies(manager, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            await client.post("/workstations/reserve", json={"workstation_id": "ws-2"})
+            await publisher.drain()
+            response = await client.post("/workstations/ws-2/cancel")
+    finally:
+        await manager.drain()
+        _reset_overrides()
+
     events = await publisher.drain()
-    assert [event.reason for event in events][-1] == "busy"
-    assert events[-1].workstation.state is WorkstationState.ASSIGNED
-
-
-@pytest.mark.anyio("asyncio")
-async def test_mark_workstation_busy_conflict_when_idle() -> None:
-    """Marking a workstation busy without a reservation should fail with 409."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-idle"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            response = await client.post("/workstations/ws-idle/busy")
-    finally:
-        _reset_overrides()
-
-    assert response.status_code == 409
-    assert "not reserved" in response.json()["detail"]
-
-
-@pytest.mark.anyio("asyncio")
-async def test_mark_workstation_busy_unknown_identifier() -> None:
-    """Busy endpoint should return 404 for unknown workstations."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-catalog"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            response = await client.post("/workstations/ws-absent/busy")
-    finally:
-        _reset_overrides()
-
-    assert response.status_code == 404
-    assert response.json()["detail"].startswith("unknown workstation")
-
-
-@pytest.mark.anyio("asyncio")
-async def test_cancel_reservation_success() -> None:
-    """Cancelling a reservation should return the workstation to idle."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-cancel"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            reserve = await client.post(
-                "/workstations/reserve", json={"workstation_id": "ws-cancel"}
-            )
-            assert reserve.status_code == 200
-            response = await client.post("/workstations/ws-cancel/cancel")
-    finally:
-        _reset_overrides()
-
     assert response.status_code == 200
-    assert response.json()["snapshot"]["state"] == WarmPoolState.IDLE.value
-    assert warm_pool.cancellations == ["ws-cancel"]
+    assert events[0].type is WorkstationEventType.STATE_CHANGED
+    assert events[0].reason == "reservation-cancelled"
+    assert events[0].workstation.state is WorkstationState.AVAILABLE
+
+
+@pytest.mark.anyio("asyncio")
+async def test_release_workstation_emits_recycled_event(tmp_path: Path) -> None:
+    """Releasing a workstation should emit state change and recycled events."""
+
+    manager, publisher, handles, _ = await _build_warm_pool(tmp_path, workstations=["ws-r"])
+    await _override_dependencies(manager, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            await client.post("/workstations/reserve", json={"workstation_id": "ws-r"})
+            await client.post("/workstations/ws-r/busy")
+            await publisher.drain()
+            response = await client.post("/workstations/ws-r/release")
+    finally:
+        await manager.drain()
+        _reset_overrides()
+
     events = await publisher.drain()
-    assert events[-1].reason == "cancelled"
-    assert events[-1].workstation.state is WorkstationState.AVAILABLE
-
-
-@pytest.mark.anyio("asyncio")
-async def test_cancel_reservation_conflict_when_idle() -> None:
-    """Cancelling a workstation without a reservation should raise HTTP 409."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-free"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            response = await client.post("/workstations/ws-free/cancel")
-    finally:
-        _reset_overrides()
-
-    assert response.status_code == 409
-    assert "not reserved" in response.json()["detail"]
-
-
-@pytest.mark.anyio("asyncio")
-async def test_cancel_reservation_unknown_identifier() -> None:
-    """Cancel endpoint should surface unknown workstations as HTTP 404."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-list"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            response = await client.post("/workstations/ws-missing/cancel")
-    finally:
-        _reset_overrides()
-
-    assert response.status_code == 404
-    assert response.json()["detail"].startswith("unknown workstation")
-
-
-@pytest.mark.anyio("asyncio")
-async def test_release_workstation_success() -> None:
-    """Releasing a busy workstation should recycle the slot and emit events."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-release"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            reserve = await client.post(
-                "/workstations/reserve", json={"workstation_id": "ws-release"}
-            )
-            assert reserve.status_code == 200
-            busy = await client.post("/workstations/ws-release/busy")
-            assert busy.status_code == 200
-            response = await client.post("/workstations/ws-release/release")
-    finally:
-        _reset_overrides()
-
     assert response.status_code == 200
-    assert response.json()["snapshot"]["state"] == WarmPoolState.IDLE.value
-    assert warm_pool.releases == ["ws-release"]
-    events = await publisher.drain()
-    assert events[-1].reason == "released"
-    assert events[-1].type is WorkstationEventType.RELEASED
-    assert events[-1].workstation.state is WorkstationState.AVAILABLE
+    event_types = [event.type for event in events]
+    assert WorkstationEventType.STATE_CHANGED in event_types
+    assert WorkstationEventType.RECYCLED in event_types
+    assert any(
+        event.reason == "recycling"
+        for event in events
+        if event.type is WorkstationEventType.STATE_CHANGED
+    )
+    recycled_event = next(
+        event for event in events if event.type is WorkstationEventType.RECYCLED
+    )
+    assert recycled_event.reason == "released"
+    assert recycled_event.workstation.state is WorkstationState.AVAILABLE
+    assert handles and handles[0].shutdown_calls, "Handle should have been recycled"
 
 
 @pytest.mark.anyio("asyncio")
-async def test_release_workstation_conflict_when_idle() -> None:
-    """Releasing an idle workstation should report HTTP 409."""
+async def test_restart_endpoint_recycles_slot(tmp_path: Path) -> None:
+    """Restart should recycle the workstation and emit recycle events."""
 
-    warm_pool = _StubWarmPoolManager(workstations=["ws-idle-release"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            response = await client.post("/workstations/ws-idle-release/release")
-    finally:
-        _reset_overrides()
-
-    assert response.status_code == 409
-    assert "cannot be recycled" in response.json()["detail"]
-
-
-@pytest.mark.anyio("asyncio")
-async def test_release_workstation_unknown_identifier() -> None:
-    """Release endpoint should return HTTP 404 for unknown identifiers."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-known-release"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
+    manager, publisher, _, _ = await _build_warm_pool(tmp_path, workstations=["ws-restart"])
+    await _override_dependencies(manager, publisher)
 
     try:
         async with AsyncClient(app=app, base_url="http://test") as client:
-            response = await client.post("/workstations/ws-ghost/release")
+            await publisher.drain()
+            response = await client.post("/workstations/ws-restart/restart")
     finally:
-        _reset_overrides()
-
-    assert response.status_code == 404
-    assert response.json()["detail"].startswith("unknown workstation")
-
-
-@pytest.mark.anyio("asyncio")
-async def test_workstation_event_stream_tracks_full_lifecycle() -> None:
-    """A full reserve → busy → release flow should emit ordered events."""
-
-    warm_pool = _StubWarmPoolManager(workstations=["ws-flow"])
-    publisher = InMemoryWorkstationEventPublisher()
-    await _override_dependencies(warm_pool, publisher)
-
-    try:
-        async with AsyncClient(app=app, base_url="http://test") as client:
-            await client.post("/workstations/reserve", json={"workstation_id": "ws-flow"})
-            await client.post("/workstations/ws-flow/busy")
-            await client.post("/workstations/ws-flow/release")
-    finally:
+        await manager.drain()
         _reset_overrides()
 
     events = await publisher.drain()
-    assert [event.reason for event in events] == ["reserved", "busy", "released"]
-    assert [event.type for event in events] == [
-        WorkstationEventType.UPDATED,
-        WorkstationEventType.UPDATED,
-        WorkstationEventType.RELEASED,
-    ]
-    assert [event.workstation.state for event in events] == [
-        WorkstationState.PROVISIONING,
-        WorkstationState.ASSIGNED,
-        WorkstationState.AVAILABLE,
-    ]
+    assert response.status_code == 200
+    event_types = [event.type for event in events]
+    assert WorkstationEventType.STATE_CHANGED in event_types
+    assert WorkstationEventType.RECYCLED in event_types
+    assert any(
+        event.reason == "restart"
+        for event in events
+        if event.type is WorkstationEventType.STATE_CHANGED
+    )
+    recycled_event = next(
+        event for event in events if event.type is WorkstationEventType.RECYCLED
+    )
+    assert recycled_event.reason == "restarted"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_drain_and_enable_cycle(tmp_path: Path) -> None:
+    """Drain and enable endpoints should toggle availability and emit events."""
+
+    manager, publisher, _, _ = await _build_warm_pool(tmp_path, workstations=["ws-cycle"])
+    await _override_dependencies(manager, publisher)
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            drain_response = await client.post("/workstations/ws-cycle/drain")
+            drain_events = await publisher.drain()
+            enable_response = await client.post("/workstations/ws-cycle/enable")
+    finally:
+        await manager.drain()
+        _reset_overrides()
+
+    enable_events = await publisher.drain()
+    assert drain_response.status_code == 200
+    assert drain_events[0].type is WorkstationEventType.STATE_CHANGED
+    assert drain_events[0].reason == "drain-slot"
+    assert drain_events[0].workstation.state is WorkstationState.UNAVAILABLE
+
+    assert enable_response.status_code == 200
+    enable_types = [event.type for event in enable_events]
+    assert WorkstationEventType.STATE_CHANGED in enable_types
+    assert WorkstationEventType.RECYCLED in enable_types
+    assert any(
+        event.reason == "enable"
+        for event in enable_events
+        if event.type is WorkstationEventType.STATE_CHANGED
+    )
+    recycled_event = next(
+        event for event in enable_events
+        if event.type is WorkstationEventType.RECYCLED
+    )
+    assert recycled_event.reason == "enabled"
+    assert recycled_event.workstation.state is WorkstationState.AVAILABLE
+
+
+@pytest.mark.anyio("asyncio")
+async def test_restart_failure_emits_error_event(tmp_path: Path) -> None:
+    """Failed restarts should surface ``workstation.error`` events."""
+
+    manager, publisher, _, _ = await _build_warm_pool(
+        tmp_path, workstations=["ws-fail"], fail_next_launch=True
+    )
+    await _override_dependencies(manager, publisher)
+
+    try:
+        transport = ASGITransport(app=app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            await publisher.drain()
+            response = await client.post("/workstations/ws-fail/restart")
+    finally:
+        await manager.drain()
+        _reset_overrides()
+
+    events = await publisher.drain()
+    assert response.status_code == 500
+    assert any(event.type is WorkstationEventType.ERROR for event in events)
+    error_event = next(event for event in events if event.type is WorkstationEventType.ERROR)
+    assert error_event.reason == "restart-failed"
+    assert error_event.workstation.state is WorkstationState.UNAVAILABLE


### PR DESCRIPTION
## Summary
- add a dedicated workstations router with typed request/response models and restart/drain/enable operations
- extend the warm pool manager to publish workstation state, recycle, and error events, and wire SSE/WebSocket wrappers
- document the new workstation event types in core models and refresh integration tests for the HTTP and streaming flows

## Testing
- `cd packages/core && PYTHONPATH=. poetry run pytest -q`
- `cd packages/core && poetry run ruff check .`
- `cd services/runner && PYTHONPATH=../../packages/core:. poetry run pytest -q`
- `cd services/runner && poetry run ruff check .`

## Security
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68de6d7e0270832aa8ab432ec58e6145