### PR TITLE
Fix UI build entrypoint

### DIFF
--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -57,6 +57,8 @@
 - `make ui-image UI_EXTRA_BUILD_ARGS="--build-arg VITE_GATEWAY_URL=<url>"` — проверка Docker-сборки (линт/тесты выполняются внутри таргета).
 
 ## Changelog (for agents)
+- 2025-11-19 · gpt-5-codex · Восстановлен entry-point `index.html`, из-за отсутствия которого `pnpm build` и Docker-сборка падали, и
+  вычищен lint-варнинг в тесте `SessionDetailsPanel`.
 - 2025-10-03 · gpt-5-codex · Добавлен offline-фоллбек в `AuthProvider` и витест, проверяющий
   отрисовку Dashboard без Keycloak.
 - 2024-09-08 · gpt-5-codex · Начальная реализация консоли: авторизация, список/детали сессий, создание/удаление, SSE, темы, базовые тесты.

--- a/apps/ui/index.html
+++ b/apps/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ru">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ghost Browsers Console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/ui/src/__tests__/SessionDetailsPanel.test.tsx
+++ b/apps/ui/src/__tests__/SessionDetailsPanel.test.tsx
@@ -37,8 +37,11 @@ describe('SessionDetailsPanel', () => {
 
     render(<SessionDetailsPanel session={session} />);
 
-    const iframe = screen.getByTitle('VNC') as HTMLIFrameElement;
-    expect(iframe).toBeTruthy();
+    const iframe = screen.getByTitle('VNC');
+    if (!(iframe instanceof HTMLIFrameElement)) {
+      throw new Error('Expected VNC preview to render as an <iframe>.');
+    }
+
     expect(iframe.src).toContain('token=opaque-token');
   });
 });


### PR DESCRIPTION
Summary
- restore the missing `apps/ui/index.html` entrypoint so the Vite build and Docker image succeed
- clean up the SessionDetailsPanel test and document the change in `AGENT_NOTES.md`

Testing
- pnpm -C apps/ui build
- pnpm -C apps/ui lint

Security
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dfbbe2911c832ab055895f6d820d1b