### PR TITLE
Add warm pool instrumentation and logging defaults

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -43,6 +43,10 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - Prometheus-инструментация живёт в `app.metrics` и использует отдельный `CollectorRegistry`;
   `SessionManager` синхронизирует gauge/counter-метрики при создании/завершении сессий,
   аллокации VNC и работе idle-reaper-а.
+- Дополнительно экспортируются warm-pool gauges (`runner_workstations_*`), histogram
+  `runner_workstation_recycle_seconds`, summary `runner_session_allocate_seconds` и счётчики
+  ошибок навигации/прокси; `WarmPoolManager` и `SessionManager` обновляют значения при смене
+  состояния.
 - Конфигурация пула прогретых рабочих станций описывается `WarmPoolConfig`
   (`app.config.warm_pool`). Запись (`WorkstationConfigEntry`) содержит хотя бы `id`
   (строгая уникальность, проверяется валидатором) и произвольные дополнительные поля
@@ -75,6 +79,9 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - **Prometheus registry**: Runner экспортирует `/metrics`, используя
   `prometheus_client.CollectorRegistry`; значения обновляются в момент изменения состояния
   (`active_sessions`, VNC аллокации, пробеги reaper-а) вместо ленивой агрегации на запрос.
+- **Structured logging defaults**: `app.logging.configure_logging()` обеспечивает единый формат
+  логов и гарантирует наличие полей `session_id`, `workstation_id`, `fingerprint_id` даже при
+  отсутствии значений в `extra`.
 - **JSON-конфиг пула прогрева**: Дополнительные параметры окружения (`WARM_POOL_CONFIG_PATH`,
   `BROWSER_PREFS_PATH`, `PREWARM_NAVIGATION`, `START_URL`, `START_URL_WAIT_MS`) разбираются в
   `RunnerSettings`. Отдельный JSON-файл описывает warm pool; при ошибках чтения/валидации
@@ -123,3 +130,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-17 · gpt-5-codex · Интегрирован warm pool в `SessionManager`/API, добавлен отклик 429 при нехватке слотов и покрытие тестами.
 - 2025-10-18 · gpt-5-codex · Добавлены REST-эндпоинты `/workstations*`, in-memory издатель `WorkstationEvent` и интеграционные тесты API.
 - 2025-10-19 · gpt-5-codex · Вынесены маршруты `/workstations` в отдельный роутер с Pydantic-моделями, WarmPoolManager публикует события state/error/recycled, добавлены SSE/WS-обёртки и интеграционные тесты.
+- 2025-10-20 · gpt-5-codex · Добавлены warm-pool метрики/таймеры, расширен `/health` данными пула и настроен формат логов с идентификаторами; обновлены тесты `/metrics` и `/health`.

--- a/services/runner/app/logging.py
+++ b/services/runner/app/logging.py
@@ -1,0 +1,58 @@
+"""Logging helpers ensuring consistent structured fields across the runner."""
+
+from __future__ import annotations
+
+import logging
+
+__all__ = ["configure_logging"]
+
+
+_CONFIGURED = False
+
+
+def configure_logging() -> None:
+    """Initialise logging so that common context fields are always present.
+
+    The runner enriches log records with ``session_id``, ``workstation_id`` and
+    ``fingerprint_id`` metadata.  When a handler emits a record without these
+    fields the standard library would normally raise ``KeyError`` if the
+    formatter references them.  This helper installs a custom log record factory
+    that guarantees the attributes exist with a ``"-"`` placeholder and updates
+    the root logger's handlers to use a consistent format.
+
+    Example:
+        >>> configure_logging()
+        >>> logger = logging.getLogger("runner.test")
+        >>> logger.info("hello", extra={"session_id": "s-1"})
+        hello  # doctest: +SKIP
+    """
+
+    global _CONFIGURED
+    if _CONFIGURED:
+        return
+
+    format_string = (
+        "%(asctime)s %(levelname)s %(name)s %(message)s "
+        "session_id=%(session_id)s workstation_id=%(workstation_id)s "
+        "fingerprint_id=%(fingerprint_id)s"
+    )
+
+    class RunnerFormatter(logging.Formatter):
+        """Formatter that backfills missing context identifiers."""
+
+        def format(self, record: logging.LogRecord) -> str:  # type: ignore[override]
+            for field in ("session_id", "workstation_id", "fingerprint_id"):
+                if not hasattr(record, field):
+                    setattr(record, field, "-")
+            return super().format(record)
+
+    formatter = RunnerFormatter(format_string)
+
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(level=logging.INFO)
+    for handler in root_logger.handlers:
+        handler.setFormatter(formatter)
+
+    _CONFIGURED = True
+

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -15,6 +15,7 @@ from .dependencies import (
     get_runner_settings,
     get_session_manager,
 )
