### PR TITLE
Add UI toolbar and dashboard tests with CI integration

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,0 +1,38 @@
+name: ui-tests
+
+on:
+  pull_request:
+    paths:
+      - 'apps/ui/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/ui-tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'apps/ui/**'
+      - 'pnpm-lock.yaml'
+      - 'package.json'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/ui-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint UI
+        run: pnpm -C apps/ui lint
+      - name: Run UI tests
+        run: pnpm -C apps/ui test

--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -36,7 +36,7 @@
 ## Known Gaps / TODO
 - [x] Реальные справочники браузеров/регионов/прокси брать с backend вместо захардкоженных значений (через `/runners` + агрегацию `buildSessionComposerData`).
 - [ ] Поддержать обновление прокси существующей сессии (UI + endpoint).
-- [ ] Покрыть компонентные сценарии (SessionToolbar/Dashboard) тестами RTL.
+- [x] Покрыть компонентные сценарии (SessionToolbar/Dashboard) тестами RTL (см. `SessionToolbar.test.tsx`, `DashboardPage.test.tsx`).
 - [ ] Реализовать обработку ошибок SSE (баннер, кнопка повторного подключения).
 - [ ] Визуализировать выбор раннера в composer, когда на бэке появится стратегия балансировки.
 
@@ -53,4 +53,5 @@
 - 2024-09-10 · gpt-5-codex · Переключили SSE на `/events`, пробрасываем токен через `access_token`, добавлен vitest для клиента.
 - 2024-09-11 · gpt-5-codex · Перевели UI на командные эндпоинты `/sessions/commands`, покрыли DashboardPage сценарии создания/удаления.
 - 2025-03-17 · gpt-5-codex · Интегрированы `/runners` в UI: динамический SessionComposer, статус-панель воркеров, тесты на загрузку/ошибки и фильтрацию раннеров.
+- 2025-10-02 · gpt-5-codex · Добавлены UI-тесты для SessionToolbar/Dashboard с моками React Query/API, обновлены скрипты и CI.
 - 2025-10-14 · gpt-5-codex · UI принимает `ws_public_endpoint`, хранит обе ссылки на WebSocket и по умолчанию использует прямой `wsEndpoint`.

--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -55,3 +55,5 @@
 - 2025-03-17 · gpt-5-codex · Интегрированы `/runners` в UI: динамический SessionComposer, статус-панель воркеров, тесты на загрузку/ошибки и фильтрацию раннеров.
 - 2025-10-02 · gpt-5-codex · Добавлены UI-тесты для SessionToolbar/Dashboard с моками React Query/API, обновлены скрипты и CI.
 - 2025-10-14 · gpt-5-codex · UI принимает `ws_public_endpoint`, хранит обе ссылки на WebSocket и по умолчанию использует прямой `wsEndpoint`.
+- 2025-10-15 · gpt-5-codex · Уточнены моки React Query/API в тестах DashboardPage для строгой типизации ESLint; адаптер
+  `buildSessionCreatePayload` теперь использует явный тип `SessionComposerSubmission`.

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.56.0",

--- a/apps/ui/src/__tests__/DashboardPage.test.tsx
+++ b/apps/ui/src/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+import { DashboardPage } from '../pages/DashboardPage';
+import { useSessionFilters } from '../store/sessionFilters';
+import { queryKeys } from '../utils/queryKeys';
+import type { Session } from '../types/session';
+import type { RunnerStatus } from '../types/runner';
+
+const useQueryMock = vi.fn();
+const useMutationMock = vi.fn();
+const invalidateQueriesMock = vi.fn();
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+  useMutation: (...args: unknown[]) => useMutationMock(...args),
+  useQueryClient: () => ({ invalidateQueries: invalidateQueriesMock }),
+}));
+
+const fetchSessionsMock = vi.fn();
+const fetchRunnersMock = vi.fn();
+const createSessionMock = vi.fn();
+const deleteSessionMock = vi.fn();
+
+vi.mock('../api/client', () => ({
+  fetchSessions: (...args: unknown[]) => fetchSessionsMock(...args),
+  fetchRunners: (...args: unknown[]) => fetchRunnersMock(...args),
+  createSession: (...args: unknown[]) => createSessionMock(...args),
+  deleteSession: (...args: unknown[]) => deleteSessionMock(...args),
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    token: 'token-123',
+    profile: { firstName: 'Tester' },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock('../components/Topbar', () => ({
+  Topbar: () => <div data-testid="topbar" />,
+}));
+
+vi.mock('../components/SessionDetailsPanel', () => ({
+  SessionDetailsPanel: ({ session }: { session: Session | null }) => (
+    <div data-testid="details-panel">{session ? session.id : 'empty'}</div>
+  ),
+}));
+
+vi.mock('../components/SessionComposer', () => ({
+  SessionComposer: ({
+    onSubmit,
+    onCancel,
+    error,
+    isLoading,
+  }: {
+    onSubmit: (values: {
+      browserName: string;
+      region: string;
+      proxyId: string | null;
+      runnerId: string | null;
+    }) => Promise<void> | void;
+    onCancel: () => void;
+    error: string | null;
+    isLoading: boolean;
+  }) => (
+    <div data-testid="session-composer">
+      {error && <div role="alert">{error}</div>}
+      {isLoading && <div>Загружаем доступные параметры…</div>}
+      <button
+        type="button"
+        onClick={() =>
+          onSubmit({ browserName: 'Chrome', region: 'eu', proxyId: null, runnerId: null })
+        }
+      >
+        Отправить composer
+      </button>
+      <button type="button" onClick={onCancel}>
+        Закрыть composer
+      </button>
+    </div>
+  ),
+}));
+
+const createSession = (overrides: Partial<Session>): Session => ({
+  id: 'session-id',
+  runnerId: 'runner-id',
+  status: 'READY',
+  createdAt: '2024-09-01T10:00:00.000Z',
+  lastSeenAt: '2024-09-01T10:05:00.000Z',
+  endedAt: null,
+  startUrl: null,
+  startUrlWait: 'none',
+  headless: false,
+  idleTtlSeconds: 60,
+  browser: 'Chrome',
+  wsEndpoint: null,
+  publicWsEndpoint: null,
+  proxy: null,
+  vnc: null,
+  vncEnabled: null,
+  labels: {},
+  metadata: {},
+  region: 'eu',
+  proxyId: 'proxy-1',
+  proxyLabel: 'Proxy 1',
+  snapshotUrl: null,
+  ...overrides,
+});
+
+const createRunner = (overrides: Partial<RunnerStatus>): RunnerStatus => ({
+  id: 'runner-1',
+  baseUrl: 'http://runner-1',
+  state: 'idle',
+  totalSlots: 1,
+  availableSlots: 1,
+  healthy: true,
+  supportsVnc: true,
+  lastHeartbeatAt: '2024-09-01T10:00:00.000Z',
+  vncHttpUrlTemplate: null,
+  vncWsUrlTemplate: null,
+  capabilities: [],
+  ...overrides,
+});
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    useSessionFilters.getState().reset();
+    useQueryMock.mockReset();
+    useMutationMock.mockReset();
+    invalidateQueriesMock.mockReset();
+    fetchSessionsMock.mockReset();
+    fetchRunnersMock.mockReset();
+    createSessionMock.mockReset();
+    deleteSessionMock.mockReset();
+    useMutationMock.mockImplementation(
+      ({
+        mutationFn,
+        onSuccess,
+      }: {
+        mutationFn: (value: unknown) => unknown;
+        onSuccess?: () => void;
+      }) => ({
+        mutate: (value?: unknown) => {
+          const result = mutationFn(value as never);
+          Promise.resolve(result).then(() => {
+            onSuccess?.();
+          });
+          return result;
+        },
+        mutateAsync: async (value?: unknown) => {
+          const result = await Promise.resolve(mutationFn(value as never));
+          onSuccess?.();
+          return result;
+        },
+        isPending: false,
+      }),
+    );
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows loading and refreshing states when queries are pending', () => {
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown }) => {
+      if (queryKey === queryKeys.sessions) {
+        return { data: undefined, isLoading: true, isFetching: true };
+      }
+      if (queryKey === queryKeys.runners) {
+        return { data: undefined, isLoading: true, isFetching: true, error: null };
+      }
+      throw new Error('Unexpected query key');
+    });
+
+    render(<DashboardPage />);
+
+    expect(screen.getByText('Загружаем сессии…')).toBeTruthy();
+    expect(screen.getAllByText('Обновление…').length).toBe(2);
+    expect(screen.getByText('Загружаем раннеров…')).toBeTruthy();
+  });
+
+  it('filters sessions based on active store filters', () => {
+    const sessions = [
+      createSession({ id: 'session-alpha', runnerId: 'runner-alpha', browser: 'Chrome', region: 'eu' }),
+      createSession({ id: 'session-beta', runnerId: 'runner-beta', browser: 'Firefox', region: 'us' }),
+    ];
+
+    useSessionFilters.setState({
+      search: 'beta',
+      status: 'all',
+      region: null,
+      proxyId: null,
+    });
+
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown }) => {
+      if (queryKey === queryKeys.sessions) {
+        return { data: sessions, isLoading: false, isFetching: false };
+      }
+      if (queryKey === queryKeys.runners) {
+        return { data: [createRunner({ id: 'runner-alpha' })], isLoading: false, isFetching: false, error: null };
+      }
+      throw new Error('Unexpected query key');
+    });
+
+    render(<DashboardPage />);
+
+    expect(screen.getByText('session-beta')).toBeTruthy();
+    expect(screen.queryByText('session-alpha')).toBeNull();
+  });
+
+  it('creates a session through the composer and invalidates the cache', async () => {
+    const sessions = [createSession({ id: 'session-alpha' })];
+
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown }) => {
+      if (queryKey === queryKeys.sessions) {
+        return { data: sessions, isLoading: false, isFetching: false };
+      }
+      if (queryKey === queryKeys.runners) {
+        return { data: [createRunner({ id: 'runner-alpha' })], isLoading: false, isFetching: false, error: null };
+      }
+      throw new Error('Unexpected query key');
+    });
+
+    createSessionMock.mockResolvedValue(createSession({ id: 'session-new' }));
+
+    render(<DashboardPage />);
+
+    fireEvent.click(screen.getByText('Создать сессию'));
+
+    const composer = await screen.findByTestId('session-composer');
+    fireEvent.click(within(composer).getByText('Отправить composer'));
+
+    await waitFor(() =>
+      expect(createSessionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browserName: 'Chrome',
+          region: 'eu',
+          proxyId: null,
+          runnerId: undefined,
+        }),
+        { token: 'token-123' },
+      ),
+    );
+
+    await waitFor(() => expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: queryKeys.sessions }));
+    await waitFor(() => expect(screen.queryByTestId('session-composer')).toBeNull());
+  });
+
+  it('deletes the selected session and refreshes the cache', async () => {
+    const sessions = [createSession({ id: 'session-alpha', runnerId: 'runner-alpha' })];
+
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown }) => {
+      if (queryKey === queryKeys.sessions) {
+        return { data: sessions, isLoading: false, isFetching: false };
+      }
+      if (queryKey === queryKeys.runners) {
+        return { data: [createRunner({ id: 'runner-alpha' })], isLoading: false, isFetching: false, error: null };
+      }
+      throw new Error('Unexpected query key');
+    });
+
+    deleteSessionMock.mockResolvedValue(undefined);
+
+    render(<DashboardPage />);
+
+    fireEvent.click(await screen.findByText('session-alpha'));
+    fireEvent.click(screen.getByText('Удалить'));
+
+    await waitFor(() => expect(deleteSessionMock).toHaveBeenCalledWith('session-alpha', { token: 'token-123' }));
+    await waitFor(() => expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: queryKeys.sessions }));
+  });
+});
+

--- a/apps/ui/src/__tests__/DashboardPage.test.tsx
+++ b/apps/ui/src/__tests__/DashboardPage.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { QueryKey, UseQueryResult } from '@tanstack/react-query';
 
 import { DashboardPage } from '../pages/DashboardPage';
 import { useSessionFilters } from '../store/sessionFilters';
@@ -7,26 +8,59 @@ import { queryKeys } from '../utils/queryKeys';
 import type { Session } from '../types/session';
 import type { RunnerStatus } from '../types/runner';
 
-const useQueryMock = vi.fn();
-const useMutationMock = vi.fn();
-const invalidateQueriesMock = vi.fn();
+type MockedQueryResult<TData> = Pick<
+  UseQueryResult<TData, Error>,
+  'data' | 'isLoading' | 'isFetching' | 'error'
+>;
 
-vi.mock('@tanstack/react-query', () => ({
-  useQuery: (...args: unknown[]) => useQueryMock(...args),
-  useMutation: (...args: unknown[]) => useMutationMock(...args),
-  useQueryClient: () => ({ invalidateQueries: invalidateQueriesMock }),
+const useQueryMock = vi.fn<(options: { queryKey: QueryKey }) => MockedQueryResult<unknown>>();
+
+type MutationOptions = {
+  mutationFn: (variables: unknown) => unknown;
+  onSuccess?: () => void;
+};
+
+type MutationResult = {
+  mutate: (value?: unknown) => void;
+  mutateAsync: (value?: unknown) => Promise<unknown>;
+  isPending: boolean;
+};
+
+const useMutationMock = vi.fn<(options: MutationOptions) => MutationResult>();
+const invalidateQueriesMock = vi.fn<(options: { queryKey: QueryKey }) => void>();
+
+vi.mock('@tanstack/react-query', () => {
+  const module: {
+    useQuery: (options: { queryKey: QueryKey }) => MockedQueryResult<unknown>;
+    useMutation: (options: MutationOptions) => MutationResult;
+    useQueryClient: () => {
+      invalidateQueries: (options: { queryKey: QueryKey }) => void;
+    };
+  } = {
+    useQuery: (options: { queryKey: QueryKey }) => useQueryMock(options),
+    useMutation: (options: MutationOptions) => useMutationMock(options),
+    useQueryClient: () => ({ invalidateQueries: invalidateQueriesMock }),
+  };
+  return module;
+});
+
+const {
+  fetchSessionsMock,
+  fetchRunnersMock,
+  createSessionMock,
+  deleteSessionMock,
+} = vi.hoisted(() => ({
+  fetchSessionsMock: vi.fn<(...args: unknown[]) => Promise<Session[]>>(),
+  fetchRunnersMock: vi.fn<(...args: unknown[]) => Promise<RunnerStatus[]>>(),
+  createSessionMock: vi.fn<(...args: unknown[]) => Promise<Session>>(),
+  deleteSessionMock: vi.fn<(...args: unknown[]) => Promise<void>>(),
 }));
 
-const fetchSessionsMock = vi.fn();
-const fetchRunnersMock = vi.fn();
-const createSessionMock = vi.fn();
-const deleteSessionMock = vi.fn();
-
 vi.mock('../api/client', () => ({
-  fetchSessions: (...args: unknown[]) => fetchSessionsMock(...args),
-  fetchRunners: (...args: unknown[]) => fetchRunnersMock(...args),
-  createSession: (...args: unknown[]) => createSessionMock(...args),
-  deleteSession: (...args: unknown[]) => deleteSessionMock(...args),
+  fetchSessions: fetchSessionsMock,
+  fetchRunners: fetchRunnersMock,
+  createSession: createSessionMock,
+  deleteSession: deleteSessionMock,
 }));
 
 vi.mock('../hooks/useAuth', () => ({
@@ -69,9 +103,9 @@ vi.mock('../components/SessionComposer', () => ({
       {isLoading && <div>Загружаем доступные параметры…</div>}
       <button
         type="button"
-        onClick={() =>
-          onSubmit({ browserName: 'Chrome', region: 'eu', proxyId: null, runnerId: null })
-        }
+        onClick={() => {
+          void onSubmit({ browserName: 'Chrome', region: 'eu', proxyId: null, runnerId: null });
+        }}
       >
         Отправить composer
       </button>
@@ -133,29 +167,20 @@ describe('DashboardPage', () => {
     fetchRunnersMock.mockReset();
     createSessionMock.mockReset();
     deleteSessionMock.mockReset();
-    useMutationMock.mockImplementation(
-      ({
-        mutationFn,
-        onSuccess,
-      }: {
-        mutationFn: (value: unknown) => unknown;
-        onSuccess?: () => void;
-      }) => ({
-        mutate: (value?: unknown) => {
-          const result = mutationFn(value as never);
-          Promise.resolve(result).then(() => {
-            onSuccess?.();
-          });
-          return result;
-        },
-        mutateAsync: async (value?: unknown) => {
-          const result = await Promise.resolve(mutationFn(value as never));
+    useMutationMock.mockImplementation(({ mutationFn, onSuccess }: MutationOptions) => ({
+      mutate: (value?: unknown) => {
+        const result = mutationFn(value);
+        void Promise.resolve(result).then(() => {
           onSuccess?.();
-          return result;
-        },
-        isPending: false,
-      }),
-    );
+        });
+      },
+      mutateAsync: async (value?: unknown) => {
+        const result = await Promise.resolve(mutationFn(value));
+        onSuccess?.();
+        return result;
+      },
+      isPending: false,
+    }));
   });
 
   afterEach(() => {
@@ -163,9 +188,9 @@ describe('DashboardPage', () => {
   });
 
   it('shows loading and refreshing states when queries are pending', () => {
-    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown }) => {
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: QueryKey }) => {
       if (queryKey === queryKeys.sessions) {
-        return { data: undefined, isLoading: true, isFetching: true };
+        return { data: undefined, isLoading: true, isFetching: true, error: undefined };
       }
       if (queryKey === queryKeys.runners) {
         return { data: undefined, isLoading: true, isFetching: true, error: null };
@@ -193,9 +218,9 @@ describe('DashboardPage', () => {
       proxyId: null,
     });
 
-    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown }) => {
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: QueryKey }) => {
       if (queryKey === queryKeys.sessions) {
-        return { data: sessions, isLoading: false, isFetching: false };
+        return { data: sessions, isLoading: false, isFetching: false, error: undefined };
       }
       if (queryKey === queryKeys.runners) {
         return { data: [createRunner({ id: 'runner-alpha' })], isLoading: false, isFetching: false, error: null };
@@ -212,9 +237,9 @@ describe('DashboardPage', () => {
   it('creates a session through the composer and invalidates the cache', async () => {
     const sessions = [createSession({ id: 'session-alpha' })];
 
-    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown }) => {
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: QueryKey }) => {
       if (queryKey === queryKeys.sessions) {
-        return { data: sessions, isLoading: false, isFetching: false };
+        return { data: sessions, isLoading: false, isFetching: false, error: undefined };
       }
       if (queryKey === queryKeys.runners) {
         return { data: [createRunner({ id: 'runner-alpha' })], isLoading: false, isFetching: false, error: null };
@@ -250,9 +275,9 @@ describe('DashboardPage', () => {
   it('deletes the selected session and refreshes the cache', async () => {
     const sessions = [createSession({ id: 'session-alpha', runnerId: 'runner-alpha' })];
 
-    useQueryMock.mockImplementation(({ queryKey }: { queryKey: unknown }) => {
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: QueryKey }) => {
       if (queryKey === queryKeys.sessions) {
-        return { data: sessions, isLoading: false, isFetching: false };
+        return { data: sessions, isLoading: false, isFetching: false, error: undefined };
       }
       if (queryKey === queryKeys.runners) {
         return { data: [createRunner({ id: 'runner-alpha' })], isLoading: false, isFetching: false, error: null };

--- a/apps/ui/src/__tests__/SessionToolbar.test.tsx
+++ b/apps/ui/src/__tests__/SessionToolbar.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+
+import { SessionToolbar } from '../components/SessionToolbar';
+import { useSessionFilters } from '../store/sessionFilters';
+import type { Session } from '../types/session';
+
+const createSession = (overrides: Partial<Session>): Session => ({
+  id: 'session-id',
+  runnerId: 'runner-id',
+  status: 'READY',
+  createdAt: '2024-09-01T10:00:00.000Z',
+  lastSeenAt: '2024-09-01T10:05:00.000Z',
+  endedAt: null,
+  startUrl: null,
+  startUrlWait: 'none',
+  headless: false,
+  idleTtlSeconds: 60,
+  browser: 'Chrome',
+  wsEndpoint: null,
+  publicWsEndpoint: null,
+  proxy: null,
+  vnc: null,
+  vncEnabled: null,
+  labels: {},
+  metadata: {},
+  region: 'eu-central-1',
+  proxyId: 'proxy-1',
+  proxyLabel: 'Proxy 1',
+  snapshotUrl: null,
+  ...overrides,
+});
+
+describe('SessionToolbar', () => {
+  beforeEach(() => {
+    useSessionFilters.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('derives filter options from provided sessions', () => {
+    const sessions = [
+      createSession({ id: 's-1', region: 'eu-west', proxyId: 'proxy-1', proxyLabel: 'Proxy Alpha' }),
+      createSession({ id: 's-2', region: 'us-east', proxyId: 'proxy-2', proxyLabel: 'Proxy Beta' }),
+      createSession({ id: 's-3', region: 'eu-west', proxyId: 'proxy-2', proxyLabel: 'Proxy Beta' }),
+    ];
+
+    render(<SessionToolbar sessions={sessions} onCreate={() => {}} />);
+
+    const regionSelect = screen.getByLabelText('Регион');
+    const regionOptions = within(regionSelect).getAllByRole('option').map((option) => option.textContent);
+    expect(regionOptions).toEqual(['Все', 'eu-west', 'us-east']);
+
+    const proxySelect = screen.getByLabelText('Прокси');
+    const proxyOptions = within(proxySelect).getAllByRole('option').map((option) => option.textContent);
+    expect(proxyOptions).toEqual(['Все', 'Proxy Alpha', 'Proxy Beta']);
+  });
+
+  it('updates filters and resets them to defaults', () => {
+    render(<SessionToolbar sessions={[createSession({})]} onCreate={() => {}} />);
+
+    const searchInput = screen.getByPlaceholderText('Поиск по ID, региону или прокси');
+    fireEvent.change(searchInput, { target: { value: 'runner' } });
+
+    const statusSelect = screen.getByLabelText('Статус');
+    fireEvent.change(statusSelect, { target: { value: 'READY' } });
+
+    const regionSelect = screen.getByLabelText('Регион');
+    fireEvent.change(regionSelect, { target: { value: 'eu-central-1' } });
+
+    const proxySelect = screen.getByLabelText('Прокси');
+    fireEvent.change(proxySelect, { target: { value: 'proxy-1' } });
+
+    expect(useSessionFilters.getState()).toMatchObject({
+      search: 'runner',
+      status: 'READY',
+      region: 'eu-central-1',
+      proxyId: 'proxy-1',
+    });
+
+    fireEvent.click(screen.getByText('Сбросить'));
+
+    expect(useSessionFilters.getState()).toMatchObject({
+      search: '',
+      status: 'all',
+      region: null,
+      proxyId: null,
+    });
+  });
+
+  it('invokes onCreate when create button is clicked', () => {
+    const handleCreate = vi.fn();
+    render(<SessionToolbar sessions={[createSession({})]} onCreate={handleCreate} />);
+
+    fireEvent.click(screen.getByText('Создать сессию'));
+
+    expect(handleCreate).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/apps/ui/src/api/__tests__/sessionCreation.test.ts
+++ b/apps/ui/src/api/__tests__/sessionCreation.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { buildSessionCreatePayload } from '../sessionCreation';
-import type { SessionComposerValues } from '../../components/SessionComposer';
+import type { SessionComposerSubmission } from '../sessionCreation';
 
 describe('session creation adapter', () => {
-  const baseValues: SessionComposerValues = {
+  const baseValues: SessionComposerSubmission = {
     browserName: 'Camoufox',
     region: 'eu-central',
     proxyId: 'proxy-1',

--- a/apps/ui/src/api/sessionCreation.ts
+++ b/apps/ui/src/api/sessionCreation.ts
@@ -1,6 +1,19 @@
 import type { SessionComposerValues } from '../components/SessionComposer';
 
 /**
+ * Subset of form values that the Runner payload adapter depends on.
+ */
+export interface SessionComposerSubmission extends SessionComposerValues {
+  readonly headless: boolean;
+  readonly idleTtlSeconds: number;
+  readonly startUrl: string;
+  readonly startUrlWait: 'none' | 'domcontentloaded' | 'load';
+  readonly proxyHttp: string;
+  readonly proxyHttps: string;
+  readonly proxySocks: string;
+}
+
+/**
  * JSON payload accepted by the Runner ``POST /sessions`` endpoint.
  */
 export interface SessionCreateRequest {
@@ -27,7 +40,7 @@ const sanitizeUrl = (value: string): string | null => {
 };
 
 const buildProxy = (
-  values: SessionComposerValues,
+  values: SessionComposerSubmission,
 ): SessionCreateRequest['proxy'] => {
   const http = sanitizeUrl(values.proxyHttp);
   const https = sanitizeUrl(values.proxyHttps);
@@ -48,7 +61,7 @@ const buildProxy = (
  * Convert form values collected by :component:`SessionComposer` into a Runner payload.
  */
 export const buildSessionCreatePayload = (
-  values: SessionComposerValues,
+  values: SessionComposerSubmission,
 ): SessionCreateRequest => {
   const startUrl = sanitizeUrl(values.startUrl);
   const labels: Record<string, string> = { region: values.region };


### PR DESCRIPTION
## Summary
- add React Testing Library coverage for the SessionToolbar filters and create action
- cover DashboardPage loading, creation, and deletion flows via mocked React Query/API clients
- run vitest in single-run mode, document the change, and wire UI tests into CI

## Testing
- `pnpm -C apps/ui test`

## Security
- no security impact

------
https://chatgpt.com/codex/tasks/task_e_68de9ec252b4832a878e74428971b53b