### PR TITLE
Add CI pipeline for runner image with signing

### DIFF
--- a/.github/workflows/runner-image.yml
+++ b/.github/workflows/runner-image.yml
@@ -1,0 +1,63 @@
+name: build-runner-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_tag:
+        description: "Tag runner-образа (пример: dev)"
+        required: true
+      camoufox_version:
+        description: "Override camoufox wheel version (пример: 0.4.11)"
+        required: false
+  push:
+    paths:
+      - "services/runner/Dockerfile"
+      - "services/runner/pyproject.toml"
+      - "services/runner/poetry.lock"
+      - "services/runner/**/*.py"
+      - "services/runner/**/py.typed"
+      - "services/runner/bin/**"
+      - "services/runner/tests/**"
+      - "camoufox/**"
+      - "packages/camoufox/**"
+      - "Makefile"
+      - ".github/workflows/runner-image.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ toLower(github.repository_owner) }}/runner
+      IMAGE_TAG: ${{ inputs.runner_tag || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Compose image reference
+        run: echo "IMAGE_REF=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_ENV"
+      - name: Build image & run container checks
+        env:
+          RUNNER_IMAGE: ${{ env.IMAGE_REF }}
+          RUNNER_CAMOUFOX_VERSION: ${{ inputs.camoufox_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${RUNNER_CAMOUFOX_VERSION}" ]; then
+            make runner-image RUNNER_IMAGE="${RUNNER_IMAGE}" RUNNER_CAMOUFOX_VERSION="${RUNNER_CAMOUFOX_VERSION}"
+          else
+            make runner-image RUNNER_IMAGE="${RUNNER_IMAGE}"
+          fi
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push runner image
+        run: docker push "${IMAGE_REF}"
+      - uses: sigstore/cosign-installer@v3.6.0
+      - name: Sign runner image
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: cosign sign --yes "${IMAGE_REF}"

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,35 @@
-.PHONY: bootstrap check
+.PHONY: bootstrap check runner-image runner-image-publish
+
+RUNNER_IMAGE ?= ghost-runner:local
+RUNNER_DOCKERFILE ?= services/runner/Dockerfile
+RUNNER_CONTEXT ?= .
+RUNNER_CAMOUFOX_VERSION ?=
+RUNNER_EXTRA_BUILD_ARGS ?=
+RUNNER_BUILD_ARGS := $(if $(RUNNER_CAMOUFOX_VERSION),--build-arg CAMOUFOX_VERSION=$(RUNNER_CAMOUFOX_VERSION),) $(RUNNER_EXTRA_BUILD_ARGS)
+RUNNER_TEST_CMD := set -euo pipefail; poetry check; poetry install --with dev --no-root --no-interaction; PYTHONPATH=. poetry run pytest -q; poetry run python -m camoufox path; poetry run python -m camoufox version
+RUNNER_SIGN ?= false
+RUNNER_COSIGN_ARGS ?= --yes
 
 bootstrap:
-pnpm install
-cd services/gateway && poetry install --no-root
-cd services/runner && poetry install --no-root
-cd services/vnc-gateway && poetry install --no-root
-cd packages/core && poetry install --no-root
+	pnpm install
+	cd services/gateway && poetry install --no-root
+	cd services/runner && poetry install --no-root
+	cd services/vnc-gateway && poetry install --no-root
+	cd packages/core && poetry install --no-root
 
 check:
-pnpm -C apps/ui lint && pnpm -C apps/ui test
-cd services/gateway && poetry run ruff check . && poetry run pytest -q
-cd services/runner && poetry run ruff check . && poetry run pytest -q
-cd services/vnc-gateway && poetry run ruff check . && poetry run pytest -q
-cd packages/core && poetry run ruff check . && poetry run pytest -q
+	pnpm -C apps/ui lint && pnpm -C apps/ui test
+	cd services/gateway && poetry run ruff check . && poetry run pytest -q
+	cd services/runner && poetry run ruff check . && poetry run pytest -q
+	cd services/vnc-gateway && poetry run ruff check . && poetry run pytest -q
+	cd packages/core && poetry run ruff check . && poetry run pytest -q
+
+runner-image:
+	docker buildx build --load -f $(RUNNER_DOCKERFILE) -t $(RUNNER_IMAGE) $(RUNNER_BUILD_ARGS) $(RUNNER_CONTEXT)
+	docker run --rm --entrypoint bash -w /workspace/services/runner $(RUNNER_IMAGE) -lc "$(RUNNER_TEST_CMD)"
+
+runner-image-publish: runner-image
+	docker push $(RUNNER_IMAGE)
+	@if [ "$(RUNNER_SIGN)" = "true" ]; then \
+	cosign sign $(RUNNER_COSIGN_ARGS) $(RUNNER_IMAGE); \
+	fi

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,3 +41,15 @@
 ## Нефункциональные требования
 - Время запуска «тёплой» сессии ≤ 4 сек.
 - SLA событий: < 2 сек до доставки в UI.
+
+## Контур доставки runner-образа
+- **Локальная сборка**: `make runner-image` использует BuildKit (`docker buildx build --load`) и
+  запускает smoke-последовательность внутри только что собранного контейнера. Внутри
+  контейнера выполняются `poetry check`, установка dev-зависимостей (`poetry install --with dev --no-root`),
+  `PYTHONPATH=. poetry run pytest -q`, а также диагностика Camoufox (`python -m camoufox path` и
+  `python -m camoufox version`). Это гарантирует, что production-образ совместим с тестами без
+  необходимости держать виртуальное окружение на хосте.
+- **CI/CD**: workflow `.github/workflows/runner-image.yml` повторно использует make-таргет на GitHub Actions,
+  публикует артефакт в `ghcr.io/<org>/runner:<tag>` и подписывает образ через cosign (keyless, `COSIGN_EXPERIMENTAL=1`).
+  Пайплайн требует `packages:write` и `id-token:write`, чтобы операторы могли тянуть подписанный production-ready билд
+  без ручной сборки.

--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -58,6 +58,11 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
   для документирования и сериализации warm-пула.
 
 ## Decisions
+- **Container delivery pipeline**: Runner образ собирается через `make runner-image`, который использует BuildKit
+  и прогоняет `poetry check`, `poetry install --with dev --no-root`, `PYTHONPATH=. poetry run pytest -q`,
+  а также `python -m camoufox path` и `python -m camoufox version` внутри контейнера. GitHub Actions workflow
+  `runner-image.yml` вызывает тот же таргет, пушит образ в GHCR и подписывает его `cosign` (keyless,
+  `COSIGN_EXPERIMENTAL=1`).
 - **In-memory publisher**: Стандартный транспорт построен на `InMemorySessionEventPublisher` и считается продукционным решением; при необходимости можно оборачивать его через `CallbackSessionEventPublisher` для сторонних интеграций без отказа от in-memory ядра.
 - **HTTP publisher toggle**: `get_event_publisher` читает `RunnerSettings.event_endpoint` и, если URL задан, использует `HttpSessionEventPublisher`, публикующий события в Gateway через `POST /events`.
 - **Workstation events**: `WarmPoolManager` публикует `workstation.state_changed|recycled|error` при любых переходах слота; маршруты `/workstations` только вызывают методы менеджера.
@@ -118,6 +123,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - `poetry install --no-root`
 - `PYTHONPATH=. poetry run pytest -q` (anyio-powered unit tests)
 - `poetry run ruff check .`
+- `make runner-image` — соберёт контейнер, выполнит `poetry check`, `poetry install --with dev --no-root`, `PYTHONPATH=. poetry run pytest -q`, `python -m camoufox path` и `python -m camoufox version` внутри образа.
 - Таргетно: `PYTHONPATH=. poetry run pytest services/runner/tests/test_config_warm_pool.py -q`
 - Таргетно: `PYTHONPATH=. poetry run pytest services/runner/tests/test_warm_pool.py -q`
 - Таргетно: `PYTHONPATH=. poetry run pytest services/runner/tests/test_workstations_api.py -q`
@@ -148,3 +154,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-24 · gpt-5-codex · Добавлен стресс-тест in-memory издателя (10k событий) и задокументированы пороги publish/drain.
 - 2025-10-25 · gpt-5-codex · Dockerfile переключён на production `camoufox[geoip]==0.4.11` с прогревом артефактов на сборке,
   добавлены BuildKit-кеши, расширен `.dockerignore`, README-TASK дополнен инструкциями по сборке/запуску.
+- 2025-10-27 · gpt-5-codex · Добавлен make-таргет/CI-контур для сборки runner-образа с контейнерными тестами и подписями cosign.


### PR DESCRIPTION
## Summary
- add make targets to build, verify, and publish the runner container image with optional cosign signing
- wire up a GitHub Actions workflow that reuses the make target, pushes to GHCR, and signs the image for operators
- document the container delivery flow and update runner AGENT_NOTES with the new checks

## Testing
- `poetry check` (warnings about legacy `[tool.poetry]` fields)

## Security
- runner image is signed via cosign in CI; requires `packages:write` and `id-token:write` permissions

------
https://chatgpt.com/codex/tasks/task_e_68debcb06714832ab2e4125f6fb40448