### PR TITLE
Add session recovery endpoints and bootstrap logic

### DIFF
--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -63,6 +63,7 @@
 - Health-чек раннеров выполняется через `RunnerHealthClient` (httpx) и сохраняет результат в `RunnerRegistry`. Селектор `select_next` использует круговой обход и фильтрует по признаку здоровья и поддержке VNC, чтобы избежать ручного выбора в роутерах.
 - Тесты аутентификатора Keycloak используют `httpx.MockTransport`, чтобы прогонять полный цикл `_fetch_jwks` без прямых правок кэша
   и проверять повторные запросы при смене `kid`, HTTP-ошибки и сбои декодирования JSON.
+- Lifespan-хук после discovery обходит только здоровых раннеров, вызывает `GET /sessions` через `RunnerCommandClient.list_sessions` и восстанавливает `SessionRegistry` вместе с веб-сокетными биндингами `RunnerRegistry`. Поток проверен тестом `test_lifespan_restores_sessions_from_healthy_runners`.
 
 ## Constraints & Invariants
 - `VNC_TOKEN_TTL_SEC` всегда ≤300; нарушение приводит к `ValueError` на старте.
@@ -83,6 +84,7 @@
 - [x] Реализовать стратегию выбора раннера (учитывать слоты/регион) вместо текущего «первый в списке». Добавлен круговой селектор, отфильтровывающий по здоровью и поддержке VNC.
 - [x] Настроить фонового воркера, который периодически опрашивает `/health` у всех раннеров и заполняет реестр. Выполнено через
       lifespan-хук FastAPI (`_runner_maintenance_loop`) с очисткой сессий и health-probe.
+- [x] Зафиксирован поток восстановления после рестартов: lifespan делает `GET /sessions`, покрыто тестами `test_list_sessions_returns_*` (runner) и `test_lifespan_restores_sessions_from_healthy_runners` (gateway).
 
 ## How to Test
 - Локально:
@@ -116,3 +118,5 @@
   и покрывающие unit-тесты HTTP/SSE/WS.
 - 2025-10-16 · gpt-5-codex · Уточнена документация зависимостей безопасности и обработка пустых env-карт для доверенных CIDR.
 - 2025-10-17 · gpt-5-codex · Добавлены registry/роуты для рабочих станций, модели `WorkstationRecord`/`WorkstationUpsertPayload` и unit-тесты API контрактов.
+- 2025-10-18 · gpt-5-codex · Восстановление сессий при рестарте через `GET /sessions`, расширенный RunnerCommandClient и новые unit-тесты bootstrap.
+

--- a/services/gateway/app/main.py
+++ b/services/gateway/app/main.py
@@ -6,7 +6,7 @@ import logging
 from contextlib import asynccontextmanager
 
 import anyio
-from core import InMemorySessionEventBridge
+from core import InMemorySessionEventBridge, Runner
 from fastapi import FastAPI
 
 from .config import GatewaySettings
@@ -16,7 +16,7 @@ from .services.discovery import (
     RunnerDiscoveryService,
     purge_sessions_for_missing_runners,
 )
-from .services.runner_client import RunnerCommandClient
+from .services.runner_client import RunnerCommandClient, RunnerCommandError
 from .services.runner_health import RunnerHealthClient
 from .services.runner_registry import RunnerRegistry
 from .services.runner_ws_proxy import RunnerWebSocketProxy
@@ -77,6 +77,8 @@ def _lifespan(app: FastAPI):
             registry,
             initial.removed,
         )
+        runners = await registry.list()
+        await _restore_runner_sessions(app, runners)
         async with anyio.create_task_group() as task_group:
             task_group.start_soon(_runner_maintenance_loop, app)
             try:
@@ -85,6 +87,62 @@ def _lifespan(app: FastAPI):
                 task_group.cancel_scope.cancel()
 
     return _context
