### PR TITLE
Add platform Helm chart and deployment docs

### DIFF
--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -30,6 +30,7 @@
 - Worker статус-панель повторно использует те же данные `/runners`, что и composer, для единого источника правды.
 - Состояние `SessionComposerValues` хранит дополнительные поля (`headless`, `idleTtlSeconds`, `startUrl*`, `proxy*`), чтобы API-адаптер мог формировать полный payload Runner даже до появления соответствующего UI.
 - Продакшн-сборка распространяется как статический бандл Vite внутри `nginx:alpine`; Dockerfile принимает build-arg `VITE_GATEWAY_URL` и вызывается через `make ui-image`.
+- Helm chart `docs/helm/platform` описывает деплой UI (Deployment/Service/Ingress) и позволяет прокидывать Keycloak секреты через `secretEnv` при запуске контейнера.
 
 ## Constraints & Invariants
 - Все сетевые вызовы через `ApiClient` (`fetch` + Zod валидация).
@@ -64,6 +65,7 @@
 - 2025-10-20 · gpt-5-codex · Добавлена форма редактирования прокси сессии, клиент `updateSessionProxy`, локальная валидация и RTL-тесты кеширования.
 - 2025-10-21 · gpt-5-codex · Расширены `SessionComposerValues` и дефолтные значения для поддержки адаптера создания сессии и строгих правил ESLint.
 - 2025-10-02 · gpt-5-codex · Добавлен стор для отслеживания SSE, обработка превышения ретраев и баннер повторного подключения.
+- 2025-10-03 · gpt-5-codex · Добавлены Helm-шаблоны/values для UI и документация по установке с секретами Keycloak.
 - 2025-10-15 · gpt-5-codex · Синхронизировали модель `SessionComposerValues` с адаптером создания сессий, устранив lint-ошибки по небезопасным полям.
 - 2025-10-15 · gpt-5-codex · Уточнены моки React Query/API в тестах DashboardPage для строгой типизации ESLint; адаптер
   `buildSessionCreatePayload` теперь использует явный тип `SessionComposerSubmission`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,3 +42,56 @@
   OTLP-экспортёр, когда `VNC_GATEWAY_METRICS_BACKEND=otlp`.
 
 > Секреты не хранятся в VCS. Используйте `.env` локально и Secret в k3s.
+
+## Helm deployment
+
+Набор чарта для control-plane компонентов расположен в `docs/helm/platform`. Он
+собирает Deployments/Services/Ingress для `gateway`, `runner`, `vnc-gateway`,
+`ui` и `camoufox-worker`, поддерживает передачу переменных окружения и Secret-
+значений (например, `VNC_TOKEN_SECRET`, Keycloak client secret, токены Camoufox).
+
+1. Подготовьте namespace и базовые Secret'ы:
+
+   ```bash
+   kubectl create namespace ghost
+   kubectl create secret generic gateway-keycloak \
+     --namespace ghost \
+     --from-literal=clientSecret=... && \
+   kubectl create secret generic gateway-vnc \
+     --namespace ghost \
+     --from-literal=token=...
+   ```
+
+   Аналогично создайте секреты для Runner (`camoufox-credentials`), UI
+   (`ui-keycloak`), camoufox-worker (`worker-gateway-token`) и т.д. либо
+   подключите существующие Secret'ы через `extraEnvFromSecrets`.
+
+2. Выберите значения для окружения. В каталоге `docs/helm/platform` приведены
+   примеры (`gateway.values.yaml`, `runner.values.yaml`, `vnc-gateway.values.yaml`,
+   `ui.values.yaml`, `camoufox-worker.values.yaml`). Их можно комбинировать или
+   использовать как шаблон для собственного файла.
+
+3. Установите релиз Helm, передав необходимые overrides:
+
+   ```bash
+   helm install ghost ./docs/helm/platform \
+     --namespace ghost --create-namespace \
+     -f docs/helm/platform/values.yaml \
+     -f docs/helm/platform/gateway.values.yaml \
+     -f docs/helm/platform/runner.values.yaml \
+     -f docs/helm/platform/vnc-gateway.values.yaml \
+     -f docs/helm/platform/ui.values.yaml \
+     -f docs/helm/platform/camoufox-worker.values.yaml
+   ```
+
+   Для обновления конфигурации используйте `helm upgrade ghost ./docs/helm/platform -f ...`.
+
+4. Проверяйте состояние релиза стандартными командами Helm/Kubernetes:
+
+   ```bash
+   helm status ghost -n ghost
+   kubectl get pods,svc,ingress -n ghost
+   ```
+
+> Чарт не создаёт Secret'ы автоматически — их нужно подготовить заранее или
+> подключить существующие через `secretEnv`/`extraEnvFromSecrets`.

