### PR TITLE
Ensure VNC flag mirrors available connection details

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -122,6 +122,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - Взаимодействие с Gateway/SSE происходит только внутри доверенной сети кластера; авторизация на уровне HTTP не ожидается,
   вместо этого требуется сетевое разделение и настройка доверенных CIDR на стороне Gateway.
 - Доступность VNC зависит от бинарей `Xvfb`, `x11vnc` и `websockify`; при их отсутствии `ProcessVncController` отключается и сессии остаются без VNC-URL.
+- `SessionManager` гарантирует, что `session.vnc_enabled` не остаётся `True`, когда VNC-детали отсутствуют или сессия работает в headless-режиме; флаг пересчитывается при создании и апдейтах.
 - Docker-образ предполагает запуск под `pwuser`, PATH включает `.venv/bin`, а контекст сборки обязан содержать каталоги `camoufox` и `packages`, иначе Poetry не найдёт path-зависимости.
 - BuildKit cache mounts для Poetry/pip отключены: docker compose запускает сборку с rootless BuildKit и разделяемые кеши получают root-владельца, что ломает установку зависимостей (`PermissionError`).
 
@@ -173,3 +174,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-30 · gpt-5-codex · Добавлены pytest-конфигурации для автоматического импорта пакета `app` и задан `PYTHONPATH` внутри контейнера Runner, чтобы `uvicorn` и тесты работали без ручных переменных окружения.
 - 2025-10-31 · gpt-5-codex · Добавлена поддержка обязательных/запросных browser flags в cold launch и warm pool, нормализация значений и тесты на совместимость режимов.
 - 2025-10-31 · gpt-5-codex · Docker-образ расширен системными шрифтами, Windows-наборами, локалями и VNC-бинарями (Xvfb/x11vnc/websockify/noVNC) при сохранении поэтапной установки зависимостей через Poetry.
+- 2025-10-31 · gpt-5-codex · Синхронизирован флаг `vnc_enabled` с реальными VNC-деталями и добавлены регрессионные тесты на headless и сбойную аллокацию.

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -249,11 +249,12 @@ class SessionManager:
                 )
                 if browser_handle.pid is not None:
                     metadata.setdefault("runner_browser_pid", browser_handle.pid)