+
+
+async def _restore_runner_sessions(app: FastAPI, runners: list[Runner]) -> None:
+    """Repopulate session registries from healthy runner snapshots.
+
+    Args:
+        app: FastAPI application exposing stateful registries and clients.
+        runners: Collection of runners observed during discovery.
+
+    Returns:
+        None. The coroutine updates the in-memory registries in place.
+
+    Example:
+        >>> await _restore_runner_sessions(app, await registry.list())  # doctest: +SKIP
+    """
+
+    if not runners:
+        return
+
+    session_registry: SessionRegistry = app.state.session_registry
+    runner_registry: RunnerRegistry = app.state.runner_registry
+    runner_client: RunnerCommandClient = app.state.runner_client
+
+    restored = 0
+    for runner in runners:
+        if not runner.healthy:
+            continue
+        try:
+            sessions = await runner_client.list_sessions(runner)
+        except RunnerCommandError as exc:
+            _LOGGER.warning(
+                "Failed to recover sessions from runner %s: %s",
+                runner.id,
+                exc,
+            )
+            continue
+
+        for session in sessions:
+            if session.runner_id and session.runner_id != runner.id:
+                _LOGGER.warning(
+                    "Skipping session %s reported by runner %s due to mismatched owner %s",
+                    session.id,
+                    runner.id,
+                    session.runner_id,
+                )
+                continue
+            await session_registry.upsert(session)
+            await runner_registry.register_session_ws_endpoint(
+                session.id,
+                runner_id=runner.id,
+                target=session.ws_endpoint,
+            )
+            restored += 1
+
+    if restored:
+        _LOGGER.info("Recovered %s session(s) from healthy runners", restored)
 
 
 async def _runner_maintenance_loop(app: FastAPI) -> None:

--- a/services/gateway/app/services/runner_client.py
+++ b/services/gateway/app/services/runner_client.py
@@ -8,7 +8,7 @@ from uuid import UUID
 
 import httpx
 from core import Runner, Session, SessionStatus
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, ValidationError
 
 
 class RunnerCommandError(RuntimeError):
@@ -139,6 +139,47 @@ class RunnerCommandClient:
 
         return await self._request(runner, "DELETE", f"/sessions/{session_id}")
 
+    async def list_sessions(self, runner: Runner) -> list[Session]:
+        """Return the collection of active sessions stored on ``runner``.
+
+        Args:
+            runner: Runner descriptor identifying the HTTP base URL that should
+                be queried.
+
+        Returns:
+            list[Session]: Validated session models returned by the runner. The
+            order mirrors the payload received from the service.
+
+        Raises:
+            RunnerCommandError: If the runner responds with a non-array JSON
+                payload or individual entries cannot be parsed as
+                :class:`core.Session` objects.
+
+        Example:
+            >>> client = RunnerCommandClient()  # doctest: +SKIP
+            >>> await client.list_sessions(runner)  # doctest: +SKIP
+        """
+
+        payload = await self._request_payload(runner, "GET", "/sessions")
+        if not isinstance(payload, list):
+            raise RunnerCommandError(
+                f"Runner {runner.id} responded with non-array payload for GET /sessions"
+            )
+
+        sessions: list[Session] = []
+        for index, item in enumerate(payload):
+            if not isinstance(item, Mapping):
+                raise RunnerCommandError(
+                    f"Runner {runner.id} returned a non-object entry at index {index}"
+                )
+            try:
+                sessions.append(Session.model_validate(item))
+            except ValidationError as exc:  # pragma: no cover - validation guard
+                raise RunnerCommandError(
+                    f"Runner {runner.id} returned an invalid session at index {index}"
+                ) from exc
+        return sessions
+
     async def _request(
         self,
         runner: Runner,
@@ -148,7 +189,74 @@ class RunnerCommandClient:
         json: Mapping[str, Any] | None = None,
         expected_status: int = 200,
     ) -> Session:
-        """Execute a Runner API call and parse the ``Session`` response."""
+        """Execute a Runner API call and parse the ``Session`` response.
+
+        Args:
+            runner: Runner descriptor identifying the API endpoint.
+            method: HTTP verb issued against the runner.
+            path: Path relative to the runner base URL.
+            json: Optional JSON body sent with the request.
+            expected_status: HTTP status code considered successful.
+
+        Returns:
+            Session: Validated session snapshot returned by the runner.
+
+        Raises:
+            RunnerCommandError: If the request fails, the status code differs
+                from ``expected_status`` or the payload cannot be validated.
+
+        Example:
+            >>> client = RunnerCommandClient()  # doctest: +SKIP
+            >>> await client._request(runner, "DELETE", "/sessions/1")  # doctest: +SKIP
+        """
+
+        payload = await self._request_payload(
+            runner,
+            method,
+            path,
+            json=json,
+            expected_status=expected_status,
+        )
+        if not isinstance(payload, Mapping):
+            raise RunnerCommandError(
+                f"Runner {runner.id} returned an unexpected payload for {method} {path}"
+            )
+        try:
+            return Session.model_validate(payload)
+        except ValidationError as exc:  # pragma: no cover - validation guard
+            raise RunnerCommandError(
+                f"Runner {runner.id} returned an invalid session payload"
+            ) from exc
+
+    async def _request_payload(
+        self,
+        runner: Runner,
+        method: str,
+        path: str,
+        *,
+        json: Mapping[str, Any] | None = None,
+        expected_status: int = 200,
+    ) -> Any:
+        """Execute a Runner API call and return the parsed JSON body.
+
+        Args:
+            runner: Runner descriptor identifying the API endpoint.
+            method: HTTP verb issued against the runner.
+            path: Relative path requested on the runner.
+            json: Optional JSON payload included in the request.
+            expected_status: HTTP status code considered successful.
+
+        Returns:
+            Any: Parsed JSON payload from the runner response.
+
+        Raises:
+            RunnerCommandError: If the HTTP request fails, returns an
+                unexpected status code or the body is not valid JSON.
+
+        Example:
+            >>> client = RunnerCommandClient()  # doctest: +SKIP
+            >>> await client._request_payload(runner, "GET", "/sessions")  # doctest: +SKIP
+        """
 
         try:
             async with httpx.AsyncClient(
@@ -172,8 +280,12 @@ class RunnerCommandClient:
                 f"Runner {runner.id} responded with unexpected status {response.status_code}"
             )
 
