### PR TITLE
Add warm pool mode selection and hybrid fallback

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -70,6 +70,10 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
   показывать последние сбои без риска утечки памяти.
 - **Warm pool-backed sessions**: `SessionManager` теперь зависит от `WarmPoolManager`, резервирует слот до создания сессии и
   рециклирует его при завершении. В случае исчерпания слотов API возвращает 429.
+- **Warm pool strategy modes**: `RunnerSettings.warm_pool_mode` позволяет выбирать между
+  тёплыми слотами, холодными запусками и гибридом; `SessionManager` автоматически
+  переключается на `launch_browser`, если гибридный режим не находит idle-слота, и
+  добавляет в метаданные `browser_origin` с деталями источника.
 - **Gateway proxy compatibility**: `SessionCreatePayload` остаётся публичным контрактом, но теперь вызывается через Gateway, потому важна обратная совместимость и строгая валидация.
 - **Playwright launch lifecycle**: `app.browser.launch_browser` стартует Playwright в режиме `launch-server`, сохраняет `wsEndpoint`/PID в метаданных и позволяет `SessionManager` останавливать процесс при переходе в `DEAD` или очистке endpoint. Исключения при старте выполняют откат без публикации событий.
 - **Idle TTL reaper**: `SessionManager` содержит AnyIO-based reaper, который вызывает
@@ -131,3 +135,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-18 · gpt-5-codex · Добавлены REST-эндпоинты `/workstations*`, in-memory издатель `WorkstationEvent` и интеграционные тесты API.
 - 2025-10-19 · gpt-5-codex · Вынесены маршруты `/workstations` в отдельный роутер с Pydantic-моделями, WarmPoolManager публикует события state/error/recycled, добавлены SSE/WS-обёртки и интеграционные тесты.
 - 2025-10-20 · gpt-5-codex · Добавлены warm-pool метрики/таймеры, расширен `/health` данными пула и настроен формат логов с идентификаторами; обновлены тесты `/metrics` и `/health`.
+- 2025-10-21 · gpt-5-codex · Реализованы режимы warm pool (warm-only/cold-only/hybrid), гибридный fallback на `launch_browser`, расширение метаданных `browser_origin` и покрытие тестами.

--- a/services/runner/app/config/__init__.py
+++ b/services/runner/app/config/__init__.py
@@ -1,6 +1,6 @@
 """Configuration helpers for the Runner service."""
 
