### PR TITLE
Add VNC gateway container image tooling

### DIFF
--- a/.github/workflows/vnc-gateway-image.yml
+++ b/.github/workflows/vnc-gateway-image.yml
@@ -1,0 +1,46 @@
+name: build-vnc-gateway-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Tag VNC Gateway image (e.g. dev)"
+        required: true
+  push:
+    paths:
+      - "services/vnc-gateway/Dockerfile"
+      - "services/vnc-gateway/pyproject.toml"
+      - "services/vnc-gateway/app/**"
+      - "services/vnc-gateway/tests/**"
+      - "services/vnc-gateway/AGENT_NOTES.md"
+      - "Makefile"
+      - "docs/configuration.md"
+      - ".github/workflows/vnc-gateway-image.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ toLower(github.repository_owner) }}/vnc-gateway
+      IMAGE_TAG: ${{ inputs.image_tag || github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Compose image reference
+        run: echo "IMAGE_REF=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_ENV"
+      - name: Build image & run smoke checks
+        env:
+          VNC_GATEWAY_IMAGE: ${{ env.IMAGE_REF }}
+        run: |
+          set -euo pipefail
+          make vnc-gateway-image VNC_GATEWAY_IMAGE="${VNC_GATEWAY_IMAGE}"
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push VNC Gateway image
+        run: docker push "${IMAGE_REF}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap check runner-image runner-image-publish
+.PHONY: bootstrap check runner-image runner-image-publish vnc-gateway-image vnc-gateway-image-publish
 
 RUNNER_IMAGE ?= ghost-runner:local
 RUNNER_DOCKERFILE ?= services/runner/Dockerfile
@@ -9,6 +9,16 @@ RUNNER_BUILD_ARGS := $(if $(RUNNER_CAMOUFOX_VERSION),--build-arg CAMOUFOX_VERSIO
 RUNNER_TEST_CMD := set -euo pipefail; poetry check; poetry install --with dev --no-root --no-interaction; PYTHONPATH=. poetry run pytest -q; poetry run python -m camoufox path; poetry run python -m camoufox version
 RUNNER_SIGN ?= false
 RUNNER_COSIGN_ARGS ?= --yes
+
+VNC_GATEWAY_IMAGE ?= ghost-vnc-gateway:local
+VNC_GATEWAY_DOCKERFILE ?= services/vnc-gateway/Dockerfile
+VNC_GATEWAY_CONTEXT ?= .
+VNC_GATEWAY_EXTRA_BUILD_ARGS ?=
+VNC_GATEWAY_BUILD_ARGS := $(VNC_GATEWAY_EXTRA_BUILD_ARGS)
+VNC_GATEWAY_SMOKE_CMD := set -euo pipefail; \
+	python -m pip install --no-cache-dir pytest ruff; \
+	ruff check app tests; \
+	pytest -q tests
 
 bootstrap:
 	pnpm install
@@ -33,3 +43,10 @@ runner-image-publish: runner-image
 	@if [ "$(RUNNER_SIGN)" = "true" ]; then \
 	cosign sign $(RUNNER_COSIGN_ARGS) $(RUNNER_IMAGE); \
 	fi
+
+vnc-gateway-image:
+	docker buildx build --load -f $(VNC_GATEWAY_DOCKERFILE) -t $(VNC_GATEWAY_IMAGE) $(VNC_GATEWAY_BUILD_ARGS) $(VNC_GATEWAY_CONTEXT)
+	docker run --rm --entrypoint bash -w /opt/app $(VNC_GATEWAY_IMAGE) -lc "$(VNC_GATEWAY_SMOKE_CMD)"
+
+vnc-gateway-image-publish: vnc-gateway-image
+	docker push $(VNC_GATEWAY_IMAGE)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,19 @@
 - `VITE_GATEWAY_URL` — базовый URL Gateway для REST/SSE (включая `POST /sessions`)
 
 ## VNC Gateway
-- `GATEWAY_URL` — базовый URL для валидации токенов
-- `CONNECT_TIMEOUT_MS`
+- `VNC_GATEWAY_RUNNER_HTTP_BASE` — базовый URL HTTP API Runner (по умолчанию
+  `http://runner:8080`). Используется для проксирования REST-запросов.
+- `VNC_GATEWAY_RUNNER_WS_BASE` — WebSocket-база Runner (по умолчанию
+  `ws://runner:8080`) для проброса VNC-трафика.
+- `VNC_GATEWAY_TOKEN_SECRET` — общий секрет для подписи и проверки VNC-токенов;
+  пустые значения запрещены.
+- `VNC_GATEWAY_METRICS_BACKEND` — `prometheus` (по умолчанию) либо `otlp`.
+- `VNC_GATEWAY_METRICS_REGISTRY_IMPORT` — (опционально) `module:attr` с
+  `CollectorRegistry`, если нужно подключить внешний реестр при
+  `prometheus`-бэкенде.
+- `VNC_GATEWAY_METRICS_OTLP_EXPORTER_IMPORT` — (опционально) `module:attr`
+  экспортёра, реализующего `MetricsEventExporter`, для варианта `otlp`.
+- Контейнерный образ слушает `0.0.0.0:8080` и запускает `uvicorn
+  camou_vnc_gateway.main:app`.
 
 > Секреты не хранятся в VCS. Используйте `.env` локально и Secret в k3s.

--- a/services/vnc-gateway/AGENT_NOTES.md
+++ b/services/vnc-gateway/AGENT_NOTES.md
@@ -21,6 +21,11 @@ FastAPI service that validates short-lived VNC access tokens and proxies HTTP/WS
 - Runner proxy keeps a singleton `httpx.AsyncClient` and resolves `target_port` from query/referer/cookie (persisting it via `vnc-target-port` cookie) to build Runner URLs with configurable prefixes; WebSocket relay теперь ждёт оба направления через `TaskGroup`, отдаёт 1008 при невалидном `target_port` и 1011 при timeouts/сетевых ошибках.
 - Prometheus экспозиция реализована через `/metrics`, чтобы scrape-еры (Prometheus, VictoriaMetrics и т.д.) могли использовать стандартный текстовый формат без дополнительных middleware.
 
+## Decisions
+- Контейнеризация: образ собирается на базе `python:3.12-slim`, зависимости ставятся через `poetry install --without dev --no-root`,
+  smoke-проверка выполняется `make vnc-gateway-image` (установка `pytest`/`ruff` внутри контейнера). В финальный образ включены `tests/`,
+  чтобы smoke-команды можно было запускать без дополнительных volume.
+
 ## Constraints & Invariants
 - Tokens must include the matching session identifier; mismatches immediately rejected.
 - `iat` допускает максимум `clock_skew_tolerance_seconds` (10 секунд) относительно сервера; reuse токена до истечения TTL запрещён.
@@ -45,3 +50,4 @@ poetry run pytest -q
 
 - 2025-10-09 · gpt-5-codex · Переписан WS-прокси на uvicorn/websockets `TaskGroup`-relay, добавлены интеграционные тесты с real сервером, внедрён Prometheus `/metrics` (active/total connections, token failures), расширен `TokenValidator` (nonce/iat cache) и документирован сценарий предотвращения replay.
 - 2025-10-10 · gpt-5-codex · Добавлена конфигурация метрик через настройки (Prometheus registry/OTLP exporter), обновлён `/metrics` endpoint и покрытие тестами.
+- 2025-10-11 · gpt-5-codex · Добавлены Dockerfile, make-таргеты и GitHub Actions workflow для сборки/публикации образа VNC Gateway; документация обновлена переменными окружения.

--- a/services/vnc-gateway/Dockerfile
+++ b/services/vnc-gateway/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.6
+FROM python:3.12-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    POETRY_VERSION=1.8.3 \
+    POETRY_HOME=/opt/poetry \
+    POETRY_NO_INTERACTION=1 \
+    POETRY_VIRTUALENVS_CREATE=0 \
+    PATH="${POETRY_HOME}/bin:${PATH}"
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends build-essential python3-dev libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install "poetry==${POETRY_VERSION}"
+
+WORKDIR /opt/app
+
+# Copy dependency descriptors first to leverage Docker layer caching.
+COPY services/vnc-gateway/pyproject.toml ./pyproject.toml
+
+RUN poetry install --without dev --no-root --no-interaction
+
+# Application sources and tests are copied afterwards to avoid busting the dependency cache.
+COPY services/vnc-gateway/app ./app
+COPY services/vnc-gateway/tests ./tests
+
+ENV PYTHONPATH=/opt/app/app
+
+EXPOSE 8080
+
+CMD ["uvicorn", "camou_vnc_gateway.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
Summary
- add a production Dockerfile for the VNC gateway and document the image environment knobs
- add make targets and a CI workflow to build, smoke-test, and publish the VNC gateway image
- record the containerization decision in the VNC gateway agent notes

Testing
- poetry run ruff check . (services/vnc-gateway) – All checks passed
- poetry run pytest -q (services/vnc-gateway) – 26 passed, 12 warnings (FastAPI on_event deprecation)

Security
- No new secrets added or modified.

------
https://chatgpt.com/codex/tasks/task_e_68df31ce4e00832a8907a5051e2a108b