--- a/docs/helm/platform/Chart.yaml
+++ b/docs/helm/platform/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: ghost-platform
+description: Helm chart for deploying the Ghost Browsers control plane components
+version: 0.1.0
+appVersion: "0.1.0"
+type: application

--- a/docs/helm/platform/camoufox-worker.values.yaml
+++ b/docs/helm/platform/camoufox-worker.values.yaml
@@ -1,0 +1,25 @@
+camoufoxWorker:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/acme/camoufox-worker
+    tag: v1.4.0
+  service:
+    type: ClusterIP
+    port: 8080
+  env:
+    WORKER_MODE: orchestrator
+    GATEWAY_URL: https://gateway.example.com
+    JOB_TIMEOUT_SEC: "120"
+  secretEnv:
+    - name: GATEWAY_TOKEN
+      secretName: worker-gateway-token
+      secretKey: token
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+  ingress:
+    enabled: false

--- a/docs/helm/platform/gateway.values.yaml
+++ b/docs/helm/platform/gateway.values.yaml
@@ -1,0 +1,43 @@
+gateway:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/acme/ghost-gateway
+    tag: v1.4.0
+  service:
+    type: ClusterIP
+    port: 8080
+  env:
+    KEYCLOAK_URL: https://id.example.com/realms/ghost
+    KEYCLOAK_REALM: ghost
+    KEYCLOAK_CLIENT_ID: ghost-gateway
+    DISCOVERY_MODE: k8s
+    JWT_JWKS_URL: https://id.example.com/realms/ghost/protocol/openid-connect/certs
+    GATEWAY_TRUSTED_CIDRS: 10.0.0.0/8,fd00::/64
+    GATEWAY_TRUSTED_HEADER: X-Forwarded-For
+    VNC_TOKEN_TTL_SEC: "300"
+  secretEnv:
+    - name: KEYCLOAK_CLIENT_SECRET
+      secretName: gateway-keycloak
+      secretKey: clientSecret
+    - name: VNC_TOKEN_SECRET
+      secretName: gateway-vnc
+      secretKey: token
+  resources:
+    requests:
+      cpu: 250m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: gateway.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - gateway.example.com
+        secretName: gateway-tls

--- a/docs/helm/platform/runner.values.yaml
+++ b/docs/helm/platform/runner.values.yaml
@@ -1,0 +1,31 @@
+runner:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/acme/ghost-runner
+    tag: v1.4.0
+  service:
+    type: ClusterIP
+    port: 8080
+  env:
+    RUNNER_ID: runner-a
+    SLOT_LIMIT: "4"
+    VNC_ENABLED: "true"
+    VNC_HTTP_BASE_URL: https://vnc.example.com
+    VNC_WS_BASE_URL: wss://vnc.example.com
+    VNC_TOKEN_TTL_SECONDS: "300"
+    WARM_POOL_MODE: hybrid
+    WARM_POOL_CONFIG_PATH: /config/warm-pool.json
+    CAMOUFOX_HEADLESS: virtual
+  secretEnv:
+    - name: CAMOUFOX_API_TOKEN
+      secretName: camoufox-credentials
+      secretKey: apiToken
+  extraEnvFromSecrets:
+    - runner-proxy-credentials
+  resources:
+    requests:
+      cpu: 1
+      memory: 2Gi
+    limits:
+      cpu: 2
+      memory: 4Gi