-from .settings import RunnerSettings
+from .settings import RunnerSettings, WarmPoolMode
 from .warm_pool import (
     WarmPoolConfig,
     WarmPoolConfigError,
@@ -10,6 +10,7 @@ from .warm_pool import (
 
 __all__ = [
     "RunnerSettings",
+    "WarmPoolMode",
     "WarmPoolConfig",
     "WarmPoolConfigError",
     "WorkstationConfigEntry",

--- a/services/runner/app/config/settings.py
+++ b/services/runner/app/config/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,14 @@ from pydantic import (
     PositiveInt,
     model_validator,
 )
+
+
+class WarmPoolMode(str, Enum):
+    """Enumerate warm pool strategies supported by the runner."""
+
+    WARM_ONLY = "warm-only"
+    COLD_ONLY = "cold-only"
+    HYBRID = "hybrid"
 
 
 class RunnerSettings(BaseModel):
@@ -33,6 +42,9 @@ class RunnerSettings(BaseModel):
         slot_limit: Maximum number of concurrently active sessions.
         warm_pool_config_path: Optional path to a JSON file describing the warm
             workstation pool.
+        warm_pool_mode: Strategy for sourcing browsers — exclusively warm pool,
+            exclusively cold launches, or hybrid (prefer warm, fall back to
+            cold).
         vnc_enabled: Controls whether VNC URLs should be generated for new
             sessions.
         vnc_http_base_url: Base URL for generating human-facing VNC previews.
@@ -71,6 +83,10 @@ class RunnerSettings(BaseModel):
     warm_pool_config_path: Path | None = Field(
         default=None,
         description="Path to the warm pool configuration JSON file",
+    )
+    warm_pool_mode: WarmPoolMode = Field(
+        default=WarmPoolMode.HYBRID,
+        description="Warm pool strategy: warm-only, cold-only, or hybrid",
     )
     vnc_enabled: bool = Field(default=True)
     vnc_http_base_url: AnyUrl = Field(default="http://127.0.0.1:8060/vnc")
@@ -149,6 +165,10 @@ class RunnerSettings(BaseModel):
         if "WARM_POOL_CONFIG_PATH" in env:
             raw = env["WARM_POOL_CONFIG_PATH"].strip()
             source["warm_pool_config_path"] = Path(raw) if raw else None
+        if "WARM_POOL_MODE" in env:
+            raw_mode = env["WARM_POOL_MODE"].strip().lower()
+            if raw_mode:
+                source["warm_pool_mode"] = raw_mode
         if "VNC_ENABLED" in env:
             source["vnc_enabled"] = env["VNC_ENABLED"].lower() in {"1", "true", "yes"}
         if "VNC_HTTP_BASE_URL" in env:
@@ -205,4 +225,4 @@ class RunnerSettings(BaseModel):
         return cls.model_validate(source)
 
 
-__all__ = ["RunnerSettings"]
+__all__ = ["RunnerSettings", "WarmPoolMode"]

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 from collections import deque
+from dataclasses import dataclass
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from time import perf_counter
@@ -23,8 +24,8 @@ from core.models import (
 )
 from pydantic import AnyUrl, BaseModel, ConfigDict, Field, PositiveInt
 
-from .browser import BrowserSessionHandle
-from .config import RunnerSettings
+from .browser import BrowserLaunchError, BrowserSessionHandle, launch_browser
+from .config import RunnerSettings, WarmPoolMode
 from .events import SessionEventPublisher
 from .metrics import (
     ACTIVE_SESSIONS_GAUGE,
@@ -143,6 +144,23 @@ class SessionManagerMetrics(BaseModel):
         return len(self.prewarm_failures)
 
 
+@dataclass(frozen=True)
+class BrowserAcquisition:
+    """Aggregate details for a browser handle obtained during session setup.
+
+    Attributes:
+        handle: Browser session handle ready to be persisted.
+        metadata: Metadata dictionary enriched with origin descriptors that
+            explain how the browser was sourced.
+        reservation: Warm pool reservation when the browser originated from a
+            pre-warmed workstation, otherwise ``None`` for cold launches.
+    """
+
+    handle: BrowserSessionHandle
+    metadata: dict[str, Any]
+    reservation: WarmPoolReservation | None
+
+
 class SessionManager:
     """Manage session lifecycle and publish events for downstream consumers.
 
@@ -205,14 +223,21 @@ class SessionManager:
                     sanitized_vnc=sanitized_vnc,
                 )
                 try:
-                    reservation = await self._reserve_warm_slot(payload.metadata)
+                    acquisition = await self._acquire_browser_handle(
+                        payload,
+                        metadata=dict(payload.metadata),
+                        vnc_handle=vnc_handle,
+                    )
                 except Exception:
                     await self._discard_vnc_handle(session_id, vnc_handle)
                     raise
-                workstation_id = reservation.snapshot.workstation_id
-                browser_handle = reservation.handle
-                metadata = self._merge_warm_pool_metadata(
-                    dict(payload.metadata), reservation
+                browser_handle = acquisition.handle
+                metadata = acquisition.metadata
+                warm_reservation = acquisition.reservation
+                workstation_id = (
+                    warm_reservation.snapshot.workstation_id
+                    if warm_reservation is not None
+                    else None
                 )
                 if browser_handle.pid is not None:
                     metadata.setdefault("runner_browser_pid", browser_handle.pid)
@@ -241,18 +266,26 @@ class SessionManager:
                         metadata=metadata,
                     )
                 except Exception:
-                    await self._cancel_warm_reservation(workstation_id)
+                    if workstation_id is not None:
+                        await self._cancel_warm_reservation(workstation_id)
+                    else:
+                        await self._safe_shutdown_cold_browser(browser_handle)
                     await self._discard_vnc_handle(session_id, vnc_handle)
                     raise
                 try:
-                    await self._mark_warm_slot_busy(workstation_id)
+                    if workstation_id is not None:
+                        await self._mark_warm_slot_busy(workstation_id)
                 except SessionCapacityError:
-                    await self._cancel_warm_reservation(workstation_id)
+                    if workstation_id is not None:
+                        await self._cancel_warm_reservation(workstation_id)
+                    else:
+                        await self._safe_shutdown_cold_browser(browser_handle)
                     await self._discard_vnc_handle(session_id, vnc_handle)
                     raise
                 self._sessions[session_id] = session
                 self._browser_handles[session_id] = browser_handle
-                self._warm_sessions[session_id] = workstation_id
+                if workstation_id is not None:
+                    self._warm_sessions[session_id] = workstation_id
                 if vnc_handle is not None:
                     self._vnc_handles[session_id] = vnc_handle
                 VNC_ALLOCATIONS_GAUGE.set(len(self._vnc_handles))
@@ -535,6 +568,186 @@ class SessionManager:
         if details.token is None and details.token_ttl_seconds is None:
             return details
         return details.model_copy(update={"token": None, "token_ttl_seconds": None})
+
+    async def _acquire_browser_handle(
+        self,
+        payload: SessionCreatePayload,
+        *,
+        metadata: dict[str, Any],
+        vnc_handle: VncSessionHandle | None,
+    ) -> BrowserAcquisition:
+        """Return a browser handle using the configured warm pool strategy.
+
+        Args:
+            payload: Request describing the desired session properties such as
+                browser family and headless mode.
+            metadata: Mutable copy of the session metadata derived from the
+                create payload. The method augments it with origin descriptors
+                before returning.
+            vnc_handle: Optional VNC allocation whose environment variables are
+                required when a cold browser launch occurs for visual sessions.
+
+        Returns:
+            BrowserAcquisition: Dataclass bundling the browser handle, enriched
+            metadata, and a warm pool reservation when a pre-warmed workstation
+            was selected.
+
+        Raises:
+            SessionCapacityError: Raised when the configuration demands a warm
+                pool but it is unavailable, or when spawning a cold browser
+                fails.
+
+        Example:
+            >>> acquisition = await manager._acquire_browser_handle(  # doctest: +SKIP
+            ...     payload,
+            ...     metadata={},
+            ...     vnc_handle=None,
+            ... )
+            >>> acquisition.handle.ws_endpoint  # doctest: +SKIP
+            'ws://camoufox/...'
+        """
+
+        mode = self._settings.warm_pool_mode
+        if mode is WarmPoolMode.COLD_ONLY:
+            metadata.pop("warm_pool", None)
+            handle = await self._launch_cold_browser(
+                payload,
+                vnc_handle=vnc_handle,
+            )
+            metadata = self._inject_browser_origin(
+                metadata,
+                kind="cold_launch",
+                details={"reason": "mode-cold-only"},
+            )
+            return BrowserAcquisition(handle=handle, metadata=metadata, reservation=None)
+
+        warm_pool = self._warm_pool
+        if warm_pool is not None:
+            try:
+                reservation = await self._reserve_warm_slot(metadata)
+            except SessionCapacityError:
+                if mode is WarmPoolMode.WARM_ONLY:
+                    raise
+            else:
+                details = {
+                    "workstation_id": reservation.snapshot.workstation_id,
+                }
+                if reservation.snapshot.fingerprint_id is not None:
+                    details["fingerprint_id"] = reservation.snapshot.fingerprint_id
+                metadata = self._merge_warm_pool_metadata(metadata, reservation)
+                metadata = self._inject_browser_origin(
+                    metadata,
+                    kind="warm_pool",
+                    details=details,
+                )
+                return BrowserAcquisition(
+                    handle=reservation.handle,
+                    metadata=metadata,
+                    reservation=reservation,
+                )
+        elif mode is WarmPoolMode.WARM_ONLY:
+            raise SessionCapacityError("warm pool is not configured")
+
+        metadata.pop("warm_pool", None)
+        reason = "warm-pool-disabled" if warm_pool is None else "warm-pool-unavailable"
+        handle = await self._launch_cold_browser(payload, vnc_handle=vnc_handle)
+        metadata = self._inject_browser_origin(
+            metadata,
+            kind="cold_launch",
+            details={"reason": reason},
+        )
+        return BrowserAcquisition(handle=handle, metadata=metadata, reservation=None)
+
+    async def _launch_cold_browser(
+        self,
+        payload: SessionCreatePayload,
+        *,
+        vnc_handle: VncSessionHandle | None,
+    ) -> BrowserSessionHandle:
+        """Launch a fresh Playwright browser outside of the warm pool.
+
+        Args:
+            payload: Session creation request containing browser preferences.
+            vnc_handle: Optional handle providing environment variables (e.g.
+                ``DISPLAY``) required for non-headless sessions.
+
+        Returns:
+            BrowserSessionHandle: Handle referencing the running Playwright
+            process.
+
+        Raises:
+            SessionCapacityError: If Playwright cannot be launched successfully.
+
+        Example:
+            >>> handle = await manager._launch_cold_browser(  # doctest: +SKIP
+            ...     payload,
+            ...     vnc_handle=None,
+            ... )
+            >>> handle.ws_endpoint  # doctest: +SKIP
+            'ws://camoufox/...'
+        """
+
+        env: dict[str, str] = {}
+        if vnc_handle is not None:
+            env.update(vnc_handle.browser_environment())
+        try:
+            return await launch_browser(
+                self._settings,
+                browser=payload.browser,
+                headless=payload.headless,
+                env=env or None,
+            )
+        except BrowserLaunchError as exc:
+            raise SessionCapacityError("failed to launch browser process") from exc
+
+    def _inject_browser_origin(
+        self,
+        metadata: dict[str, Any],
+        *,
+        kind: str,
+        details: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Attach metadata describing how the browser was provisioned.
+
+        Args:
+            metadata: Session metadata dictionary to update in-place.
+            kind: Human-readable label identifying the browser origin.
+            details: Optional mapping providing additional context such as
+                fallback reasons or workstation identifiers.
+
+        Returns:
+            dict[str, Any]: The mutated metadata dictionary for chaining.
+
+        Example:
+            >>> manager._inject_browser_origin({}, kind="cold_launch")  # doctest: +SKIP
+            {'browser_origin': {'kind': 'cold_launch', 'mode': 'hybrid'}}
+        """
+
+        descriptor: dict[str, Any] = {
+            "kind": kind,
+            "mode": self._settings.warm_pool_mode.value,
+        }
+        if details:
+            descriptor.update(details)
+        existing = metadata.get("browser_origin")
+        if isinstance(existing, dict):
+            metadata["browser_origin"] = {**existing, **descriptor}
+        else:
+            metadata["browser_origin"] = descriptor
+        return metadata
+
+    async def _safe_shutdown_cold_browser(self, handle: BrowserSessionHandle) -> None:
+        """Terminate a cold-launched browser that was not persisted.
+
+        Args:
+            handle: Browser handle obtained from :func:`launch_browser`.
+
+        Example:
+            >>> await manager._safe_shutdown_cold_browser(handle)  # doctest: +SKIP
+        """
+
+        with contextlib.suppress(Exception):
+            await handle.shutdown(force=True)
 
     async def _reserve_warm_slot(
         self, metadata: dict[str, Any]

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -6,7 +6,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Callable
 
 import pytest
-from app.config import RunnerSettings
+from app.config import RunnerSettings, WarmPoolMode
 from app.events import InMemorySessionEventPublisher
 from app.metrics import METRICS_REGISTRY
 from app.session_manager import (
@@ -200,18 +200,21 @@ def _build_manager(
     clock: Callable[[], datetime] | None = None,
     vnc_controller: "_StubVncController" | None = None,
     warm_pool: _StubWarmPoolManager | None = None,
-) -> tuple[SessionManager, _StubWarmPoolManager]:
-    """Instantiate a session manager backed by the warm pool stub."""
+    use_warm_pool: bool = True,
+) -> tuple[SessionManager, _StubWarmPoolManager | None]:
+    """Instantiate a session manager with optional warm pool support."""
 
-    warm_pool = warm_pool or _StubWarmPoolManager()
+    warm_pool_manager = warm_pool
+    if warm_pool_manager is None and use_warm_pool:
+        warm_pool_manager = _StubWarmPoolManager()
     manager = SessionManager(
         settings,
         publisher,
         clock=clock,
         vnc_controller=vnc_controller,
-        warm_pool_manager=warm_pool,
+        warm_pool_manager=warm_pool_manager,
     )
-    return manager, warm_pool
+    return manager, warm_pool_manager
 
 
 @pytest.fixture
@@ -251,6 +254,7 @@ async def test_create_session_emits_event_and_vnc_stub(
     )
 
     session = await manager.create_session(payload)
+    assert warm_pool is not None
 
     assert session.runner_id == "runner-test"
     assert session.proxy is not None
@@ -261,6 +265,10 @@ async def test_create_session_emits_event_and_vnc_stub(
     warm_meta = session.metadata.get("warm_pool", {})
     assert warm_meta["workstation_id"] == warm_pool.reservations[0]
     assert warm_meta["fingerprint_id"].startswith("fp-")
+    origin = session.metadata["browser_origin"]
+    assert origin["kind"] == "warm_pool"
+    assert origin["mode"] == settings.warm_pool_mode.value
+    assert origin["workstation_id"] == warm_pool.reservations[0]
     events = await publisher.drain()
     assert len(events) == 1
     assert events[0].type is SessionEventType.CREATED
@@ -278,8 +286,13 @@ async def test_create_session_raises_when_warm_pool_exhausted(
     warm_pool = _StubWarmPoolManager(workstations=["ws-only"])
     await warm_pool.reserve_slot("ws-only")
     await warm_pool.mark_busy("ws-only")
+    settings = RunnerSettings(
+        runner_id="runner-capacity",
+        camoufox_path="/usr/bin/camoufox",
+        warm_pool_mode=WarmPoolMode.WARM_ONLY,
+    )
     manager, _ = _build_manager(
-        RunnerSettings(runner_id="runner-capacity", camoufox_path="/usr/bin/camoufox"),
+        settings,
         publisher,
         vnc_controller=stub_vnc_controller,
         warm_pool=warm_pool,
@@ -287,6 +300,126 @@ async def test_create_session_raises_when_warm_pool_exhausted(
 
     with pytest.raises(SessionCapacityError):
         await manager.create_session(SessionCreatePayload())
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_session_cold_only_launches_new_browser(
+    monkeypatch: pytest.MonkeyPatch, stub_vnc_controller: _StubVncController
+) -> None:
+    """Cold-only mode should bypass the warm pool and spawn a fresh browser."""
+
+    calls: list[dict[str, object]] = []
+
+    async def _fake_launch(
+        settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        command: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        read_timeout: float = 10.0,
+    ) -> _StubBrowserHandle:
+        handle = _StubBrowserHandle(ws_endpoint="ws://cold/0", pid=8800)
+        calls.append(
+            {
+                "browser": browser,
+                "headless": headless,
+                "env": dict(env or {}),
+                "timeout": read_timeout,
+            }
+        )
+        return handle
+
+    monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
+
+    settings = RunnerSettings(
+        runner_id="runner-cold",
+        camoufox_path="/usr/bin/camoufox",
+        warm_pool_mode=WarmPoolMode.COLD_ONLY,
+    )
+    publisher = InMemorySessionEventPublisher()
+    manager, warm_pool = _build_manager(
+        settings,
+        publisher,
+        vnc_controller=stub_vnc_controller,
+        use_warm_pool=False,
+    )
+
+    session = await manager.create_session(SessionCreatePayload(headless=False))
+
+    assert warm_pool is None
+    assert calls
+    launch_call = calls[0]
+    assert launch_call["browser"] == "camoufox"
+    assert launch_call["headless"] is False
+    assert launch_call["env"] == {"DISPLAY": ":stub"}
+    origin = session.metadata["browser_origin"]
+    assert origin["kind"] == "cold_launch"
+    assert origin["mode"] == settings.warm_pool_mode.value
+    assert origin["reason"] == "mode-cold-only"
+    assert "warm_pool" not in session.metadata
+    assert session.metadata["runner_browser_pid"] == 8800
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_session_hybrid_falls_back_when_warm_pool_busy(
+    monkeypatch: pytest.MonkeyPatch, stub_vnc_controller: _StubVncController
+) -> None:
+    """Hybrid mode should fall back to cold launches when the pool is exhausted."""
+
+    calls: list[dict[str, object]] = []
+
+    async def _fake_launch(
+        settings: RunnerSettings,
+        *,
+        browser: str,
+        headless: bool,
+        command: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        read_timeout: float = 10.0,
+    ) -> _StubBrowserHandle:
+        handle = _StubBrowserHandle(ws_endpoint="ws://cold/fallback", pid=9900)
+        calls.append(
+            {
+                "browser": browser,
+                "headless": headless,
+                "env": dict(env or {}),
+                "timeout": read_timeout,
+            }
+        )
+        return handle
+
+    monkeypatch.setattr("app.session_manager.launch_browser", _fake_launch)
+
+    warm_pool = _StubWarmPoolManager(workstations=["ws-only"])
+    await warm_pool.reserve_slot("ws-only")
+    await warm_pool.mark_busy("ws-only")
+
+    settings = RunnerSettings(
+        runner_id="runner-hybrid",
+        camoufox_path="/usr/bin/camoufox",
+        warm_pool_mode=WarmPoolMode.HYBRID,
+    )
+    publisher = InMemorySessionEventPublisher()
+    manager, _ = _build_manager(
+        settings,
+        publisher,
+        vnc_controller=stub_vnc_controller,
+        warm_pool=warm_pool,
+    )
+
+    session = await manager.create_session(SessionCreatePayload(headless=False))
+
+    assert calls
+    launch_call = calls[0]
+    assert launch_call["headless"] is False
+    assert launch_call["env"] == {"DISPLAY": ":stub"}
+    origin = session.metadata["browser_origin"]
+    assert origin["kind"] == "cold_launch"
+    assert origin["mode"] == settings.warm_pool_mode.value
+    assert origin["reason"] == "warm-pool-unavailable"
+    assert "warm_pool" not in session.metadata
+    assert session.metadata["runner_browser_pid"] == 9900
 
 
 @pytest.mark.anyio("asyncio")
@@ -656,8 +789,11 @@ async def test_create_session_uses_warm_pool_handle() -> None:
 
     publisher = InMemorySessionEventPublisher()
     warm_pool = _StubWarmPoolManager(workstations=["ws-meta"])
+    settings = RunnerSettings(
+        runner_id="runner-browser", camoufox_path="/usr/bin/camoufox"
+    )
     manager, warm_pool = _build_manager(
-        RunnerSettings(runner_id="runner-browser", camoufox_path="/usr/bin/camoufox"),
+        settings,
         publisher,
         warm_pool=warm_pool,
     )
@@ -666,8 +802,13 @@ async def test_create_session_uses_warm_pool_handle() -> None:
         SessionCreatePayload(headless=True, metadata={"flow": "launch-test"})
     )
 
+    assert warm_pool is not None
     warm_info = session.metadata["warm_pool"]
     assert warm_info["workstation_id"] == "ws-meta"
+    origin = session.metadata["browser_origin"]
+    assert origin["kind"] == "warm_pool"
+    assert origin["mode"] == settings.warm_pool_mode.value
+    assert origin["workstation_id"] == "ws-meta"
     assert warm_pool.busy == ["ws-meta"]
     stored_handle = manager._browser_handles[session.id]
     assert stored_handle.ws_endpoint.startswith("ws://warm/ws-meta/")


### PR DESCRIPTION
## Summary
- add a `WarmPoolMode` enum to runner settings so operators can choose warm-only, cold-only, or hybrid acquisition
- update `SessionManager.create_session` to use the new mode, fall back to cold launches when hybrid slots are exhausted, and record browser origin metadata
- extend unit tests to cover cold-only and hybrid fallback scenarios and document the modes in the runner agent notes

## Testing
- `PYTHONPATH=. poetry run pytest -q tests/test_session_manager.py`
- `PYTHONPATH=. poetry run pytest -q tests/test_main.py`

## Security
- no security-impacting changes


------
https://chatgpt.com/codex/tasks/task_e_68de7bbe4518832abd66775a3938f14f