### PR TITLE
Add VNC gateway Docker image build and GHCR workflow

### DIFF
--- a/.github/workflows/vnc-gateway-image.yml
+++ b/.github/workflows/vnc-gateway-image.yml
@@ -1,0 +1,56 @@
+name: build-vnc-gateway-image
+
+on:
+  workflow_dispatch:
+    inputs:
+      vnc_gateway_tag:
+        description: "Tag VNC Gateway-образа (пример: dev)"
+        required: true
+      sign_image:
+        description: "Подписывать образ (true/false)"
+        required: false
+        default: "true"
+  push:
+    paths:
+      - "services/vnc-gateway/Dockerfile"
+      - "services/vnc-gateway/pyproject.toml"
+      - "services/vnc-gateway/app/**"
+      - "services/vnc-gateway/tests/**"
+      - "services/vnc-gateway/AGENT_NOTES.md"
+      - "Makefile"
+      - ".github/workflows/vnc-gateway-image.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ toLower(github.repository_owner) }}/vnc-gateway
+      IMAGE_TAG: ${{ inputs.vnc_gateway_tag || github.sha }}
+      SIGN_IMAGE: ${{ inputs.sign_image || 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Compose image reference
+        run: echo "IMAGE_REF=${IMAGE_NAME}:${IMAGE_TAG}" >> "$GITHUB_ENV"
+      - name: Build image & run smoke checks
+        env:
+          VNC_GATEWAY_IMAGE: ${{ env.IMAGE_REF }}
+        run: make vnc-gateway-image VNC_GATEWAY_IMAGE="${VNC_GATEWAY_IMAGE}"
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push image
+        run: docker push "${IMAGE_REF}"
+      - uses: sigstore/cosign-installer@v3.6.0
+        if: env.SIGN_IMAGE == 'true'
+      - name: Sign image
+        if: env.SIGN_IMAGE == 'true'
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: cosign sign --yes "${IMAGE_REF}"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bootstrap check runner-image runner-image-publish gateway-image gateway-image-publish
+.PHONY: bootstrap check runner-image runner-image-publish gateway-image gateway-image-publish vnc-gateway-image vnc-gateway-image-publish
 
 RUNNER_IMAGE ?= ghost-runner:local
 RUNNER_DOCKERFILE ?= services/runner/Dockerfile
@@ -18,11 +18,20 @@ GATEWAY_BUILD_ARGS := $(GATEWAY_EXTRA_BUILD_ARGS)
 GATEWAY_SIGN ?= false
 GATEWAY_COSIGN_ARGS ?= --yes
 
+VNC_GATEWAY_IMAGE ?= ghost-vnc-gateway:local
+VNC_GATEWAY_DOCKERFILE ?= services/vnc-gateway/Dockerfile
+VNC_GATEWAY_CONTEXT ?= .
+VNC_GATEWAY_EXTRA_BUILD_ARGS ?=
+VNC_GATEWAY_BUILD_ARGS := $(VNC_GATEWAY_EXTRA_BUILD_ARGS)
+VNC_GATEWAY_SIGN ?= false
+VNC_GATEWAY_COSIGN_ARGS ?= --yes
+VNC_GATEWAY_SMOKE_CMD := poetry install --with dev --no-root --no-interaction && poetry run ruff check . && poetry run pytest -q
+
 bootstrap:
-	pnpm install
-	cd services/gateway && poetry install --no-root
-	cd services/runner && poetry install --no-root
-	cd services/vnc-gateway && poetry install --no-root
+        pnpm install
+        cd services/gateway && poetry install --no-root
+        cd services/runner && poetry install --no-root
+        cd services/vnc-gateway && poetry install --no-root
 	cd packages/core && poetry install --no-root
 
 check:
@@ -46,7 +55,17 @@ gateway-image:
 	docker buildx build --load -f $(GATEWAY_DOCKERFILE) -t $(GATEWAY_IMAGE) $(GATEWAY_BUILD_ARGS) $(GATEWAY_CONTEXT)
 
 gateway-image-publish: gateway-image
-	docker push $(GATEWAY_IMAGE)
-	@if [ "$(GATEWAY_SIGN)" = "true" ]; then \
-	cosign sign $(GATEWAY_COSIGN_ARGS) $(GATEWAY_IMAGE); \
-	fi
+        docker push $(GATEWAY_IMAGE)
+        @if [ "$(GATEWAY_SIGN)" = "true" ]; then \
+        cosign sign $(GATEWAY_COSIGN_ARGS) $(GATEWAY_IMAGE); \
+        fi
+
+vnc-gateway-image:
+        cd services/vnc-gateway && $(VNC_GATEWAY_SMOKE_CMD)
+        docker buildx build --load -f $(VNC_GATEWAY_DOCKERFILE) -t $(VNC_GATEWAY_IMAGE) $(VNC_GATEWAY_BUILD_ARGS) $(VNC_GATEWAY_CONTEXT)
+
+vnc-gateway-image-publish: vnc-gateway-image
+        docker push $(VNC_GATEWAY_IMAGE)
+        @if [ "$(VNC_GATEWAY_SIGN)" = "true" ]; then \
+        cosign sign $(VNC_GATEWAY_COSIGN_ARGS) $(VNC_GATEWAY_IMAGE); \
+        fi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,7 +27,18 @@
 - `VITE_GATEWAY_URL` — базовый URL Gateway для REST/SSE (включая `POST /sessions`)
 
 ## VNC Gateway
-- `GATEWAY_URL` — базовый URL для валидации токенов
-- `CONNECT_TIMEOUT_MS`
+- `VNC_GATEWAY_RUNNER_HTTP_BASE` — базовый HTTP URL Runner'а, к которому
+  проксируются REST-запросы (по умолчанию `http://runner:8080`).
+- `VNC_GATEWAY_RUNNER_WS_BASE` — базовый WebSocket URL Runner'а для прокси
+  VNC-туннелей (по умолчанию `ws://runner:8080`).
+- `VNC_GATEWAY_TOKEN_SECRET` — общий секрет для проверки HMAC-токенов, который
+  Gateway использует совместно с VNC Gateway (по умолчанию `dev-secret`).
+- `VNC_GATEWAY_METRICS_BACKEND` — `prometheus` (значение по умолчанию) или
+  `otlp`; определяет куда отправляются метрики соединений.
+- `VNC_GATEWAY_METRICS_REGISTRY_IMPORT` — `module:attribute` с существующим
+  `CollectorRegistry`, если Prometheus-метрики нужно собирать в общую
+  регистрацию.
+- `VNC_GATEWAY_METRICS_OTLP_EXPORTER_IMPORT` — `module:attribute`, возвращающий
+  OTLP-экспортёр, когда `VNC_GATEWAY_METRICS_BACKEND=otlp`.
 
 > Секреты не хранятся в VCS. Используйте `.env` локально и Secret в k3s.

--- a/services/vnc-gateway/AGENT_NOTES.md
+++ b/services/vnc-gateway/AGENT_NOTES.md
@@ -21,6 +21,9 @@ FastAPI service that validates short-lived VNC access tokens and proxies HTTP/WS
 - Runner proxy keeps a singleton `httpx.AsyncClient` and resolves `target_port` from query/referer/cookie (persisting it via `vnc-target-port` cookie) to build Runner URLs with configurable prefixes; WebSocket relay теперь ждёт оба направления через `TaskGroup`, отдаёт 1008 при невалидном `target_port` и 1011 при timeouts/сетевых ошибках.
 - Prometheus экспозиция реализована через `/metrics`, чтобы scrape-еры (Prometheus, VictoriaMetrics и т.д.) могли использовать стандартный текстовый формат без дополнительных middleware.
 
+## Decisions
+- 2025-02-14 · Runtime-образ собирается через builder-стейдж, который упаковывает сервис в wheel. Финальный слой устанавливает wheel и копирует исходники `app/`, поэтому рантайм остаётся лёгким, но при необходимости сохраняется возможность отладки по исходникам. Перед сборкой образа make-таргет `vnc-gateway-image` выполняет smoke-проверки (`ruff`, `pytest`), чтобы pipeline не публиковал образ с регрессиями.
+
 ## Constraints & Invariants
 - Tokens must include the matching session identifier; mismatches immediately rejected.
 - `iat` допускает максимум `clock_skew_tolerance_seconds` (10 секунд) относительно сервера; reuse токена до истечения TTL запрещён.
@@ -38,10 +41,14 @@ FastAPI service that validates short-lived VNC access tokens and proxies HTTP/WS
 ## How to Test
 ```bash
 cd services/vnc-gateway
-poetry install --no-root
+poetry install --with dev --no-root
 poetry run ruff check .
 poetry run pytest -q
 ```
 
+## Changelog (for agents)
+Дата · Кем/чем изменено · Коротко *что и почему*.
+
 - 2025-10-09 · gpt-5-codex · Переписан WS-прокси на uvicorn/websockets `TaskGroup`-relay, добавлены интеграционные тесты с real сервером, внедрён Prometheus `/metrics` (active/total connections, token failures), расширен `TokenValidator` (nonce/iat cache) и документирован сценарий предотвращения replay.
 - 2025-10-10 · gpt-5-codex · Добавлена конфигурация метрик через настройки (Prometheus registry/OTLP exporter), обновлён `/metrics` endpoint и покрытие тестами.
+- 2025-02-14 · gpt-5-codex · Добавлен Dockerfile с многоступенчатой сборкой, make/CI-таргеты для образа и документация по переменным окружения VNC Gateway.

--- a/services/vnc-gateway/Dockerfile
+++ b/services/vnc-gateway/Dockerfile
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1.7
+
+FROM python:3.12-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /workspace
+
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY services/vnc-gateway/pyproject.toml ./pyproject.toml
+COPY services/vnc-gateway/app ./app
+
+RUN pip install --upgrade pip wheel setuptools \
+    && pip wheel --no-cache-dir --no-deps --wheel-dir /wheels .
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PYTHONPATH=/workspace/app
+
+WORKDIR /workspace
+
+COPY --from=builder /wheels /wheels
+RUN pip install --no-cache-dir /wheels/* \
+    && rm -rf /wheels
+
+COPY services/vnc-gateway/app /workspace/app
+
+EXPOSE 8000
+
+CMD ["uvicorn", "camou_vnc_gateway.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and Makefile targets for building and testing the VNC gateway image
- document the VNC gateway runtime configuration variables and capture the containerisation decision in agent notes
- add a GitHub Actions workflow to build, smoke-test, publish, and optionally sign the VNC gateway image in GHCR

## Testing
- `cd services/vnc-gateway && poetry run ruff check .`
- `cd services/vnc-gateway && poetry run pytest -q`

## Security
- No new security issues identified.


------
https://chatgpt.com/codex/tasks/task_e_68df35fc4a30832ab188fe40d001a446