-                vnc_enabled = (
-                    payload.vnc_enabled
-                    if payload.vnc_enabled is not None
-                    else (vnc_details is not None and not payload.headless)
-                )
+                if payload.vnc_enabled is None:
+                    vnc_enabled = vnc_details is not None and not payload.headless
+                else:
+                    vnc_enabled = payload.vnc_enabled
+                if payload.headless or vnc_details is None:
+                    vnc_enabled = False
                 try:
                     session = Session(
                         id=session_id,
@@ -335,6 +336,12 @@ class SessionManager:
                 update_data["labels"] = {**existing.labels, **merged_labels}
             if merged_metadata is not None:
                 update_data["metadata"] = {**existing.metadata, **merged_metadata}
+            next_headless = update_data.get("headless")
+            if next_headless is None:
+                next_headless = existing.headless
+            next_vnc = update_data.get("vnc", existing.vnc)
+            if next_headless or next_vnc is None:
+                update_data["vnc_enabled"] = False
             session = existing.model_copy(update=update_data, deep=True)
             self._sessions[session_id] = session
             self._recalculate_active_sessions(existing.status, session.status)

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import types
 from datetime import UTC, datetime, timedelta
 from typing import Callable
+from uuid import UUID
 
 import pytest
 from app.config import RunnerSettings, WarmPoolMode
@@ -15,6 +17,7 @@ from app.session_manager import (
     SessionManager,
     SessionUpdatePayload,
 )
+from app.vnc import VncSessionHandle
 from app.warm_pool import (
     WarmPoolReservation,
     WarmPoolSnapshot,
@@ -274,6 +277,75 @@ async def test_create_session_emits_event_and_vnc_stub(
     assert events[0].type is SessionEventType.CREATED
     assert events[0].session.id == session.id
     assert events[0].occurred_at == clock_now
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_session_headless_disables_vnc_flag(
+    stub_vnc_controller: _StubVncController,
+) -> None:
+    """Headless sessions must not persist VNC handles or enable the flag."""
+
+    settings = RunnerSettings(
+        runner_id="runner-headless",
+        camoufox_path="/usr/bin/camoufox",
+    )
+    publisher = InMemorySessionEventPublisher()
+    manager, _ = _build_manager(
+        settings,
+        publisher,
+        vnc_controller=stub_vnc_controller,
+    )
+
+    session = await manager.create_session(
+        SessionCreatePayload(headless=True, vnc_enabled=True)
+    )
+
+    assert session.headless is True
+    assert session.vnc is None
+    assert session.vnc_enabled is False
+    assert session.id not in manager._vnc_handles
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_session_disables_vnc_when_allocation_fails(
+    monkeypatch: pytest.MonkeyPatch, stub_vnc_controller: _StubVncController
+) -> None:
+    """Failed VNC allocations should force ``vnc_enabled`` to ``False``."""
+
+    settings = RunnerSettings(
+        runner_id="runner-vnc-fail",
+        camoufox_path="/usr/bin/camoufox",
+    )
+    publisher = InMemorySessionEventPublisher()
+    manager, _ = _build_manager(
+        settings,
+        publisher,
+        vnc_controller=stub_vnc_controller,
+    )
+
+    async def _fail_resolve(
+        self: SessionManager,
+        payload: SessionCreatePayload,
+        session_id: UUID,
+        *,
+        sanitized_vnc: SessionVncDetails | None,
+    ) -> tuple[SessionVncDetails | None, VncSessionHandle | None]:
+        del payload, session_id, sanitized_vnc
+        return None, None
+
+    monkeypatch.setattr(
+        manager,
+        "_resolve_vnc",
+        types.MethodType(_fail_resolve, manager),
+    )
+
+    session = await manager.create_session(
+        SessionCreatePayload(headless=False, vnc_enabled=True)
+    )
+
+    assert session.vnc is None
+    assert session.vnc_enabled is False
+    assert session.id not in manager._vnc_handles
 
 
 @pytest.mark.anyio("asyncio")
@@ -665,6 +737,35 @@ async def test_update_session_strips_user_vnc_token(
     assert updated.vnc is not None
     assert updated.vnc.token is None
     assert updated.vnc.token_ttl_seconds is None
+
+
+@pytest.mark.anyio("asyncio")
+async def test_update_session_disables_vnc_when_details_removed(
+    stub_vnc_controller: _StubVncController,
+) -> None:
+    """Clearing VNC details must also disable the ``vnc_enabled`` flag."""
+
+    publisher = InMemorySessionEventPublisher()
+    manager, _ = _build_manager(
+        RunnerSettings(
+            runner_id="runner-update-vnc",
+            camoufox_path="/usr/bin/camoufox",
+        ),
+        publisher,
+        vnc_controller=stub_vnc_controller,
+    )
+    session = await manager.create_session(SessionCreatePayload(headless=False))
+    assert session.vnc is not None
+    assert session.vnc_enabled is True
+
+    updated = await manager.update_session(
+        session.id,
+        SessionUpdatePayload(vnc=None, vnc_enabled=True),
+    )
+
+    assert updated.vnc is None
+    assert updated.vnc_enabled is False
+    assert session.id not in manager._vnc_handles
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- prevent SessionManager from leaving vnc_enabled True when sessions are headless or missing VNC allocations
- cover headless launches, allocation failures, and VNC removal with dedicated tests
- document the enforced VNC flag invariant in the runner AGENT_NOTES changelog

## Testing
- poetry -C services/runner run pytest tests/test_session_manager.py -q

## Security
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dfe9a24134832a95d17cecab26edac