### PR TITLE
Handle session publish failures

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -177,3 +177,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-31 · gpt-5-codex · Docker-образ расширен системными шрифтами, Windows-наборами, локалями и VNC-бинарями (Xvfb/x11vnc/websockify/noVNC) при сохранении поэтапной установки зависимостей через Poetry.
 - 2025-10-31 · gpt-5-codex · Сессии, созданные на warm-слотах, теперь запоминают workstation-метаданные и очищают их при релизе; добавлены проверки в unit-тестах.
 - 2025-10-31 · gpt-5-codex · Синхронизирован флаг `vnc_enabled` с реальными VNC-деталями и добавлены регрессионные тесты на headless и сбойную аллокацию.
+- 2025-10-31 · gpt-5-codex · Защищено `SessionManager.create_session` от сбоев публикации: откат аллокаций warm/VNC, обновлены метрики и добавлен регрессионный тест.

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -321,7 +321,28 @@ class SessionManager:
                 if session.status is not SessionStatus.DEAD:
                     self._active_sessions += 1
                     ACTIVE_SESSIONS_GAUGE.set(self._active_sessions)
-                await self._publish(session, SessionEventType.CREATED, reason=None)
+                try:
+                    await self._publish(session, SessionEventType.CREATED, reason=None)
+                except Exception:
+                    self._sessions.pop(session_id, None)
+                    browser_handle = self._browser_handles.pop(session_id, None)
+                    warm_tracked = session_id in self._warm_sessions
+                    if session.status is not SessionStatus.DEAD:
+                        self._active_sessions = max(0, self._active_sessions - 1)
+                    ACTIVE_SESSIONS_GAUGE.set(self._active_sessions)
+                    with contextlib.suppress(Exception):
+                        if session_id in self._vnc_handles:
+                            await self._release_vnc_handle(session_id)
+                        else:
+                            await self._discard_vnc_handle(session_id, vnc_handle)
+                    with contextlib.suppress(Exception):
+                        if warm_tracked:
+                            await self._release_warm_slot(session_id)
+                        elif browser_handle is not None:
+                            await self._safe_shutdown_cold_browser(browser_handle)
+                    VNC_ALLOCATIONS_GAUGE.set(len(self._vnc_handles))
+                    self._recalculate_next_idle_expiry_locked()
+                    raise
                 return session
         finally:
             SESSION_ALLOCATE_SECONDS.observe(perf_counter() - start_time)

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -26,6 +26,7 @@ from app.warm_pool import (
     WarmPoolStatistics,
 )
 from core.models import (
+    SessionEvent,
     SessionEventType,
     SessionProxySettings,
     SessionStatus,
@@ -228,6 +229,22 @@ def stub_vnc_controller() -> _StubVncController:
     return _StubVncController()
 
 
+class _FailingSessionEventPublisher:
+    """Session event publisher double that raises to emulate transport failures."""
+
+    def __init__(self, exc: Exception | None = None) -> None:
+        """Initialise the publisher with an optional exception to propagate."""
+
+        self._exc = exc or RuntimeError("session publish failure")
+        self.events: list[SessionEvent] = []
+
+    async def publish(self, event: SessionEvent) -> None:
+        """Record the attempted event and raise the configured exception."""
+
+        self.events.append(event)
+        raise self._exc
+
+
 @pytest.mark.anyio("asyncio")
 async def test_create_session_emits_event_and_vnc_stub(
     stub_vnc_controller: _StubVncController,
@@ -278,6 +295,43 @@ async def test_create_session_emits_event_and_vnc_stub(
     assert events[0].type is SessionEventType.CREATED
     assert events[0].session.id == session.id
     assert events[0].occurred_at == clock_now
+
+
+@pytest.mark.anyio("asyncio")
+async def test_create_session_rolls_back_state_when_publish_fails(
+    stub_vnc_controller: _StubVncController,
+) -> None:
+    """Publish failures during creation must roll back all allocations."""
+
+    def _sample(name: str) -> float:
+        value = METRICS_REGISTRY.get_sample_value(name)
+        return 0.0 if value is None else value
+
+    publisher = _FailingSessionEventPublisher()
+    manager, warm_pool = _build_manager(
+        RunnerSettings(runner_id="runner-publish-fail", camoufox_path="/usr/bin/camoufox"),
+        publisher,
+        vnc_controller=stub_vnc_controller,
+    )
+    assert warm_pool is not None
+
+    baseline_active = _sample("runner_active_sessions")
+    baseline_vnc = _sample("runner_vnc_allocations")
+
+    with pytest.raises(RuntimeError):
+        await manager.create_session(SessionCreatePayload(headless=False))
+
+    assert len(manager._sessions) == 0
+    assert manager._browser_handles == {}
+    assert manager._warm_sessions == {}
+    assert manager._vnc_handles == {}
+    assert manager._next_idle_expiry_at is None
+    assert manager._active_sessions == 0
+
+    assert len(warm_pool.releases) == 1
+    assert all(handle.released for handle in stub_vnc_controller.handles.values())
+    assert _sample("runner_active_sessions") == pytest.approx(baseline_active)
+    assert _sample("runner_vnc_allocations") == pytest.approx(baseline_vnc)
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
Summary
- roll back session, warm slot, and VNC allocations when publishing the CREATED event fails
- add a regression test with a failing publisher stub to assert state cleanup
- update runner agent notes with the new safeguard

Testing
- poetry run pytest -q tests/test_session_manager.py

Security
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dff8b3f930832aa8b1758400ec57ea