### PR TITLE
Normalize SSE event stream URLs

### DIFF
--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -83,3 +83,4 @@
 - 2025-10-24 · gpt-5-codex · Добавлен Nginx-конфиг, проксирующий `/api` на gateway, и обновлена Docker-сборка для совместимости с docker-compose стеком.
 - 2025-10-25 · gpt-5-codex · UI адаптеры теперь дописывают `token` в VNC URL, обновлён `SessionDetailsPanel` тест для верификации iframe.
 - 2025-02-14 · gpt-5-codex · Верифицированы рабочие команды `pnpm install`, `pnpm -C apps/ui lint`, `pnpm -C apps/ui test`, `pnpm -C apps/ui build`.
+- 2025-10-26 · gpt-5-codex · Нормализован SSE-клиент при относительном `VITE_GATEWAY_URL`, добавлен витест, проверяющий абсолютный URL EventSource.

--- a/apps/ui/src/api/client.test.ts
+++ b/apps/ui/src/api/client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { openSessionEventStream } from './client';
 
@@ -64,5 +64,26 @@ describe('openSessionEventStream', () => {
     expect(MockEventSource.createdUrls[0]).not.toContain('access_token=');
 
     eventSource.close();
+  });
+
+  it('normalises relative gateway URLs against the current origin', async () => {
+    vi.resetModules();
+    vi.stubEnv('VITE_GATEWAY_URL', '/api');
+
+    try {
+      const { openSessionEventStream: relativeOpenSessionEventStream } = await import('./client');
+
+      const { eventSource } = relativeOpenSessionEventStream({ token: 'xyz' });
+
+      expect(MockEventSource.createdUrls).toHaveLength(1);
+      expect(MockEventSource.createdUrls[0]).toContain('/api/events');
+      expect(MockEventSource.createdUrls[0]).toContain('access_token=xyz');
+      expect(MockEventSource.createdUrls[0].startsWith(window.location.origin)).toBe(true);
+
+      eventSource.close();
+    } finally {
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
   });
 });

--- a/apps/ui/src/api/client.ts
+++ b/apps/ui/src/api/client.ts
@@ -196,7 +196,26 @@ export const deleteSession = (sessionId: string, headers?: AuthHeaders) =>
  * support function correctly.
  */
 export const openSessionEventStream = (headers?: AuthHeaders) => {
-  const url = new URL(createUrl(gatewayUrl, '/events'));
+  const eventsPath = createUrl(gatewayUrl, '/events');
+  let url: URL;
+
+  try {
+    url = new URL(eventsPath);
+  } catch (error) {
+    const origin =
+      typeof window !== 'undefined' && typeof window.location?.origin === 'string'
+        ? window.location.origin
+        : undefined;
+
+    if (!origin) {
+      throw error;
+    }
+
+    // Relative gateway URLs (e.g. "/api") are resolved against the current origin so
+    // the EventSource receives an absolute URL compatible with native implementations.
+    url = new URL(eventsPath, origin);
+  }
+
   if (headers?.token) {
     url.searchParams.set('access_token', headers.token);
   }


### PR DESCRIPTION
## Summary
- resolve the session event stream URL against the current origin when the gateway base is relative
- extend the API client tests to cover relative gateway configuration and token propagation
- note the SSE normalisation change in the UI agent knowledge base

## Testing
- `pnpm -C apps/ui lint`
- `pnpm -C apps/ui test`

## Security
- no security concerns


------
https://chatgpt.com/codex/tasks/task_e_68dff9d241a8832ab926a93beab9ce86