-        payload = response.json()
-        return Session.model_validate(payload)
+        try:
+            return response.json()
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise RunnerCommandError(
+                f"Runner {runner.id} returned non-JSON payload for {method} {path}"
+            ) from exc
 
 
 __all__ = [

--- a/services/gateway/tests/test_gateway.py
+++ b/services/gateway/tests/test_gateway.py
@@ -29,6 +29,7 @@ from app.deps import get_vnc_token_service  # noqa: E402
 from app.deps.security import get_authenticator, get_current_user  # noqa: E402
 from app.security import AuthenticatedUser, KeycloakAuthenticator, VncTokenService  # noqa: E402
 from app.services.runner_client import RunnerCommandClient  # noqa: E402
+from app.services.runner_health import RunnerHealthClient  # noqa: E402
 from core import (
     Runner,
     Session,
@@ -196,6 +197,78 @@ def test_vnc_overrides_apply_runner_templates(gateway_client: TestClient) -> Non
     assert payload["websocket_url"] == f"wss://vnc.example/ws/{session_id}"
     assert payload["token"]
     assert payload["token_ttl_seconds"] == 120
+
+
+@pytest.mark.anyio("asyncio")
+async def test_lifespan_restores_sessions_from_healthy_runners() -> None:
+    """Gateway lifespan should recover active sessions during startup."""
+
+    now = datetime.now(tz=UTC)
+    session_id = uuid4()
+    session_payload = {
+        "id": str(session_id),
+        "runner_id": "runner-1",
+        "status": SessionStatus.READY.value,
+        "created_at": now.isoformat(),
+        "last_seen_at": now.isoformat(),
+        "headless": False,
+        "idle_ttl_seconds": 300,
+        "labels": {"region": "eu-central"},
+        "ws_endpoint": "ws://runner-1/playwright/1",
+    }
+    list_requests: list[httpx.Request] = []
+
+    def _list_handler(request: httpx.Request) -> httpx.Response:
+        list_requests.append(request)
+        assert request.url.path == "/sessions"
+        return httpx.Response(200, json=[session_payload])
+
+    health_requests: list[httpx.Request] = []
+
+    def _health_handler(request: httpx.Request) -> httpx.Response:
+        health_requests.append(request)
+        assert request.url.path == "/health"
+        return httpx.Response(
+            200,
+            json={
+                "status": "ok",
+                "runner_id": "runner-1",
+                "slots": {"total": 1, "available": 0},
+                "vnc": {"enabled": True},
+            },
+        )
+
+    settings = GatewaySettings(
+        discovery_mode="static",
+        runners=[
+            Runner(
+                id="runner-1",
+                base_url="http://runner-1",
+                total_slots=1,
+                supports_vnc=True,
+            )
+        ],
+        jwt_jwks_url="http://jwks.local",
+        vnc_token_secret="unit-test-secret",
+        vnc_token_ttl_seconds=120,
+    )
+    app = create_app(settings)
+    app.state.runner_client = RunnerCommandClient(transport=httpx.MockTransport(_list_handler))
+    app.state.runner_health_client = RunnerHealthClient(transport=httpx.MockTransport(_health_handler))
+
+    async with app.router.lifespan_context(app):
+        stored = await app.state.session_registry.list()
+        assert len(stored) == 1
+        session = stored[0]
+        assert session.id == session_id
+        assert session.runner_id == "runner-1"
+        assert session.ws_endpoint == "ws://runner-1/playwright/1"
+        public = await app.state.runner_registry.resolve_session_ws_public(session.id)
+        assert public == f"/sessions/{session_id}/ws"
+
+    assert [request.url.path for request in list_requests] == ["/sessions"]
+    if health_requests:
+        assert [request.url.path for request in health_requests] == ["/health"]
 
 
 def test_session_reads_reflect_runner_override_updates(

--- a/services/gateway/tests/test_runner_client.py
+++ b/services/gateway/tests/test_runner_client.py
@@ -128,6 +128,38 @@ async def test_delete_session_issues_delete(sample_runner: Runner) -> None:
     assert requests[0].url.path.endswith(f"/sessions/{session_id}")
 
 
+async def test_list_sessions_returns_validated_models(sample_runner: Runner) -> None:
+    """``list_sessions`` issues ``GET /sessions`` and validates each entry."""
+
+    requests: list[httpx.Request] = []
+    payload = [_session_payload(), _session_payload()]
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200, json=payload)
+
+    client = RunnerCommandClient(transport=httpx.MockTransport(_handler))
+
+    sessions = await client.list_sessions(sample_runner)
+
+    assert requests
+    assert requests[0].method == "GET"
+    assert requests[0].url.path == "/sessions"
+    assert [str(session.id) for session in sessions] == [item["id"] for item in payload]
+
+
+async def test_list_sessions_rejects_invalid_entries(sample_runner: Runner) -> None:
+    """Non-mapping elements in the response should trigger ``RunnerCommandError``."""
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=["invalid"])
+
+    client = RunnerCommandClient(transport=httpx.MockTransport(_handler))
+
+    with pytest.raises(RunnerCommandError):
+        await client.list_sessions(sample_runner)
+
+
 async def test_create_session_raises_on_unexpected_status(sample_runner: Runner) -> None:
     """Non-201 responses for create commands raise ``RunnerCommandError``."""
 

--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -91,6 +91,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
   `RunnerSettings`. Отдельный JSON-файл описывает warm pool; при ошибках чтения/валидации
   старт завершается с развёрнутым сообщением, что упрощает операционную диагностику.
 - **Warm pool state machine**: ``WarmPoolManager`` использует явные состояния (`idle → reserved → busy → recycling`, а также `draining`/`error`) и индивидуальные ``asyncio.Lock`` для каждой рабочей станции. Это предотвращает гонки при параллельных резервациях и гарантирует, что recycle всегда закрывает процесс, чистит профили и перезапускает Camoufox с тем же fingerprint.
+- **Session recovery endpoint**: Runner публикует `GET /sessions`, который отдаёт `SessionManager.list_sessions` для восстановления состояния control-plane сервисов (gateway, worker) после рестартов. Контракт покрыт юнит-тестами `test_list_sessions_returns_empty_collection` и `test_list_sessions_returns_active_sessions`.
 
 ## Constraints & Invariants
 - `RunnerSettings.vnc_token_ttl_seconds` capped at 300 seconds to align with `SessionVncDetails` validation.
@@ -108,6 +109,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 
 ## Known Gaps / TODO
 - [ ] Зафиксировать профиль нагрузки для in-memory издателя после появления боевых метрик, чтобы подтвердить соответствие latency требованиям.
+- [x] Документирован поток восстановления: gateway опрашивает `GET /sessions` на старте (см. `test_lifespan_restores_sessions_from_healthy_runners`), runner покрыт тестами `test_list_sessions_returns_*`.
 
 ## How to Test
 - `poetry install --no-root`
@@ -136,3 +138,5 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-19 · gpt-5-codex · Вынесены маршруты `/workstations` в отдельный роутер с Pydantic-моделями, WarmPoolManager публикует события state/error/recycled, добавлены SSE/WS-обёртки и интеграционные тесты.
 - 2025-10-20 · gpt-5-codex · Добавлены warm-pool метрики/таймеры, расширен `/health` данными пула и настроен формат логов с идентификаторами; обновлены тесты `/metrics` и `/health`.
 - 2025-10-21 · gpt-5-codex · Реализованы режимы warm pool (warm-only/cold-only/hybrid), гибридный fallback на `launch_browser`, расширение метаданных `browser_origin` и покрытие тестами.
+- 2025-10-22 · gpt-5-codex · Добавлен `GET /sessions` для восстановления состояния gateway и юнит-тесты на пустой и заполненный реестры.
+

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -160,6 +160,24 @@ async def create_session(
         ) from exc
 
 
+@app.get("/sessions", response_model=list[Session], summary="List sessions")
+async def list_sessions(manager: SessionManagerDep) -> list[Session]:
+    """Return all active sessions tracked by the runner.
+
+    Args:
+        manager: Session manager responsible for storing active sessions.
+
+    Returns:
+        list[Session]: Ordered collection of active sessions managed by the
+        runner.
+
+    Example:
+        >>> await list_sessions(manager)  # doctest: +SKIP
+    """
+
+    return await manager.list_sessions()
+
+
 @app.patch("/sessions/{session_id}", response_model=Session, summary="Update a session")
 async def update_session(
     session_id: UUID,

--- a/services/runner/tests/test_main.py
+++ b/services/runner/tests/test_main.py
@@ -218,6 +218,72 @@ class _MainStubWarmPool:
             if slot["state"] is WarmPoolState.IDLE:
                 return workstation_id
         raise WarmPoolStateError("no idle warm workstations available")
+
+
+@pytest.mark.anyio("asyncio")
+async def test_list_sessions_returns_empty_collection() -> None:
+    """``GET /sessions`` should return an empty list when no sessions exist."""
+
+    clock = _ApiStubClock(datetime(2024, 2, 1, 8, 0, 0, tzinfo=UTC))
+    settings = RunnerSettings(runner_id="runner-list", camoufox_path="/usr/bin/camoufox")
+    publisher = InMemorySessionEventPublisher()
+    manager = SessionManager(
+        settings,
+        publisher,
+        clock=clock,
+        reaper_interval_seconds=5.0,
+        vnc_controller=_MainStubVncController(),
+        warm_pool_manager=_MainStubWarmPool(),
+    )
+
+    app.dependency_overrides[get_runner_settings] = lambda: settings
+    app.dependency_overrides[get_event_publisher] = lambda: publisher
+    app.dependency_overrides[get_session_manager] = lambda: manager
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.get("/sessions")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.anyio("asyncio")
+async def test_list_sessions_returns_active_sessions() -> None:
+    """``GET /sessions`` should mirror the sessions maintained in memory."""
+
+    clock = _ApiStubClock(datetime(2024, 2, 1, 8, 30, 0, tzinfo=UTC))
+    settings = RunnerSettings(runner_id="runner-list", camoufox_path="/usr/bin/camoufox")
+    publisher = InMemorySessionEventPublisher()
+    warm_pool = _MainStubWarmPool()
+    manager = SessionManager(
+        settings,
+        publisher,
+        clock=clock,
+        reaper_interval_seconds=5.0,
+        vnc_controller=_MainStubVncController(),
+        warm_pool_manager=warm_pool,
+    )
+
+    first = await manager.create_session(SessionCreatePayload(headless=False))
+    second = await manager.create_session(SessionCreatePayload(headless=True))
+
+    app.dependency_overrides[get_runner_settings] = lambda: settings
+    app.dependency_overrides[get_event_publisher] = lambda: publisher
+    app.dependency_overrides[get_session_manager] = lambda: manager
+
+    try:
+        async with AsyncClient(app=app, base_url="http://test") as client:
+            response = await client.get("/sessions")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert {item["id"] for item in payload} == {str(first.id), str(second.id)}
+
 @pytest.mark.anyio("asyncio")
 async def test_health_endpoint_reports_extended_metrics() -> None:
     """``GET /health`` should expose slots, proxy, VNC, and prewarm diagnostics."""


### PR DESCRIPTION
## Summary
- expose GET /sessions on the runner so control-plane services can enumerate active sessions
- extend the gateway runner client with list_sessions validation and bootstrap recovery that seeds registries from healthy runners
- add focused unit tests plus documentation updates covering the recovery flow in both runner and gateway notes

## Testing
- `cd services/runner && PYTHONPATH=. poetry run pytest tests/test_main.py::test_list_sessions_returns_empty_collection tests/test_main.py::test_list_sessions_returns_active_sessions -q`
- `cd services/gateway && PYTHONPATH=. poetry run pytest tests/test_runner_client.py::test_list_sessions_returns_validated_models tests/test_runner_client.py::test_list_sessions_rejects_invalid_entries tests/test_gateway.py::test_lifespan_restores_sessions_from_healthy_runners -q`

## Security
- no security concerns identified

------
https://chatgpt.com/codex/tasks/task_e_68de9381ffe4832a8f8c68c47e80761a