### PR TITLE
Ensure runner package is importable in tests and container

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -124,7 +124,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 
 ## How to Test
 - `poetry install --no-root`
-- `PYTHONPATH=. poetry run pytest -q` (anyio-powered unit tests)
+- `poetry run pytest -q` (anyio-powered unit tests)
 - `poetry run ruff check .`
 - `make runner-image` — соберёт контейнер, выполнит `poetry check`, `poetry install --with dev --no-root`, `PYTHONPATH=. poetry run pytest -q`, `python -m camoufox path` и `python -m camoufox version` внутри образа.
 - Таргетно: `PYTHONPATH=. poetry run pytest services/runner/tests/test_config_warm_pool.py -q`
@@ -161,3 +161,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-27 · gpt-5-codex · Добавлен make-таргет/CI-контур для сборки runner-образа с контейнерными тестами и подписями cosign.
 - 2025-10-28 · gpt-5-codex · Документирован локальный парк прогретых рабочих станций и примеры конфигов для docker compose.
 - 2025-10-29 · gpt-5-codex · Перевели docker compose на гибридный режим тёплого пула, чтобы локально запускались холодные сессии при исчерпании парка.
+- 2025-10-30 · gpt-5-codex · Добавлены pytest-конфигурации для автоматического импорта пакета `app` и задан `PYTHONPATH` внутри контейнера Runner, чтобы `uvicorn` и тесты работали без ручных переменных окружения.

--- a/services/runner/Dockerfile
+++ b/services/runner/Dockerfile
@@ -46,7 +46,8 @@ COPY --chown=pwuser:pwuser services/runner ./
 RUN rm -rf /workspace/camoufox /workspace/packages/camoufox
 
 ENV PATH="/workspace/services/runner/.venv/bin:${PATH}" \
-    CAMOUFOX_HEADLESS=virtual
+    CAMOUFOX_HEADLESS=virtual \
+    PYTHONPATH="/workspace/services/runner"
 
 EXPOSE 8080
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/runner/pyproject.toml
+++ b/services/runner/pyproject.toml
@@ -28,6 +28,7 @@ markers = [
     "anyio: mark tests requiring the AnyIO event loop",
 ]
 testpaths = ["tests"]
+pythonpath = ["app"]
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]

--- a/services/runner/tests/conftest.py
+++ b/services/runner/tests/conftest.py
@@ -1,12 +1,26 @@
-"""Pytest fixtures configuring Camoufox test doubles for the runner suite."""
+"""Pytest fixtures configuring Camoufox test doubles for the runner suite.
+
+The module also ensures that the ``app`` package resolves without requiring
+contributors to export ``PYTHONPATH`` manually. This mirrors the runtime
+Docker image where the service root is appended to the module search path.
+
+Example:
+    >>> import importlib
+    >>> importlib.import_module("app.config")  # doctest: +SKIP
+"""
 
 from __future__ import annotations
 
+import sys
 from importlib import import_module
 from pathlib import Path
 from typing import Iterator
 
 import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- add the runner service directory to `PYTHONPATH` inside the container so `uvicorn` can import the app package without extra flags
- extend the pytest bootstrap to mirror that behaviour locally and document the workflow in the runner agent notes

## Testing
- `cd services/runner && poetry run pytest -q` (50 passed, 17 warnings)  
- `cd services/gateway && poetry run pytest -q` (49 passed)

## Security
- no security-relevant changes


------
https://chatgpt.com/codex/tasks/task_e_68df793756c8832a911100d1d23ec41a