### PR TITLE
Preserve duplicate Set-Cookie headers in VNC gateway

### DIFF
--- a/services/vnc-gateway/AGENT_NOTES.md
+++ b/services/vnc-gateway/AGENT_NOTES.md
@@ -19,6 +19,7 @@ FastAPI service that validates short-lived VNC access tokens and proxies HTTP/WS
 - Dependency wiring relies on `typing.Annotated` wrappers to avoid Ruff `B008` violations while keeping FastAPI semantics.
 - Tests inject stubbed `RunnerProxy` via dependency overrides; `tests/conftest.py` adjusts `sys.path` instead of installing the package.
 - Runner proxy keeps a singleton `httpx.AsyncClient` and resolves `target_port` from query/referer/cookie (persisting it via `vnc-target-port` cookie) to build Runner URLs with configurable prefixes; WebSocket relay теперь ждёт оба направления через `TaskGroup`, отдаёт 1008 при невалидном `target_port` и 1011 при timeouts/сетевых ошибках.
+- HTTP proxy фильтрует заголовки как упорядоченный список пар, чтобы проксировать дублирующиеся значения (`Set-Cookie`) без потерь.
 - Prometheus экспозиция реализована через `/metrics`, чтобы scrape-еры (Prometheus, VictoriaMetrics и т.д.) могли использовать стандартный текстовый формат без дополнительных middleware.
 
 ## Decisions
@@ -64,3 +65,4 @@ poetry run pytest -q
 - 2025-02-14 · gpt-5-codex · Добавлен Dockerfile с многоступенчатой сборкой, make/CI-таргеты для образа и документация по переменным окружения VNC Gateway.
 - 2025-10-25 · gpt-5-codex · Добавлен fallback обработки токена через query `token`/`access_token`, обновлены роуты и unit-тесты ключевых сценариев.
 - 2025-10-26 · gpt-5-codex · Разрешено повторное использование токенов без `nonce` (HTTP→WS), добавлен регрессионный тест и сохранена защита от replay для токенов с `nonce`.
+- 2025-10-27 · gpt-5-codex · HTTP proxy сохраняет порядок дублирующихся заголовков (`Set-Cookie`), добавлен регрессионный тест на проксирование двух cookie.

--- a/services/vnc-gateway/app/camou_vnc_gateway/proxy.py
+++ b/services/vnc-gateway/app/camou_vnc_gateway/proxy.py
@@ -150,9 +150,10 @@ class RunnerProxy:
         response = Response(
             content=upstream_response.content,
             status_code=upstream_response.status_code,
-            headers=dict(filtered_headers),
-            media_type=upstream_response.headers.get("content-type"),
         )
+        response.raw_headers = []
+        for header, value in filtered_headers:
+            response.headers.append(header, value)
 
         if source == "query" and port_override is not None:
             response.set_cookie(
@@ -325,8 +326,8 @@ class RunnerProxy:
         }
 
     @staticmethod
-    def _filter_response_headers(headers: httpx.Headers) -> dict[str, str]:
-        """Filter upstream response headers to remove hop-by-hop entries."""
+    def _filter_response_headers(headers: httpx.Headers) -> list[tuple[str, str]]:
+        """Filter upstream response headers while preserving duplicates."""
 
         hop_by_hop = {
             "connection",
@@ -337,8 +338,12 @@ class RunnerProxy:
             "trailers",
             "transfer-encoding",
             "upgrade",
-        } 
-        return {k: v for k, v in headers.items() if k.lower() not in hop_by_hop}
+        }
+        return [
+            (key, value)
+            for key, value in headers.multi_items()
+            if key.lower() not in hop_by_hop
+        ]
 
 
 def _build_upstream_url(

--- a/services/vnc-gateway/tests/test_http_proxy_headers.py
+++ b/services/vnc-gateway/tests/test_http_proxy_headers.py
@@ -1,0 +1,74 @@
+"""HTTP proxy tests covering response header handling semantics."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+from camou_vnc_gateway.config import Settings
+from camou_vnc_gateway.proxy import RunnerProxy
+from fastapi import Request
+
+
+def _build_request() -> Request:
+    """Create a minimal ASGI ``Request`` suitable for ``forward_http`` tests."""
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/sessions/test",
+        "headers": [(b"accept", b"application/json")],
+        "query_string": b"",
+        "client": ("127.0.0.1", 12345),
+        "server": ("testserver", 80),
+    }
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+async def _run_forward_http_preserves_duplicate_set_cookie(monkeypatch) -> None:
+    """Execute the duplicate ``Set-Cookie`` preservation scenario."""
+
+    settings = Settings(
+        token_secret="secret",
+        runner_http_base="http://runner",  # actual host mocked below
+        runner_ws_base="ws://runner",
+    )
+    proxy = RunnerProxy(settings)
+
+    upstream_headers = httpx.Headers(
+        [
+            ("Set-Cookie", "a=1; Path=/"),
+            ("Set-Cookie", "b=2; Path=/"),
+            ("Content-Type", "application/json"),
+        ]
+    )
+    upstream_response = httpx.Response(200, headers=upstream_headers, content=b"{}")
+
+    async def fake_request(method: str, url: str, **kwargs: Any) -> httpx.Response:
+        return upstream_response
+
+    monkeypatch.setattr(proxy._client, "request", fake_request)  # type: ignore[attr-defined]
+
+    request = _build_request()
+    response = await proxy.forward_http(session_id="test", request=request)
+
+    try:
+        assert response.status_code == upstream_response.status_code
+        assert response.headers.getlist("set-cookie") == [
+            "a=1; Path=/",
+            "b=2; Path=/",
+        ]
+        assert response.headers["content-type"] == "application/json"
+    finally:
+        await proxy.aclose()
+
+
+def test_forward_http_preserves_duplicate_set_cookie(monkeypatch) -> None:
+    """The HTTP proxy forwards duplicate ``Set-Cookie`` headers without loss."""
+
+    asyncio.run(_run_forward_http_preserves_duplicate_set_cookie(monkeypatch))


### PR DESCRIPTION
## Summary
- ensure the HTTP proxy replays upstream headers as ordered pairs so duplicate Set-Cookie values are forwarded intact
- add a regression test that stubs the runner client and asserts both cookies reach the FastAPI response
- document the new header-handling behaviour in the vnc-gateway agent notes

## Testing
- poetry run pytest -q

## Security
- No security concerns were introduced by this change.

------
https://chatgpt.com/codex/tasks/task_e_68dfe8e42e54832a8b3c822687f59a55