### PR TITLE
Add gateway container image build and CI pipeline

### DIFF
--- a/.github/workflows/gateway-image.yml
+++ b/.github/workflows/gateway-image.yml
@@ -1,0 +1,57 @@
+name: build-gateway-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      gateway_tag:
+        description: "Tag gateway-образа (пример: dev)"
+        required: true
+      sign_image:
+        description: "Подписывать образ (true/false)"
+        required: false
+        default: "true"
+  push:
+    paths:
+      - "services/gateway/Dockerfile"
+      - "services/gateway/pyproject.toml"
+      - "services/gateway/**/*.py"
+      - "services/gateway/**/py.typed"
+      - "services/gateway/tests/**"
+      - "packages/core/**"
+      - "Makefile"
+      - ".github/workflows/gateway-image.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ toLower(github.repository_owner) }}/gateway
+      IMAGE_TAG: ${{ inputs.gateway_tag || github.sha }}
+      SIGN_IMAGE: ${{ inputs.sign_image || 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Compose image reference
+        run: echo "IMAGE_REF=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_ENV"
+      - name: Build gateway image
+        env:
+          GATEWAY_IMAGE: ${{ env.IMAGE_REF }}
+        run: make gateway-image GATEWAY_IMAGE="${GATEWAY_IMAGE}"
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push gateway image
+        run: docker push "${IMAGE_REF}"
+      - uses: sigstore/cosign-installer@v3.6.0
+        if: env.SIGN_IMAGE == 'true'
+      - name: Sign gateway image
+        if: env.SIGN_IMAGE == 'true'
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: cosign sign --yes "${IMAGE_REF}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap check runner-image runner-image-publish
+.PHONY: bootstrap check runner-image runner-image-publish gateway-image gateway-image-publish
 
 RUNNER_IMAGE ?= ghost-runner:local
 RUNNER_DOCKERFILE ?= services/runner/Dockerfile
@@ -9,6 +9,14 @@ RUNNER_BUILD_ARGS := $(if $(RUNNER_CAMOUFOX_VERSION),--build-arg CAMOUFOX_VERSIO
 RUNNER_TEST_CMD := set -euo pipefail; poetry check; poetry install --with dev --no-root --no-interaction; PYTHONPATH=. poetry run pytest -q; poetry run python -m camoufox path; poetry run python -m camoufox version
 RUNNER_SIGN ?= false
 RUNNER_COSIGN_ARGS ?= --yes
+
+GATEWAY_IMAGE ?= ghost-gateway:local
+GATEWAY_DOCKERFILE ?= services/gateway/Dockerfile
+GATEWAY_CONTEXT ?= .
+GATEWAY_EXTRA_BUILD_ARGS ?=
+GATEWAY_BUILD_ARGS := $(GATEWAY_EXTRA_BUILD_ARGS)
+GATEWAY_SIGN ?= false
+GATEWAY_COSIGN_ARGS ?= --yes
 
 bootstrap:
 	pnpm install
@@ -32,4 +40,13 @@ runner-image-publish: runner-image
 	docker push $(RUNNER_IMAGE)
 	@if [ "$(RUNNER_SIGN)" = "true" ]; then \
 	cosign sign $(RUNNER_COSIGN_ARGS) $(RUNNER_IMAGE); \
+	fi
+
+gateway-image:
+	docker buildx build --load -f $(GATEWAY_DOCKERFILE) -t $(GATEWAY_IMAGE) $(GATEWAY_BUILD_ARGS) $(GATEWAY_CONTEXT)
+
+gateway-image-publish: gateway-image
+	docker push $(GATEWAY_IMAGE)
+	@if [ "$(GATEWAY_SIGN)" = "true" ]; then \
+	cosign sign $(GATEWAY_COSIGN_ARGS) $(GATEWAY_IMAGE); \
 	fi

--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -32,6 +32,10 @@
   заголовок `GATEWAY_TRUSTED_HEADER` с оригинальным клиентским IP. Совпадение выдаёт синтетического пользователя
   `internal:<ip>` и логирует стратегию `auth_strategy=internal-bypass`.
 - Аутентификация: Bearer JWT (Keycloak). Для WebSocket токен передаётся в заголовке `Authorization: Bearer` или параметре `token`.
+- Контейнерный образ: `services/gateway/Dockerfile` на базе `python:3.12-slim` ставит прод-зависимости через
+  `poetry install --without dev`, монтирует `packages/core` и запускает `uvicorn app.main:create_app`
+  (порт 8080). Собирается локально `make gateway-image`, публикуется через `make gateway-image-publish`
+  либо GitHub Actions workflow `build-gateway-image` (GHCR `ghcr.io/<owner>/gateway:<tag>` с опциональной подписью Cosign).
 
 ## Data & Models
 - Переиспользуются модели из `packages/core`: `Session`, `SessionEvent`, `Runner`, `SessionProxySettings`, `SessionVncDetails` и др.
@@ -64,6 +68,10 @@
 - Тесты аутентификатора Keycloak используют `httpx.MockTransport`, чтобы прогонять полный цикл `_fetch_jwks` без прямых правок кэша
   и проверять повторные запросы при смене `kid`, HTTP-ошибки и сбои декодирования JSON.
 - Lifespan-хук после discovery обходит только здоровых раннеров, вызывает `GET /sessions` через `RunnerCommandClient.list_sessions` и восстанавливает `SessionRegistry` вместе с веб-сокетными биндингами `RunnerRegistry`. Поток проверен тестом `test_lifespan_restores_sessions_from_healthy_runners`.
+- Контейнер формируется на базе `python:3.12-slim`: добавлены системные пакеты (`build-essential`, `python3-dev`, `libffi-dev`),
+  чтобы собрать `uvicorn[standard]` зависимости, и Poetry 1.8.3 создает локальное venv. Entry-point использует
+  `uvicorn app.main:create_app`, чтобы запускать приложение через фабрику и корректно применять конфигурацию.
+  Публикация в GHCR сопровождается опциональной подписью Cosign (переключается флагом `sign_image`).
 
 ## Constraints & Invariants
 - `VNC_TOKEN_TTL_SEC` всегда ≤300; нарушение приводит к `ValueError` на старте.
@@ -119,4 +127,6 @@
 - 2025-10-16 · gpt-5-codex · Уточнена документация зависимостей безопасности и обработка пустых env-карт для доверенных CIDR.
 - 2025-10-17 · gpt-5-codex · Добавлены registry/роуты для рабочих станций, модели `WorkstationRecord`/`WorkstationUpsertPayload` и unit-тесты API контрактов.
 - 2025-10-18 · gpt-5-codex · Восстановление сессий при рестарте через `GET /sessions`, расширенный RunnerCommandClient и новые unit-тесты bootstrap.
+- 2025-10-19 · gpt-5-codex · Добавлены контейнерный образ Gateway, make-таргеты для сборки/публикации и GitHub Actions пайплайн
+  с опциональной подписью Cosign.
 

--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -1,0 +1,45 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    POETRY_VERSION=1.8.3 \
+    POETRY_HOME=/opt/poetry \
+    POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_IN_PROJECT=1 \
+    POETRY_VIRTUALENVS_CREATE=1 \
+    PATH="${POETRY_HOME}/bin:${PATH}"
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential python3-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install "poetry==${POETRY_VERSION}"
+
+RUN addgroup --system app \
+    && adduser --system --ingroup app app
+
+WORKDIR /workspace
+
+# Copy dependency descriptors and shared packages first for better cache reuse.
+COPY services/gateway/pyproject.toml ./services/gateway/pyproject.toml
+COPY packages ./packages
+
+RUN chown -R app:app /workspace
+
+USER app
+WORKDIR /workspace/services/gateway
+
+RUN --mount=type=cache,target=/home/app/.cache/pypoetry \
+    --mount=type=cache,target=/home/app/.cache/pip \
+    poetry install --without dev
+
+# Copy application sources after dependency resolution to maximize cache hits.
+COPY --chown=app:app services/gateway ./
+
+ENV PATH="/workspace/services/gateway/.venv/bin:${PATH}"
+
+EXPOSE 8080
+CMD ["uvicorn", "app.main:create_app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -42,3 +42,16 @@ poetry run pytest -q
 ```
 
 Use `poetry run ruff check .` for linting the service codebase.
+
+## Container image
+
+- Dockerfile: `services/gateway/Dockerfile` builds on top of `python:3.12-slim`,
+  installs production dependencies via `poetry install --without dev`, and
+  starts the service with `uvicorn app.main:create_app` bound to port `8080`.
+- Local build: `make gateway-image` produces a `ghost-gateway:local` image
+  using Docker BuildKit; use `GATEWAY_IMAGE=<ref>` to override the tag.
+- Publishing: `make gateway-image-publish GATEWAY_IMAGE=<registry/repo:tag>`
+  pushes the artefact and optionally signs it when `GATEWAY_SIGN=true`.
+- CI/CD: `.github/workflows/gateway-image.yml` builds and pushes
+  `ghcr.io/<owner>/gateway:<tag>` on relevant changes or manual dispatch, with
+  opt-in Cosign signing controlled by the `sign_image` input (default `true`).


### PR DESCRIPTION
## Summary
- add a Python slim-based Dockerfile for the gateway service that installs production dependencies with Poetry and launches `uvicorn app.main:create_app`
- extend the Makefile with gateway image build/publish targets including optional Cosign signing
- create a GitHub Actions workflow to build and push the gateway image to GHCR and document the container artifact in the gateway docs/notes

## Testing
- `poetry run pytest -q`

## Security
- container image runs on the slim Python base with only the build tools required for `uvicorn[standard]`; Cosign signing remains optional but available via CI and make targets


------
https://chatgpt.com/codex/tasks/task_e_68df31add354832aa87b385868be1acd