### PR TITLE
Release session manager lock before publishing events

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -65,6 +65,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
   `runner-image.yml` вызывает тот же таргет, пушит образ в GHCR и подписывает его `cosign` (keyless,
   `COSIGN_EXPERIMENTAL=1`).
 - **In-memory publisher**: Стандартный транспорт построен на `InMemorySessionEventPublisher` и считается продукционным решением; при необходимости можно оборачивать его через `CallbackSessionEventPublisher` для сторонних интеграций без отказа от in-memory ядра.
+- **Event publishing outside critical section**: `SessionManager` освобождает `anyio.Lock` до ожидания `SessionEventPublisher.publish`, исключая head-of-line блокировку при медленных транспортных слоях. Поведение покрыто тестом `test_update_session_releases_lock_before_publishing`.
 - **HTTP publisher toggle**: `get_event_publisher` читает `RunnerSettings.event_endpoint` и, если URL задан, использует `HttpSessionEventPublisher`, публикующий события в Gateway через `POST /events`.
 - **Workstation events**: `WarmPoolManager` публикует `workstation.state_changed|recycled|error` при любых переходах слота; маршруты `/workstations` только вызывают методы менеджера.
 - **SSE/WS обёртки**: `SseWorkstationEventPublisher` и `WebSocketWorkstationEventPublisher` форматируют события для стриминга в Gateway/UI.
@@ -177,3 +178,4 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-31 · gpt-5-codex · Docker-образ расширен системными шрифтами, Windows-наборами, локалями и VNC-бинарями (Xvfb/x11vnc/websockify/noVNC) при сохранении поэтапной установки зависимостей через Poetry.
 - 2025-10-31 · gpt-5-codex · Сессии, созданные на warm-слотах, теперь запоминают workstation-метаданные и очищают их при релизе; добавлены проверки в unit-тестах.
 - 2025-10-31 · gpt-5-codex · Синхронизирован флаг `vnc_enabled` с реальными VNC-деталями и добавлены регрессионные тесты на headless и сбойную аллокацию.
+- 2025-11-01 · gpt-5-codex · Перенесена публикация событий из-под `SessionManager`-блокировки и добавлен тест на отсутствие head-of-line блокировок.

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -321,8 +321,10 @@ class SessionManager:
                 if session.status is not SessionStatus.DEAD:
                     self._active_sessions += 1
                     ACTIVE_SESSIONS_GAUGE.set(self._active_sessions)
-                await self._publish(session, SessionEventType.CREATED, reason=None)
-                return session
+                event_type = SessionEventType.CREATED
+                reason: str | None = None
+            await self._publish(session, event_type, reason=reason)
+            return session
         finally:
             SESSION_ALLOCATE_SECONDS.observe(perf_counter() - start_time)
 
@@ -393,8 +395,8 @@ class SessionManager:
                 if session.status is SessionStatus.DEAD
                 else SessionEventType.UPDATED
             )
-            await self._publish(session, event_type, reason=reason)
-            return session
+        await self._publish(session, event_type, reason=reason)
+        return session
 
     async def end_session(
         self,

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 import types
+from collections import deque
 from datetime import UTC, datetime, timedelta
 from typing import Callable
 from uuid import UUID
 
+import anyio
 import pytest
 from app.config import RunnerSettings, WarmPoolMode
-from app.events import InMemorySessionEventPublisher
+from app.events import InMemorySessionEventPublisher, SessionEventPublisher
 from app.metrics import METRICS_REGISTRY
 from app.session_manager import (
     SessionCapacityError,
@@ -26,12 +28,39 @@ from app.warm_pool import (
     WarmPoolStatistics,
 )
 from core.models import (
+    Session,
+    SessionEvent,
     SessionEventType,
     SessionProxySettings,
     SessionStatus,
     SessionVncDetails,
     WorkstationState,
 )
+
+
+class _BlockingSessionEventPublisher:
+    """Publisher double that can delay delivery for specific events."""
+
+    def __init__(self) -> None:
+        self.events: list[SessionEvent] = []
+        self._blocks: deque[tuple[anyio.Event, anyio.Event]] = deque()
+
+    def arm_block(self) -> tuple[anyio.Event, anyio.Event]:
+        """Arrange for the next publish call to pause until released."""
+
+        start = anyio.Event()
+        resume = anyio.Event()
+        self._blocks.append((start, resume))
+        return start, resume
+
+    async def publish(self, event: SessionEvent) -> None:
+        """Record ``event`` and optionally wait for an external release."""
+
+        self.events.append(event)
+        if self._blocks:
+            start, resume = self._blocks.popleft()
+            start.set()
+            await resume.wait()
 
 
 class _StubBrowserHandle:
@@ -199,7 +228,7 @@ def anyio_backend() -> str:
 
 def _build_manager(
     settings: RunnerSettings,
-    publisher: InMemorySessionEventPublisher,
+    publisher: SessionEventPublisher,
     *,
     clock: Callable[[], datetime] | None = None,
     vnc_controller: "_StubVncController" | None = None,
@@ -671,6 +700,62 @@ async def test_update_session_merges_labels_and_publishes_update(
     assert events[-1].session.status is SessionStatus.READY
     assert events[-1].occurred_at == clock_now
 
+
+
+@pytest.mark.anyio("asyncio")
+async def test_update_session_releases_lock_before_publishing(
+    stub_vnc_controller: _StubVncController,
+) -> None:
+    """Slow publishers must not block subsequent session updates."""
+
+    settings = RunnerSettings(
+        runner_id="runner-blocking",
+        camoufox_path="/usr/bin/camoufox",
+    )
+    publisher = _BlockingSessionEventPublisher()
+    manager, _ = _build_manager(
+        settings,
+        publisher,
+        vnc_controller=stub_vnc_controller,
+    )
+
+    first_session = await manager.create_session(SessionCreatePayload(headless=True))
+    second_session = await manager.create_session(
+        SessionCreatePayload(headless=True, metadata={"origin": "second"})
+    )
+
+    start_event, release_event = publisher.arm_block()
+    results: dict[str, object] = {}
+
+    async def _perform_blocking_update() -> None:
+        results["first"] = await manager.update_session(
+            first_session.id,
+            SessionUpdatePayload(status=SessionStatus.READY),
+        )
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(_perform_blocking_update)
+        await start_event.wait()
+        assert "first" not in results
+
+        with anyio.fail_after(0.5):
+            updated_second = await manager.update_session(
+                second_session.id,
+                SessionUpdatePayload(metadata={"actor": "second"}),
+            )
+
+        assert updated_second.metadata["actor"] == "second"
+        assert len(publisher.events) == 4
+        assert [event.type for event in publisher.events][-2:] == [
+            SessionEventType.UPDATED,
+            SessionEventType.UPDATED,
+        ]
+        assert publisher.events[-1].type is SessionEventType.UPDATED
+        release_event.set()
+
+    first_result = results["first"]
+    assert isinstance(first_result, Session)
+    assert first_result.status is SessionStatus.READY
 
 @pytest.mark.anyio("asyncio")
 async def test_create_session_strips_user_vnc_token(


### PR DESCRIPTION
## Summary
- release the `SessionManager` mutex before awaiting the event publisher in session creation and updates to avoid head-of-line blocking
- document the concurrency change in `AGENT_NOTES.md`
- add a blocking publisher test that proves updates continue while publishes are delayed

## Testing
- `poetry run pytest tests/test_session_manager.py -q`

## Security
- No security impact

------
https://chatgpt.com/codex/tasks/task_e_68dff81d5ce0832ab86d31cce20cfec8