+from .logging import configure_logging
 from .metrics import METRICS_REGISTRY
 from .routers import workstations_router
 from .session_manager import (
@@ -24,6 +25,8 @@ from .session_manager import (
     SessionNotFoundError,
     SessionUpdatePayload,
 )
+
+configure_logging()
 
 app = FastAPI(title="Ghost Browsers Runner", version="0.1.0")
 app.include_router(workstations_router)
@@ -91,6 +94,15 @@ async def health(
     active_slots = metrics.active_sessions
     total_slots = settings.slot_limit
     available_slots = max(total_slots - active_slots, 0)
+    warm_pool_stats = manager.get_warm_pool_statistics()
+    warm_pool_payload = {
+        "enabled": warm_pool_stats is not None and warm_pool_stats.total > 0,
+        "total": warm_pool_stats.total if warm_pool_stats else 0,
+        "idle": warm_pool_stats.idle if warm_pool_stats else 0,
+        "busy": warm_pool_stats.busy if warm_pool_stats else 0,
+        "error": warm_pool_stats.error if warm_pool_stats else 0,
+        "draining": warm_pool_stats.draining if warm_pool_stats else False,
+    }
     return {
         "status": "ok",
         "runner_id": settings.runner_id,
@@ -100,6 +112,7 @@ async def health(
             "active": active_slots,
             "available": available_slots,
         },
+        "warm_pool": warm_pool_payload,
         "vnc": {
             "http_base_url": str(settings.vnc_http_base_url),
             "ws_base_url": str(settings.vnc_ws_base_url),
@@ -112,6 +125,8 @@ async def health(
             "socks_base_url": _normalise_base_url(settings.proxy_socks_base_url),
         },
         "prewarm": {
+            "enabled": settings.prewarm_navigation,
+            "start_url": str(settings.start_url) if settings.start_url else None,
             "failures": metrics.prewarm_failure_count,
             "last_error": metrics.last_prewarm_error,
         },

--- a/services/runner/app/metrics.py
+++ b/services/runner/app/metrics.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from prometheus_client import CollectorRegistry, Counter, Gauge
+from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, Summary
 
 METRICS_REGISTRY = CollectorRegistry()
 
@@ -49,12 +49,76 @@ VNC_ALLOCATION_REQUESTS_COUNTER = Counter(
 )
 
 
+WORKSTATIONS_TOTAL_GAUGE = Gauge(
+    "runner_workstations_total",
+    "Total number of warm workstations managed by the pool.",
+    registry=METRICS_REGISTRY,
+)
+
+
+WORKSTATIONS_IDLE_GAUGE = Gauge(
+    "runner_workstations_idle",
+    "Warm workstations currently available for reservation.",
+    registry=METRICS_REGISTRY,
+)
+
+
+WORKSTATIONS_BUSY_GAUGE = Gauge(
+    "runner_workstations_busy",
+    "Warm workstations that are reserved, busy, or recycling.",
+    registry=METRICS_REGISTRY,
+)
+
+
+WORKSTATIONS_ERROR_GAUGE = Gauge(
+    "runner_workstations_error",
+    "Warm workstations stuck in an error state requiring operator action.",
+    registry=METRICS_REGISTRY,
+)
+
+
+WORKSTATION_RECYCLE_SECONDS = Histogram(
+    "runner_workstation_recycle_seconds",
+    "Time spent recycling a workstation back into the idle pool.",
+    registry=METRICS_REGISTRY,
+)
+
+
+SESSION_ALLOCATE_SECONDS = Summary(
+    "runner_session_allocate_seconds",
+    "Latency of session allocation including warm pool reservation.",
+    registry=METRICS_REGISTRY,
+)
+
+
+WORKSTATION_PROXY_ERRORS_COUNTER = Counter(
+    "runner_workstation_proxy_errors_total",
+    "Total number of workstation provisioning failures attributed to proxies.",
+    registry=METRICS_REGISTRY,
+)
+
+
+WORKSTATION_NAVIGATION_ERRORS_COUNTER = Counter(
+    "runner_workstation_navigation_errors_total",
+    "Total number of prewarm navigation failures encountered by the pool.",
+    registry=METRICS_REGISTRY,
+)
+
+
 __all__ = [
     "ACTIVE_SESSIONS_GAUGE",
     "METRICS_REGISTRY",
     "REAPER_EXPIRED_SESSIONS_COUNTER",
     "REAPER_LAST_RUN_GAUGE",
     "REAPER_RUNS_COUNTER",
+    "SESSION_ALLOCATE_SECONDS",
     "VNC_ALLOCATION_REQUESTS_COUNTER",
     "VNC_ALLOCATIONS_GAUGE",
+    "WORKSTATION_NAVIGATION_ERRORS_COUNTER",
+    "WORKSTATION_PROXY_ERRORS_COUNTER",
+    "WORKSTATION_RECYCLE_SECONDS",
+    "WORKSTATIONS_BUSY_GAUGE",
+    "WORKSTATIONS_ERROR_GAUGE",
+    "WORKSTATIONS_IDLE_GAUGE",
+    "WORKSTATIONS_TOTAL_GAUGE",
 ]

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -6,6 +6,7 @@ import contextlib
 from collections import deque
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
+from time import perf_counter
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -30,6 +31,7 @@ from .metrics import (
     REAPER_EXPIRED_SESSIONS_COUNTER,
     REAPER_LAST_RUN_GAUGE,
     REAPER_RUNS_COUNTER,
+    SESSION_ALLOCATE_SECONDS,
     VNC_ALLOCATION_REQUESTS_COUNTER,
     VNC_ALLOCATIONS_GAUGE,
 )
@@ -39,6 +41,7 @@ from .warm_pool import (
     WarmPoolProvisioningError,
     WarmPoolReservation,
     WarmPoolStateError,
+    WarmPoolStatistics,
 )
 
 
@@ -190,73 +193,77 @@ class SessionManager:
     async def create_session(self, payload: SessionCreatePayload) -> Session:
         """Create, persist, and broadcast a new session object."""
 
-        async with self._lock:
-            session_id = uuid4()
-            now = self._clock()
-            sanitized_vnc = self._sanitize_vnc_payload(payload.vnc)
-            vnc_details, vnc_handle = await self._resolve_vnc(
-                payload,
-                session_id,
-                sanitized_vnc=sanitized_vnc,
-            )
-            try:
-                reservation = await self._reserve_warm_slot(payload.metadata)
-            except Exception:
-                await self._discard_vnc_handle(session_id, vnc_handle)
-                raise
-            workstation_id = reservation.snapshot.workstation_id
-            browser_handle = reservation.handle
-            metadata = self._merge_warm_pool_metadata(
-                dict(payload.metadata), reservation
-            )
-            if browser_handle.pid is not None:
-                metadata.setdefault("runner_browser_pid", browser_handle.pid)
-            vnc_enabled = (
-                payload.vnc_enabled
-                if payload.vnc_enabled is not None
-                else (vnc_details is not None and not payload.headless)
-            )
-            try:
-                session = Session(
-                    id=session_id,
-                    runner_id=self._settings.runner_id,
-                    status=payload.status,
-                    created_at=now,
-                    last_seen_at=now,
-                    headless=payload.headless,
-                    idle_ttl_seconds=payload.idle_ttl_seconds,
-                    start_url=payload.start_url,
-                    start_url_wait=payload.start_url_wait,
-                    browser=payload.browser,
-                    labels=payload.labels,
-                    ws_endpoint=browser_handle.ws_endpoint,
-                    proxy=payload.proxy,
-                    vnc=vnc_details,
-                    vnc_enabled=vnc_enabled,
-                    metadata=metadata,
+        start_time = perf_counter()
+        try:
+            async with self._lock:
+                session_id = uuid4()
+                now = self._clock()
+                sanitized_vnc = self._sanitize_vnc_payload(payload.vnc)
+                vnc_details, vnc_handle = await self._resolve_vnc(
+                    payload,
+                    session_id,
+                    sanitized_vnc=sanitized_vnc,
                 )
-            except Exception:
-                await self._cancel_warm_reservation(workstation_id)
-                await self._discard_vnc_handle(session_id, vnc_handle)
-                raise
-            try:
-                await self._mark_warm_slot_busy(workstation_id)
-            except SessionCapacityError:
-                await self._cancel_warm_reservation(workstation_id)
-                await self._discard_vnc_handle(session_id, vnc_handle)
-                raise
-            self._sessions[session_id] = session
-            self._browser_handles[session_id] = browser_handle
-            self._warm_sessions[session_id] = workstation_id
-            if vnc_handle is not None:
-                self._vnc_handles[session_id] = vnc_handle
-            VNC_ALLOCATIONS_GAUGE.set(len(self._vnc_handles))
-            self._recalculate_next_idle_expiry_locked()
-            if session.status is not SessionStatus.DEAD:
-                self._active_sessions += 1
-                ACTIVE_SESSIONS_GAUGE.set(self._active_sessions)
-            await self._publish(session, SessionEventType.CREATED, reason=None)
-            return session
+                try:
+                    reservation = await self._reserve_warm_slot(payload.metadata)
+                except Exception:
+                    await self._discard_vnc_handle(session_id, vnc_handle)
+                    raise
+                workstation_id = reservation.snapshot.workstation_id
+                browser_handle = reservation.handle
+                metadata = self._merge_warm_pool_metadata(
+                    dict(payload.metadata), reservation
+                )
+                if browser_handle.pid is not None:
+                    metadata.setdefault("runner_browser_pid", browser_handle.pid)
+                vnc_enabled = (
+                    payload.vnc_enabled
+                    if payload.vnc_enabled is not None
+                    else (vnc_details is not None and not payload.headless)
+                )
+                try:
+                    session = Session(
+                        id=session_id,
+                        runner_id=self._settings.runner_id,
+                        status=payload.status,
+                        created_at=now,
+                        last_seen_at=now,
+                        headless=payload.headless,
+                        idle_ttl_seconds=payload.idle_ttl_seconds,
+                        start_url=payload.start_url,
+                        start_url_wait=payload.start_url_wait,
+                        browser=payload.browser,
+                        labels=payload.labels,
+                        ws_endpoint=browser_handle.ws_endpoint,
+                        proxy=payload.proxy,
+                        vnc=vnc_details,
+                        vnc_enabled=vnc_enabled,
+                        metadata=metadata,
+                    )
+                except Exception:
+                    await self._cancel_warm_reservation(workstation_id)
+                    await self._discard_vnc_handle(session_id, vnc_handle)
+                    raise
+                try:
+                    await self._mark_warm_slot_busy(workstation_id)
+                except SessionCapacityError:
+                    await self._cancel_warm_reservation(workstation_id)
+                    await self._discard_vnc_handle(session_id, vnc_handle)
+                    raise
+                self._sessions[session_id] = session
+                self._browser_handles[session_id] = browser_handle
+                self._warm_sessions[session_id] = workstation_id
+                if vnc_handle is not None:
+                    self._vnc_handles[session_id] = vnc_handle
+                VNC_ALLOCATIONS_GAUGE.set(len(self._vnc_handles))
+                self._recalculate_next_idle_expiry_locked()
+                if session.status is not SessionStatus.DEAD:
+                    self._active_sessions += 1
+                    ACTIVE_SESSIONS_GAUGE.set(self._active_sessions)
+                await self._publish(session, SessionEventType.CREATED, reason=None)
+                return session
+        finally:
+            SESSION_ALLOCATE_SECONDS.observe(perf_counter() - start_time)
 
     async def update_session(self, session_id: UUID, payload: SessionUpdatePayload) -> Session:
         """Apply a partial update to a stored session and broadcast the change."""
@@ -344,6 +351,14 @@ class SessionManager:
 
         async with self._lock:
             return list(self._sessions.values())
+
+    def get_warm_pool_statistics(self) -> WarmPoolStatistics | None:
+        """Return warm pool utilisation statistics for health reporting."""
+
+        warm_pool = self._warm_pool
+        if warm_pool is None:
+            return None
+        return warm_pool.get_statistics()
 
     async def record_prewarm_failure(self, message: str) -> None:
         """Append ``message`` to the rolling prewarm failure history."""

--- a/services/runner/app/warm_pool.py
+++ b/services/runner/app/warm_pool.py
@@ -27,11 +27,13 @@ import logging
 import shutil
 import tempfile
 from asyncio import Lock
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from enum import Enum
 from pathlib import Path
+from time import perf_counter
 from typing import Any
 
 from core.models import WorkstationEvent, WorkstationEventType, WorkstationMeta, WorkstationState
@@ -44,6 +46,15 @@ from .config import (
     load_warm_pool_config,
 )
 from .events import WorkstationEventPublisher
+from .metrics import (
+    WORKSTATION_NAVIGATION_ERRORS_COUNTER,
+    WORKSTATION_PROXY_ERRORS_COUNTER,
+    WORKSTATION_RECYCLE_SECONDS,
+    WORKSTATIONS_BUSY_GAUGE,
+    WORKSTATIONS_ERROR_GAUGE,
+    WORKSTATIONS_IDLE_GAUGE,
+    WORKSTATIONS_TOTAL_GAUGE,
+)
 
 __all__ = [
     "WarmPoolError",
@@ -51,6 +62,7 @@ __all__ = [
     "WarmPoolProvisioningError",
     "WarmPoolReservation",
     "WarmPoolSnapshot",
+    "WarmPoolStatistics",
     "WarmPoolState",
     "WarmPoolStateError",
 ]
@@ -140,6 +152,17 @@ class WarmPoolReservation:
     environment: dict[str, str]
 
 
+@dataclass(frozen=True)
+class WarmPoolStatistics:
+    """Aggregated view of warm pool utilisation used by health reporting."""
+
+    total: int
+    idle: int
+    busy: int
+    error: int
+    draining: bool
+
+
 class WarmPoolManager:
     """Coordinate lifecycle of pre-warmed Camoufox workstations.
 
@@ -200,6 +223,7 @@ class WarmPoolManager:
         self._slots: dict[str, _WarmSlot] = {}
         self._draining = False
         self._event_publisher = event_publisher
+        self._update_state_metrics()
 
     def _build_workstation_meta(
         self,
@@ -312,11 +336,13 @@ class WarmPoolManager:
             self._config = self._config_loader(self._settings.warm_pool_config_path)
         if self._config is None or not self._config.workstations:
             LOGGER.info("Warm pool disabled: no configuration entries discovered")
+            self._update_state_metrics()
             return
 
         for entry in self._config.workstations:
             slot = self._build_slot(entry)
             self._slots[entry.id] = slot
+            self._update_state_metrics()
             try:
                 await self._provision_slot(slot)
                 LOGGER.info(
@@ -327,6 +353,7 @@ class WarmPoolManager:
                         "state": slot.state.value,
                     },
                 )
+                self._update_state_metrics()
                 await self._emit_state_change(
                     slot,
                     slot.snapshot(),
@@ -340,6 +367,7 @@ class WarmPoolManager:
                         "fingerprint_id": slot.fingerprint_id,
                     },
                 )
+                self._update_state_metrics()
                 await self._emit_error(
                     slot,
                     slot.snapshot(),
@@ -380,6 +408,7 @@ class WarmPoolManager:
             snapshot = slot.snapshot()
             handle = slot.handle
             environment = dict(slot.last_launch_env)
+            self._update_state_metrics()
 
         await self._emit_state_change(
             slot,
@@ -404,6 +433,7 @@ class WarmPoolManager:
                 )
             slot.state = WarmPoolState.BUSY
             snapshot = slot.snapshot()
+            self._update_state_metrics()
 
         await self._emit_state_change(slot, snapshot, reason="busy")
         return snapshot
@@ -419,6 +449,7 @@ class WarmPoolManager:
                 )
             slot.state = WarmPoolState.IDLE
             snapshot = slot.snapshot()
+            self._update_state_metrics()
 
         await self._emit_state_change(slot, snapshot, reason="reservation-cancelled")
         return snapshot
@@ -430,40 +461,46 @@ class WarmPoolManager:
         recycling_snapshot: WarmPoolSnapshot | None = None
         recycled_snapshot: WarmPoolSnapshot | None = None
         error_snapshot: WarmPoolSnapshot | None = None
-        try:
-            async with slot.lock:
-                if slot.state not in {WarmPoolState.BUSY, WarmPoolState.RESERVED}:
-                    raise WarmPoolStateError(
-                        f"workstation '{workstation_id}' cannot be recycled from {slot.state.value}"
-                    )
-                slot.state = WarmPoolState.RECYCLING
-                recycling_snapshot = slot.snapshot()
-                await self._teardown_slot(slot)
-                slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
-                try:
-                    await self._provision_slot(slot)
-                except WarmPoolProvisioningError:
-                    LOGGER.exception(
-                        "Warm pool slot recycle failed",
-                        extra={
-                            "workstation_id": slot.workstation.id,
-                            "fingerprint_id": slot.fingerprint_id,
-                        },
-                    )
-                    slot.state = WarmPoolState.ERROR
-                    error_snapshot = slot.snapshot()
-                    raise
-                recycled_snapshot = slot.snapshot()
-        except WarmPoolProvisioningError:
-            if recycling_snapshot is not None:
-                await self._emit_state_change(slot, recycling_snapshot, reason="recycling")
-            if error_snapshot is not None:
-                await self._emit_error(slot, error_snapshot, reason="recycle-failed")
-            raise
+        with self._record_recycle_duration():
+            try:
+                async with slot.lock:
+                    if slot.state not in {WarmPoolState.BUSY, WarmPoolState.RESERVED}:
+                        message = (
+                            f"workstation '{workstation_id}' cannot be recycled from "
+                            f"{slot.state.value}"
+                        )
+                        raise WarmPoolStateError(message)
+                    slot.state = WarmPoolState.RECYCLING
+                    recycling_snapshot = slot.snapshot()
+                    self._update_state_metrics()
+                    await self._teardown_slot(slot)
+                    slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
+                    try:
+                        await self._provision_slot(slot)
+                    except WarmPoolProvisioningError:
+                        LOGGER.exception(
+                            "Warm pool slot recycle failed",
+                            extra={
+                                "workstation_id": slot.workstation.id,
+                                "fingerprint_id": slot.fingerprint_id,
+                            },
+                        )
+                        slot.state = WarmPoolState.ERROR
+                        error_snapshot = slot.snapshot()
+                        self._update_state_metrics()
+                        raise
+                    recycled_snapshot = slot.snapshot()
+            except WarmPoolProvisioningError:
+                if recycling_snapshot is not None:
+                    await self._emit_state_change(slot, recycling_snapshot, reason="recycling")
+                if error_snapshot is not None:
+                    await self._emit_error(slot, error_snapshot, reason="recycle-failed")
+                raise
 
         assert recycling_snapshot is not None and recycled_snapshot is not None
         await self._emit_state_change(slot, recycling_snapshot, reason="recycling")
         await self._emit_recycled(slot, recycled_snapshot, reason="released")
+        self._update_state_metrics()
         return recycled_snapshot
 
     async def drain(self) -> list[WarmPoolSnapshot]:
@@ -478,9 +515,11 @@ class WarmPoolManager:
                 await self._teardown_slot(slot)
                 snapshot = slot.snapshot()
                 snapshots.append(snapshot)
+                self._update_state_metrics()
             events.append((slot, snapshot))
         for slot, snapshot in events:
             await self._emit_state_change(slot, snapshot, reason="drain")
+        self._update_state_metrics()
         return snapshots
 
     async def drain_slot(self, workstation_id: str) -> WarmPoolSnapshot:
@@ -495,6 +534,7 @@ class WarmPoolManager:
             slot.state = WarmPoolState.DRAINING
             await self._teardown_slot(slot)
             snapshot = slot.snapshot()
+            self._update_state_metrics()
 
         await self._emit_state_change(slot, snapshot, reason="drain-slot")
         return snapshot
@@ -506,40 +546,46 @@ class WarmPoolManager:
         recycling_snapshot: WarmPoolSnapshot | None = None
         enabled_snapshot: WarmPoolSnapshot | None = None
         error_snapshot: WarmPoolSnapshot | None = None
-        try:
-            async with slot.lock:
-                if slot.state not in {WarmPoolState.DRAINING, WarmPoolState.ERROR}:
-                    raise WarmPoolStateError(
-                        f"workstation '{workstation_id}' cannot be enabled from {slot.state.value}"
-                    )
-                slot.state = WarmPoolState.RECYCLING
-                recycling_snapshot = slot.snapshot()
-                await self._teardown_slot(slot)
-                slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
-                try:
-                    await self._provision_slot(slot)
-                except WarmPoolProvisioningError:
-                    LOGGER.exception(
-                        "Warm pool slot enable failed",
-                        extra={
-                            "workstation_id": slot.workstation.id,
-                            "fingerprint_id": slot.fingerprint_id,
-                        },
-                    )
-                    slot.state = WarmPoolState.ERROR
-                    error_snapshot = slot.snapshot()
-                    raise
-                enabled_snapshot = slot.snapshot()
-        except WarmPoolProvisioningError:
-            if recycling_snapshot is not None:
-                await self._emit_state_change(slot, recycling_snapshot, reason="enable")
-            if error_snapshot is not None:
-                await self._emit_error(slot, error_snapshot, reason="enable-failed")
-            raise
+        with self._record_recycle_duration():
+            try:
+                async with slot.lock:
+                    if slot.state not in {WarmPoolState.DRAINING, WarmPoolState.ERROR}:
+                        message = (
+                            f"workstation '{workstation_id}' cannot be enabled from "
+                            f"{slot.state.value}"
+                        )
+                        raise WarmPoolStateError(message)
+                    slot.state = WarmPoolState.RECYCLING
+                    recycling_snapshot = slot.snapshot()
+                    self._update_state_metrics()
+                    await self._teardown_slot(slot)
+                    slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
+                    try:
+                        await self._provision_slot(slot)
+                    except WarmPoolProvisioningError:
+                        LOGGER.exception(
+                            "Warm pool slot enable failed",
+                            extra={
+                                "workstation_id": slot.workstation.id,
+                                "fingerprint_id": slot.fingerprint_id,
+                            },
+                        )
+                        slot.state = WarmPoolState.ERROR
+                        error_snapshot = slot.snapshot()
+                        self._update_state_metrics()
+                        raise
+                    enabled_snapshot = slot.snapshot()
+            except WarmPoolProvisioningError:
+                if recycling_snapshot is not None:
+                    await self._emit_state_change(slot, recycling_snapshot, reason="enable")
+                if error_snapshot is not None:
+                    await self._emit_error(slot, error_snapshot, reason="enable-failed")
+                raise
 
         assert recycling_snapshot is not None and enabled_snapshot is not None
         await self._emit_state_change(slot, recycling_snapshot, reason="enable")
         await self._emit_recycled(slot, enabled_snapshot, reason="enabled")
+        self._update_state_metrics()
         return enabled_snapshot
 
     async def restart_slot(self, workstation_id: str) -> WarmPoolSnapshot:
@@ -549,47 +595,63 @@ class WarmPoolManager:
         recycling_snapshot: WarmPoolSnapshot | None = None
         restarted_snapshot: WarmPoolSnapshot | None = None
         error_snapshot: WarmPoolSnapshot | None = None
-        try:
-            async with slot.lock:
-                if slot.state not in {WarmPoolState.IDLE, WarmPoolState.ERROR}:
-                    raise WarmPoolStateError(
-                        "workstation "
-                        f"'{workstation_id}' cannot be restarted from {slot.state.value}"
-                    )
-                slot.state = WarmPoolState.RECYCLING
-                recycling_snapshot = slot.snapshot()
-                await self._teardown_slot(slot)
-                slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
-                try:
-                    await self._provision_slot(slot)
-                except WarmPoolProvisioningError:
-                    LOGGER.exception(
-                        "Warm pool slot restart failed",
-                        extra={
-                            "workstation_id": slot.workstation.id,
-                            "fingerprint_id": slot.fingerprint_id,
-                        },
-                    )
-                    slot.state = WarmPoolState.ERROR
-                    error_snapshot = slot.snapshot()
-                    raise
-                restarted_snapshot = slot.snapshot()
-        except WarmPoolProvisioningError:
-            if recycling_snapshot is not None:
-                await self._emit_state_change(slot, recycling_snapshot, reason="restart")
-            if error_snapshot is not None:
-                await self._emit_error(slot, error_snapshot, reason="restart-failed")
-            raise
+        with self._record_recycle_duration():
+            try:
+                async with slot.lock:
+                    if slot.state not in {WarmPoolState.IDLE, WarmPoolState.ERROR}:
+                        raise WarmPoolStateError(
+                            "workstation "
+                            f"'{workstation_id}' cannot be restarted from {slot.state.value}"
+                        )
+                    slot.state = WarmPoolState.RECYCLING
+                    recycling_snapshot = slot.snapshot()
+                    self._update_state_metrics()
+                    await self._teardown_slot(slot)
+                    slot.temp_dir = self._temp_dir_factory(slot.workstation.id)
+                    try:
+                        await self._provision_slot(slot)
+                    except WarmPoolProvisioningError:
+                        LOGGER.exception(
+                            "Warm pool slot restart failed",
+                            extra={
+                                "workstation_id": slot.workstation.id,
+                                "fingerprint_id": slot.fingerprint_id,
+                            },
+                        )
+                        slot.state = WarmPoolState.ERROR
+                        error_snapshot = slot.snapshot()
+                        self._update_state_metrics()
+                        raise
+                    restarted_snapshot = slot.snapshot()
+            except WarmPoolProvisioningError:
+                if recycling_snapshot is not None:
+                    await self._emit_state_change(slot, recycling_snapshot, reason="restart")
+                if error_snapshot is not None:
+                    await self._emit_error(slot, error_snapshot, reason="restart-failed")
+                raise
 
         assert recycling_snapshot is not None and restarted_snapshot is not None
         await self._emit_state_change(slot, recycling_snapshot, reason="restart")
         await self._emit_recycled(slot, restarted_snapshot, reason="restarted")
+        self._update_state_metrics()
         return restarted_snapshot
 
     def list_slots(self) -> list[WarmPoolSnapshot]:
         """Return snapshots for all known slots."""
 
         return [slot.snapshot() for slot in self._slots.values()]
+
+    def get_statistics(self) -> WarmPoolStatistics:
+        """Return aggregated warm pool utilisation statistics."""
+
+        total, idle, busy, error = self._collect_state_counts()
+        return WarmPoolStatistics(
+            total=total,
+            idle=idle,
+            busy=busy,
+            error=error,
+            draining=self._draining,
+        )
 
     def _build_slot(self, entry: WorkstationConfigEntry) -> _WarmSlot:
         """Create an internal representation for ``entry``."""
@@ -614,11 +676,13 @@ class WarmPoolManager:
         except WarmPoolProvisioningError as exc:
             slot.last_error = exc.__cause__ or exc
             slot.state = WarmPoolState.ERROR
+            self._update_state_metrics()
             raise
         else:
             slot.handle = handle
             slot.state = WarmPoolState.IDLE
             slot.last_error = None
+            self._update_state_metrics()
 
     async def _attempt_launch(self, slot: _WarmSlot) -> BrowserSessionHandle:
         """Attempt to launch Camoufox for ``slot`` with retries."""
@@ -643,6 +707,7 @@ class WarmPoolManager:
                     await self._maybe_prewarm(slot, handle)
                 except Exception as exc:  # pragma: no cover - defensive logging
                     last_error = exc
+                    WORKSTATION_NAVIGATION_ERRORS_COUNTER.inc()
                     LOGGER.warning(
                         "Prewarm navigation failed",
                         extra={
@@ -675,6 +740,8 @@ class WarmPoolManager:
                 env=env,
             )
         except BrowserLaunchError as exc:
+            if slot.proxy_url:
+                WORKSTATION_PROXY_ERRORS_COUNTER.inc()
             LOGGER.warning(
                 "Camoufox launch failed",
                 extra={
@@ -779,4 +846,45 @@ class WarmPoolManager:
         """Allocate a dedicated temporary directory for ``workstation_id``."""
 
         return Path(tempfile.mkdtemp(prefix=f"warm-pool-{workstation_id}-"))
+
+    def _collect_state_counts(self) -> tuple[int, int, int, int]:
+        """Return total, idle, busy, and error slot counts."""
+
+        total = len(self._slots)
+        idle = 0
+        busy = 0
+        error = 0
+        busy_states = {
+            WarmPoolState.RESERVED,
+            WarmPoolState.BUSY,
+            WarmPoolState.RECYCLING,
+            WarmPoolState.DRAINING,
+        }
+        for slot in self._slots.values():
+            if slot.state is WarmPoolState.IDLE:
+                idle += 1
+            elif slot.state in busy_states:
+                busy += 1
+            elif slot.state is WarmPoolState.ERROR:
+                error += 1
+        return total, idle, busy, error
+
+    def _update_state_metrics(self) -> None:
+        """Synchronise Prometheus gauges with the current slot distribution."""
+
+        total, idle, busy, error = self._collect_state_counts()
+        WORKSTATIONS_TOTAL_GAUGE.set(total)
+        WORKSTATIONS_IDLE_GAUGE.set(idle)
+        WORKSTATIONS_BUSY_GAUGE.set(busy)
+        WORKSTATIONS_ERROR_GAUGE.set(error)
+
+    @contextmanager
+    def _record_recycle_duration(self) -> Iterator[None]:
+        """Observe recycle durations for histogram reporting."""
+
+        start = perf_counter()
+        try:
+            yield
+        finally:
+            WORKSTATION_RECYCLE_SECONDS.observe(perf_counter() - start)
 

--- a/services/runner/tests/test_main.py
+++ b/services/runner/tests/test_main.py
@@ -14,7 +14,13 @@ from app.dependencies.session_manager import (
 from app.events import InMemorySessionEventPublisher
 from app.main import app
 from app.session_manager import SessionCreatePayload, SessionManager
-from app.warm_pool import WarmPoolReservation, WarmPoolSnapshot, WarmPoolState, WarmPoolStateError
+from app.warm_pool import (
+    WarmPoolReservation,
+    WarmPoolSnapshot,
+    WarmPoolState,
+    WarmPoolStateError,
+    WarmPoolStatistics,
+)
 from core.models import SessionVncDetails
 from httpx import AsyncClient
 
@@ -106,6 +112,7 @@ class _MainStubWarmPool:
         self.reservations: list[str] = []
         self.busy: list[str] = []
         self.releases: list[str] = []
+        self.draining = False
 
     async def start(self) -> None:
         """Warm pool stubs start instantly."""
@@ -182,6 +189,24 @@ class _MainStubWarmPool:
             state=WarmPoolState.IDLE,
         )
 
+    def get_statistics(self) -> WarmPoolStatistics:
+        """Return aggregate counts mirroring the real warm pool manager."""
+
+        idle = sum(1 for slot in self._slots.values() if slot["state"] is WarmPoolState.IDLE)
+        busy = sum(
+            1
+            for slot in self._slots.values()
+            if slot["state"] in {WarmPoolState.RESERVED, WarmPoolState.BUSY}
+        )
+        error = sum(1 for slot in self._slots.values() if slot["state"] is WarmPoolState.ERROR)
+        return WarmPoolStatistics(
+            total=len(self._slots),
+            idle=idle,
+            busy=busy,
+            error=error,
+            draining=self.draining,
+        )
+
     def _require_slot(self, workstation_id: str) -> dict[str, object]:
         try:
             return self._slots[workstation_id]
@@ -208,6 +233,7 @@ async def test_health_endpoint_reports_extended_metrics() -> None:
         proxy_enabled=True,
         proxy_http_base_url="http://proxy.example:3128",
         prewarm_failure_history_size=5,
+        prewarm_navigation=False,
     )
     publisher = InMemorySessionEventPublisher()
     warm_pool = _MainStubWarmPool()
@@ -241,6 +267,14 @@ async def test_health_endpoint_reports_extended_metrics() -> None:
     assert payload["runner_id"] == "runner-health"
     assert payload["camoufox_path"].endswith("camoufox")
     assert payload["slots"] == {"total": 3, "active": 2, "available": 1}
+    assert payload["warm_pool"] == {
+        "enabled": True,
+        "total": 3,
+        "idle": 1,
+        "busy": 2,
+        "error": 0,
+        "draining": False,
+    }
     assert payload["vnc"] == {
         "http_base_url": "http://localhost:9000/vnc",
         "ws_base_url": "ws://localhost:9000/vnc",
@@ -253,6 +287,8 @@ async def test_health_endpoint_reports_extended_metrics() -> None:
         "socks_base_url": None,
     }
     assert payload["prewarm"] == {
+        "enabled": False,
+        "start_url": None,
         "failures": 2,
         "last_error": "prewarm retry failed",
     }
@@ -305,6 +341,11 @@ async def test_metrics_endpoint_exposes_prometheus_payload() -> None:
     assert "runner_active_sessions" in body
     assert "runner_vnc_allocations" in body
     assert "runner_vnc_allocation_requests_total" in body
+    assert "runner_workstations_total" in body
+    assert "runner_session_allocate_seconds_count" in body
+    assert "runner_workstation_recycle_seconds_bucket" in body
+    assert "runner_workstation_proxy_errors_total" in body
+    assert "runner_workstation_navigation_errors_total" in body
 
 
 @pytest.mark.anyio("asyncio")

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -15,7 +15,13 @@ from app.session_manager import (
     SessionManager,
     SessionUpdatePayload,
 )
-from app.warm_pool import WarmPoolReservation, WarmPoolSnapshot, WarmPoolState, WarmPoolStateError
+from app.warm_pool import (
+    WarmPoolReservation,
+    WarmPoolSnapshot,
+    WarmPoolState,
+    WarmPoolStateError,
+    WarmPoolStatistics,
+)
 from core.models import (
     SessionEventType,
     SessionProxySettings,
@@ -139,6 +145,24 @@ class _StubWarmPoolManager:
             fingerprint_id=slot["fingerprint"],
             proxy_url=slot["proxy"],
             state=WarmPoolState.IDLE,
+        )
+
+    def get_statistics(self) -> WarmPoolStatistics:
+        """Return utilisation counters for compatibility with the real manager."""
+
+        idle = sum(1 for slot in self._slots.values() if slot["state"] is WarmPoolState.IDLE)
+        busy = sum(
+            1
+            for slot in self._slots.values()
+            if slot["state"] in {WarmPoolState.RESERVED, WarmPoolState.BUSY}
+        )
+        error = sum(1 for slot in self._slots.values() if slot["state"] is WarmPoolState.ERROR)
+        return WarmPoolStatistics(
+            total=len(self._slots),
+            idle=idle,
+            busy=busy,
+            error=error,
+            draining=False,
         )
 
     def _make_handle(self, workstation_id: str) -> _StubBrowserHandle:


### PR DESCRIPTION
## Summary
- add Prometheus gauges, histogram, summary, and error counters for warm pool/session allocation metrics
- extend the FastAPI health endpoint with warm pool statistics and prewarm status while introducing structured logging defaults
- update tests to cover new /health fields and ensure /metrics exposes the added metrics

## Testing
- `poetry run ruff check .`
- `PYTHONPATH=.:../..:../../packages/core poetry run pytest -q`

## Security
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68de76ca636c832aa7ee3548c7b25ec2