--- a/docs/helm/platform/templates/_helpers.tpl
+++ b/docs/helm/platform/templates/_helpers.tpl
@@ -1,0 +1,14 @@
+{{- define "ghost-platform.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "ghost-platform.componentName" -}}
+{{- $root := index . 0 -}}
+{{- $component := index . 1 -}}
+{{- printf "%s-%s" (include "ghost-platform.fullname" $root) $component | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/docs/helm/platform/templates/camoufox-worker-deployment.yaml
+++ b/docs/helm/platform/templates/camoufox-worker-deployment.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.camoufoxWorker.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "camoufox-worker") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: camoufox-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  replicas: {{ .Values.camoufoxWorker.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+      app.kubernetes.io/component: camoufox-worker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+        app.kubernetes.io/component: camoufox-worker
+{{- with .Values.camoufoxWorker.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.camoufoxWorker.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+        - name: {{ .name }}
+{{- end }}
+{{- end }}
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      containers:
+        - name: camoufox-worker
+          image: "{{ .Values.camoufoxWorker.image.repository }}:{{ .Values.camoufoxWorker.image.tag }}"
+          imagePullPolicy: {{ .Values.camoufoxWorker.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.camoufoxWorker.service.port }}
+              name: http
+{{- $hasEnv := or (gt (len .Values.camoufoxWorker.env) 0) (gt (len .Values.camoufoxWorker.secretEnv) 0) }}
+{{- if $hasEnv }}
+          env:
+{{- range $key, $value := .Values.camoufoxWorker.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range .Values.camoufoxWorker.secretEnv }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+{{- end }}
+{{- end }}
+{{- if .Values.camoufoxWorker.extraEnvFromSecrets }}
+          envFrom:
+{{- range .Values.camoufoxWorker.extraEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Values.camoufoxWorker.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/camoufox-worker-ingress.yaml
+++ b/docs/helm/platform/templates/camoufox-worker-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.camoufoxWorker.enabled .Values.camoufoxWorker.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "camoufox-worker") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: camoufox-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.camoufoxWorker.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.camoufoxWorker.ingress.className }}
+  ingressClassName: {{ . }}
+{{- end }}
+  rules:
+{{- range .Values.camoufoxWorker.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+{{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "ghost-platform.componentName" (list $ "camoufox-worker") }}
+                port:
+                  number: {{ $.Values.camoufoxWorker.service.port }}
+{{- end }}
+{{- end }}
+{{- with .Values.camoufoxWorker.ingress.tls }}
+  tls:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/camoufox-worker-service.yaml
+++ b/docs/helm/platform/templates/camoufox-worker-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.camoufoxWorker.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "camoufox-worker") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: camoufox-worker
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.camoufoxWorker.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: camoufox-worker
+  ports:
+    - name: http
+      port: {{ .Values.camoufoxWorker.service.port }}
+      targetPort: {{ .Values.camoufoxWorker.service.port }}
+{{- end }}

--- a/docs/helm/platform/templates/gateway-deployment.yaml
+++ b/docs/helm/platform/templates/gateway-deployment.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "gateway") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  replicas: {{ .Values.gateway.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+      app.kubernetes.io/component: gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+        app.kubernetes.io/component: gateway
+{{- with .Values.gateway.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.gateway.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+        - name: {{ .name }}
+{{- end }}
+{{- end }}
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      containers:
+        - name: gateway
+          image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
+          imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.gateway.service.port }}
+              name: http
+{{- $hasEnv := or (gt (len .Values.gateway.env) 0) (gt (len .Values.gateway.secretEnv) 0) }}
+{{- if $hasEnv }}
+          env:
+{{- range $key, $value := .Values.gateway.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range .Values.gateway.secretEnv }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+{{- end }}
+{{- end }}
+{{- if .Values.gateway.extraEnvFromSecrets }}
+          envFrom:
+{{- range .Values.gateway.extraEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Values.gateway.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/gateway-ingress.yaml
+++ b/docs/helm/platform/templates/gateway-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.gateway.enabled .Values.gateway.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "gateway") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.gateway.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.gateway.ingress.className }}
+  ingressClassName: {{ . }}
+{{- end }}
+  rules:
+{{- range .Values.gateway.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+{{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "ghost-platform.componentName" (list $ "gateway") }}
+                port:
+                  number: {{ $.Values.gateway.service.port }}
+{{- end }}
+{{- end }}
+{{- with .Values.gateway.ingress.tls }}
+  tls:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/gateway-service.yaml
+++ b/docs/helm/platform/templates/gateway-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.gateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "gateway") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.gateway.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: gateway
+  ports:
+    - name: http
+      port: {{ .Values.gateway.service.port }}
+      targetPort: {{ .Values.gateway.service.port }}
+{{- end }}

--- a/docs/helm/platform/templates/runner-deployment.yaml
+++ b/docs/helm/platform/templates/runner-deployment.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.runner.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "runner") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: runner
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  replicas: {{ .Values.runner.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+      app.kubernetes.io/component: runner
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+        app.kubernetes.io/component: runner
+{{- with .Values.runner.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.runner.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+        - name: {{ .name }}
+{{- end }}
+{{- end }}
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      containers:
+        - name: runner
+          image: "{{ .Values.runner.image.repository }}:{{ .Values.runner.image.tag }}"
+          imagePullPolicy: {{ .Values.runner.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.runner.service.port }}
+              name: http
+{{- $hasEnv := or (gt (len .Values.runner.env) 0) (gt (len .Values.runner.secretEnv) 0) }}
+{{- if $hasEnv }}
+          env:
+{{- range $key, $value := .Values.runner.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range .Values.runner.secretEnv }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+{{- end }}
+{{- end }}
+{{- if .Values.runner.extraEnvFromSecrets }}
+          envFrom:
+{{- range .Values.runner.extraEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Values.runner.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/runner-ingress.yaml
+++ b/docs/helm/platform/templates/runner-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.runner.enabled .Values.runner.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "runner") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: runner
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.runner.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.runner.ingress.className }}
+  ingressClassName: {{ . }}
+{{- end }}
+  rules:
+{{- range .Values.runner.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+{{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "ghost-platform.componentName" (list $ "runner") }}
+                port:
+                  number: {{ $.Values.runner.service.port }}
+{{- end }}
+{{- end }}
+{{- with .Values.runner.ingress.tls }}
+  tls:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/runner-service.yaml
+++ b/docs/helm/platform/templates/runner-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.runner.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "runner") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: runner
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.runner.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: runner
+  ports:
+    - name: http
+      port: {{ .Values.runner.service.port }}
+      targetPort: {{ .Values.runner.service.port }}
+{{- end }}

--- a/docs/helm/platform/templates/ui-deployment.yaml
+++ b/docs/helm/platform/templates/ui-deployment.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.ui.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "ui") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  replicas: {{ .Values.ui.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+      app.kubernetes.io/component: ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+        app.kubernetes.io/component: ui
+{{- with .Values.ui.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.ui.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+        - name: {{ .name }}
+{{- end }}
+{{- end }}
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      containers:
+        - name: ui
+          image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
+          imagePullPolicy: {{ .Values.ui.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.ui.service.port }}
+              name: http
+{{- $hasEnv := or (gt (len .Values.ui.env) 0) (gt (len .Values.ui.secretEnv) 0) }}
+{{- if $hasEnv }}
+          env:
+{{- range $key, $value := .Values.ui.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range .Values.ui.secretEnv }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+{{- end }}
+{{- end }}
+{{- if .Values.ui.extraEnvFromSecrets }}
+          envFrom:
+{{- range .Values.ui.extraEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Values.ui.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/ui-ingress.yaml
+++ b/docs/helm/platform/templates/ui-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.ui.enabled .Values.ui.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "ui") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.ui.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.ui.ingress.className }}
+  ingressClassName: {{ . }}
+{{- end }}
+  rules:
+{{- range .Values.ui.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+{{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "ghost-platform.componentName" (list $ "ui") }}
+                port:
+                  number: {{ $.Values.ui.service.port }}
+{{- end }}
+{{- end }}
+{{- with .Values.ui.ingress.tls }}
+  tls:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/ui-service.yaml
+++ b/docs/helm/platform/templates/ui-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.ui.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "ui") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: ui
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.ui.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: ui
+  ports:
+    - name: http
+      port: {{ .Values.ui.service.port }}
+      targetPort: {{ .Values.ui.service.port }}
+{{- end }}

--- a/docs/helm/platform/templates/vnc-gateway-deployment.yaml
+++ b/docs/helm/platform/templates/vnc-gateway-deployment.yaml
@@ -1,0 +1,85 @@
+{{- if .Values.vncGateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "vnc-gateway") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: vnc-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+spec:
+  replicas: {{ .Values.vncGateway.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+      app.kubernetes.io/component: vnc-gateway
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+        app.kubernetes.io/component: vnc-gateway
+{{- with .Values.vncGateway.podLabels }}
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.vncGateway.podAnnotations }}
+      annotations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- range .Values.imagePullSecrets }}
+        - name: {{ .name }}
+{{- end }}
+{{- end }}
+{{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+{{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+{{- end }}
+      containers:
+        - name: vnc-gateway
+          image: "{{ .Values.vncGateway.image.repository }}:{{ .Values.vncGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.vncGateway.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.vncGateway.service.port }}
+              name: http
+{{- $hasEnv := or (gt (len .Values.vncGateway.env) 0) (gt (len .Values.vncGateway.secretEnv) 0) }}
+{{- if $hasEnv }}
+          env:
+{{- range $key, $value := .Values.vncGateway.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+{{- end }}
+{{- range .Values.vncGateway.secretEnv }}
+            - name: {{ .name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .secretName }}
+                  key: {{ .secretKey }}
+{{- end }}
+{{- end }}
+{{- if .Values.vncGateway.extraEnvFromSecrets }}
+          envFrom:
+{{- range .Values.vncGateway.extraEnvFromSecrets }}
+            - secretRef:
+                name: {{ . }}
+{{- end }}
+{{- end }}
+{{- with .Values.vncGateway.resources }}
+          resources:
+{{ toYaml . | indent 12 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/vnc-gateway-ingress.yaml
+++ b/docs/helm/platform/templates/vnc-gateway-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.vncGateway.enabled .Values.vncGateway.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "vnc-gateway") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: vnc-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.vncGateway.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.vncGateway.ingress.className }}
+  ingressClassName: {{ . }}
+{{- end }}
+  rules:
+{{- range .Values.vncGateway.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+{{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "ghost-platform.componentName" (list $ "vnc-gateway") }}
+                port:
+                  number: {{ $.Values.vncGateway.service.port }}
+{{- end }}
+{{- end }}
+{{- with .Values.vncGateway.ingress.tls }}
+  tls:
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/docs/helm/platform/templates/vnc-gateway-service.yaml
+++ b/docs/helm/platform/templates/vnc-gateway-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.vncGateway.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ghost-platform.componentName" (list . "vnc-gateway") }}
+  labels:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: vnc-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  type: {{ .Values.vncGateway.service.type }}
+  selector:
+    app.kubernetes.io/name: {{ include "ghost-platform.fullname" . }}
+    app.kubernetes.io/component: vnc-gateway
+  ports:
+    - name: http
+      port: {{ .Values.vncGateway.service.port }}
+      targetPort: {{ .Values.vncGateway.service.port }}
+{{- end }}

--- a/docs/helm/platform/ui.values.yaml
+++ b/docs/helm/platform/ui.values.yaml
@@ -1,0 +1,35 @@
+ui:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/acme/ghost-ui
+    tag: v1.4.0
+  service:
+    type: ClusterIP
+    port: 80
+  env:
+    VITE_GATEWAY_URL: https://gateway.example.com
+    VITE_KEYCLOAK_URL: https://id.example.com/realms/ghost
+    VITE_KEYCLOAK_CLIENT_ID: ghost-ui
+  secretEnv:
+    - name: VITE_KEYCLOAK_CLIENT_SECRET
+      secretName: ui-keycloak
+      secretKey: clientSecret
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: ui.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - ui.example.com
+        secretName: ui-tls

--- a/docs/helm/platform/values.yaml
+++ b/docs/helm/platform/values.yaml
@@ -1,0 +1,123 @@
+fullnameOverride: ""
+nameOverride: ""
+
+imagePullSecrets: []
+serviceAccountName: ""
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+gateway:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/example/gateway
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8080
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  env: {}
+  secretEnv: []
+  extraEnvFromSecrets: []
+  resources: {}
+  podAnnotations: {}
+  podLabels: {}
+
+runner:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/example/runner
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8080
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  env: {}
+  secretEnv: []
+  extraEnvFromSecrets: []
+  resources: {}
+  podAnnotations: {}
+  podLabels: {}
+
+vncGateway:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/example/vnc-gateway
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8000
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  env: {}
+  secretEnv: []
+  extraEnvFromSecrets: []
+  resources: {}
+  podAnnotations: {}
+  podLabels: {}
+
+ui:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/example/ui
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 80
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  env: {}
+  secretEnv: []
+  extraEnvFromSecrets: []
+  resources: {}
+  podAnnotations: {}
+  podLabels: {}
+
+camoufoxWorker:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: ghcr.io/example/camoufox-worker
+    tag: latest
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 8080
+  ingress:
+    enabled: false
+    className: ""
+    annotations: {}
+    hosts: []
+    tls: []
+  env: {}
+  secretEnv: []
+  extraEnvFromSecrets: []
+  resources: {}
+  podAnnotations: {}
+  podLabels: {}

--- a/docs/helm/platform/vnc-gateway.values.yaml
+++ b/docs/helm/platform/vnc-gateway.values.yaml
@@ -1,0 +1,35 @@
+vncGateway:
+  replicaCount: 2
+  image:
+    repository: ghcr.io/acme/ghost-vnc-gateway
+    tag: v1.4.0
+  service:
+    type: ClusterIP
+    port: 8000
+  env:
+    VNC_GATEWAY_RUNNER_HTTP_BASE: http://runner.ghost.svc.cluster.local:8080
+    VNC_GATEWAY_RUNNER_WS_BASE: ws://runner.ghost.svc.cluster.local:8080
+    VNC_GATEWAY_METRICS_BACKEND: prometheus
+  secretEnv:
+    - name: VNC_GATEWAY_TOKEN_SECRET
+      secretName: gateway-vnc
+      secretKey: token
+  resources:
+    requests:
+      cpu: 200m
+      memory: 256Mi
+    limits:
+      cpu: 400m
+      memory: 512Mi
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: vnc-gateway.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls:
+      - hosts:
+          - vnc-gateway.example.com
+        secretName: vnc-gateway-tls

--- a/services/camoufox_worker/AGENT_NOTES.md
+++ b/services/camoufox_worker/AGENT_NOTES.md
@@ -31,6 +31,7 @@ Camoufox worker обеспечивает выполнение короткожи
   `camoufox` лёгкой заглушкой до monkeypatch'ей тестов.
 * Dockerfile устанавливает зависимости через Poetry (`poetry.lock`), копирует `worker/` и `bin/worker-launch.sh` под пользователем `pwuser` и допускает переопределение версии `camoufox` build-аргументом.
 * `worker.queue` реализует консьюмера задач с поддержкой Redis Streams, AMQP и in-memory backend, ретраями/идемпотентностью, Prometheus-метриками и структурированными JSON-логами. Исполнители инжектируются, что позволяет переопределять стратегию запуска задач.
+* Helm chart `docs/helm/platform` разворачивает worker рядом с Gateway/Runner, позволяет объявлять секреты (`GATEWAY_TOKEN`, proxy creds) через `secretEnv` и пример `camoufox-worker.values.yaml`.
 
 ## Constraints & Invariants
 * Выполнение под non-root пользователем, без `pip install`/`camoufox fetch` в рантайме.
@@ -67,4 +68,5 @@ Camoufox worker обеспечивает выполнение короткожи
   обновлены инструкции по зависимостям и тестам.
 * 2025-02-24 · ChatGPT · Добавлен модуль очереди с Redis/AMQP адаптерами, Prometheus метриками, тумблерами профиля и тестами интеграций.
 * 2025-02-26 · ChatGPT · Интегрирован FastAPI worker (REST/VNC/WebSocket), добавлены конфиги `worker.config`, обязательные флаги браузера и unit-тесты `test_service.py`; обновлены зависимости Poetry.
+* 2025-10-03 · gpt-5-codex · Добавлены Helm-шаблоны/values для camoufox-worker с примерами секретов и описанием деплоя.
 * 2025-10-14 · gpt-5-codex · Возврат прямого runner `ws_endpoint` в REST-ответах и добавление поля `ws_proxy_endpoint` вместо перезаписи URL прокси.

--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -72,6 +72,8 @@
   чтобы собрать `uvicorn[standard]` зависимости, и Poetry 1.8.3 создает локальное venv. Entry-point использует
   `uvicorn app.main:create_app`, чтобы запускать приложение через фабрику и корректно применять конфигурацию.
   Публикация в GHCR сопровождается опциональной подписью Cosign (переключается флагом `sign_image`).
+- Helm chart `docs/helm/platform` описывает деплой Gateway вместе с другими контрол-плейн сервисами, поддерживая передачу
+  переменных окружения и Secret-значений (Keycloak, `VNC_TOKEN_SECRET`) через `secretEnv`/`extraEnvFromSecrets`.
 
 ## Constraints & Invariants
 - `VNC_TOKEN_TTL_SEC` всегда ≤300; нарушение приводит к `ValueError` на старте.
@@ -107,6 +109,7 @@
 - 2025-10-01 · OpenAI ChatGPT · Реализован FastAPI gateway (REST/SSE/WS), Keycloak JWT, VNC-токены и покрывающие unit-тесты.
 - 2025-10-02 · OpenAI ChatGPT · Добавлены публичные VNC-шаблоны для раннеров и переписывание URL при создании сессий по образцу beta-control-plane.
 - 2025-10-03 · gpt-5-codex · Вынесен VNC JWT секрет в конфигурацию и синхронизирован с VNC Gateway.
+- 2025-10-03 · gpt-5-codex · Задокументирован Helm-чарт control plane (templates + values) с опциями для секретов Gateway.
 - 2025-10-05 · gpt-5-codex · Уточнена логика выдачи VNC токенов при пустых значениях от Runner и добавлены покрывающие тесты.
 - 2025-10-06 · gpt-5-codex · Разрешена аутентификация SSE через query `access_token`, добавлен unit-тест маршрута `/events`.
 - 2025-10-07 · gpt-5-codex · Добавлены командные эндпоинты `/sessions/commands*`, httpx-клиент Runner и покрывающие тесты.

--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -81,6 +81,8 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
   переключается на `launch_browser`, если гибридный режим не находит idle-слота, и
   добавляет в метаданные `browser_origin` с деталями источника.
 - **Gateway proxy compatibility**: `SessionCreatePayload` остаётся публичным контрактом, но теперь вызывается через Gateway, потому важна обратная совместимость и строгая валидация.
+- **Helm deployment**: общий чарт `docs/helm/platform` разворачивает Runner вместе с Gateway/VNC/UI, позволяет прокидывать переменные
+  окружения и секреты (`secretEnv`, `extraEnvFromSecrets`) для токенов Camoufox, прокси и warm-pool конфигураций.
 - **Playwright launch lifecycle**: `app.browser.launch_browser` стартует Playwright в режиме `launch-server`, сохраняет `wsEndpoint`/PID в метаданных и позволяет `SessionManager` останавливать процесс при переходе в `DEAD` или очистке endpoint. Исключения при старте выполняют откат без публикации событий.
 - **Idle TTL reaper**: `SessionManager` содержит AnyIO-based reaper, который вызывает
   `reap_expired_sessions`, завершает истёкшие по `idle_ttl_seconds` сессии и публикует события
@@ -132,6 +134,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 ## Changelog (for agents)
 - 2024-09-22 · OpenAI ChatGPT · Расширен `/health`, добавлены метрики/история prewarm, новые настройки и модульные тесты.
 - 2025-10-03 · gpt-5-codex · Добавлен Dockerfile на базе Playwright-образа, Poetry-инсталляция зависимостей и `.dockerignore` для сборки runner внутри контейнера без выполнения `camoufox fetch`.
+- 2025-10-03 · gpt-5-codex · Подготовлены Helm-шаблоны и образцы values для Runner (секреты Camoufox/прокси, ресурсы) и обновлена документация по деплою.
 - 2025-10-05 · gpt-5-codex · Sanitised runner VNC payloads to defer token issuance to the gateway and extended unit tests.
 - 2025-10-07 · gpt-5-codex · Зафиксировано использование in-memory event publisher как основного транспорта, обновлены Known Gaps.
 - 2025-10-08 · gpt-5-codex · Добавлен HTTP publisher (`POST /events`) и покрытие unit-тестами + конфиг-переключатель в зависимостях.

--- a/services/vnc-gateway/AGENT_NOTES.md
+++ b/services/vnc-gateway/AGENT_NOTES.md
@@ -23,6 +23,7 @@ FastAPI service that validates short-lived VNC access tokens and proxies HTTP/WS
 
 ## Decisions
 - 2025-02-14 · Runtime-образ собирается через builder-стейдж, который упаковывает сервис в wheel. Финальный слой устанавливает wheel и копирует исходники `app/`, поэтому рантайм остаётся лёгким, но при необходимости сохраняется возможность отладки по исходникам. Перед сборкой образа make-таргет `vnc-gateway-image` выполняет smoke-проверки (`ruff`, `pytest`), чтобы pipeline не публиковал образ с регрессиями.
+- Helm chart `docs/helm/platform` предоставляет шаблон Deployment/Service/Ingress для VNC Gateway, принимает `secretEnv` c общим `VNC_GATEWAY_TOKEN_SECRET` и прочими секретами, обеспечивая синхронизацию конфигурации с Gateway/Runner.
 
 ## Constraints & Invariants
 - Tokens must include the matching session identifier; mismatches immediately rejected.
@@ -49,6 +50,7 @@ poetry run pytest -q
 ## Changelog (for agents)
 Дата · Кем/чем изменено · Коротко *что и почему*.
 
-- 2025-10-09 · gpt-5-codex · Переписан WS-прокси на uvicorn/websockets `TaskGroup`-relay, добавлены интеграционные тесты с real сервером, внедрён Prometheus `/metrics` (active/total connections, token failures), расширен `TokenValidator` (nonce/iat cache) и документирован сценарий предотвращения replay.
 - 2025-10-10 · gpt-5-codex · Добавлена конфигурация метрик через настройки (Prometheus registry/OTLP exporter), обновлён `/metrics` endpoint и покрытие тестами.
+- 2025-10-09 · gpt-5-codex · Переписан WS-прокси на uvicorn/websockets `TaskGroup`-relay, добавлены интеграционные тесты с real сервером, внедрён Prometheus `/metrics` (active/total connections, token failures), расширен `TokenValidator` (nonce/iat cache) и документирован сценарий предотвращения replay.
+- 2025-10-03 · gpt-5-codex · Добавлены Helm-шаблоны/values для VNC Gateway с примерами секретов и документация по установке.
 - 2025-02-14 · gpt-5-codex · Добавлен Dockerfile с многоступенчатой сборкой, make/CI-таргеты для образа и документация по переменным окружения VNC Gateway.


### PR DESCRIPTION
## Summary
- add a platform Helm chart that provisions gateway, runner, vnc-gateway, UI, and camoufox-worker Deployments/Services/Ingress with secret-aware env configuration
- provide per-component example values files highlighting resource and secret overrides for typical environments
- document the Helm installation flow and record the deployment option in component AGENT_NOTES

## Testing
- not run (docs and manifests only)

## Security
- no new security risks introduced

------
https://chatgpt.com/codex/tasks/task_e_68df3df8905c832ab2f208108569c147