### PR TITLE
Remove runner session slot limits

### DIFF
--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -18,6 +18,7 @@
   `wsEndpoint` при наличии и прокидывает fallback `publicWsEndpoint` для случаев,
   когда до runner'а нет прямого доступа.
 - `adaptVnc` гарантирует, что подписанный gateway-токен встроен в `httpUrl`/`websocketUrl` как query `token`, а также очищает устаревший `access_token`, чтобы iframe и веб-клиенты могли пользоваться ссылками без ручного вмешательства.
+- `RunnerStatusSchema` допускает `total_slots=null`, отображая «безлимитных» раннеров; адаптер `adaptRunnerStatus` нормализует значения в `totalSlots: null`.
 - Обновление прокси использует `SessionProxyUpdateSchema`, валидирующий наличие хотя бы одного URL
   перед вызовом `updateSessionProxy`.
 - Состояние фильтров в `store/sessionFilters.ts` (Zustand).
@@ -83,3 +84,4 @@
 - 2025-10-24 · gpt-5-codex · Добавлен Nginx-конфиг, проксирующий `/api` на gateway, и обновлена Docker-сборка для совместимости с docker-compose стеком.
 - 2025-10-25 · gpt-5-codex · UI адаптеры теперь дописывают `token` в VNC URL, обновлён `SessionDetailsPanel` тест для верификации iframe.
 - 2025-02-14 · gpt-5-codex · Верифицированы рабочие команды `pnpm install`, `pnpm -C apps/ui lint`, `pnpm -C apps/ui test`, `pnpm -C apps/ui build`.
+- 2025-10-28 · gpt-5-codex · UI принимает `totalSlots=null` от Gateway: обновлены Zod-схемы, адаптеры и тестовые моки.

--- a/apps/ui/src/__tests__/DashboardPage.test.tsx
+++ b/apps/ui/src/__tests__/DashboardPage.test.tsx
@@ -226,7 +226,7 @@ const createRunner = (overrides: Partial<RunnerStatus>): RunnerStatus => ({
   id: 'runner-1',
   baseUrl: 'http://runner-1',
   state: 'idle',
-  totalSlots: 1,
+  totalSlots: null,
   availableSlots: 1,
   healthy: true,
   supportsVnc: true,

--- a/apps/ui/src/pages/DashboardPage.test.tsx
+++ b/apps/ui/src/pages/DashboardPage.test.tsx
@@ -99,7 +99,7 @@ describe('DashboardPage', () => {
       id: 'runner-1',
       baseUrl: 'http://runner',
       state: 'idle',
-      totalSlots: 1,
+      totalSlots: null,
       availableSlots: 1,
       healthy: true,
       supportsVnc: true,

--- a/apps/ui/src/types/runner.ts
+++ b/apps/ui/src/types/runner.ts
@@ -13,7 +13,7 @@ export const RunnerStatusSchema = z
     id: z.string(),
     base_url: z.string().url(),
     state: RunnerStateSchema,
-    total_slots: z.number().int().nonnegative(),
+    total_slots: z.number().int().nonnegative().nullable(),
     available_slots: z.number().int().nonnegative().nullable(),
     healthy: z.boolean(),
     supports_vnc: z.boolean(),
@@ -34,7 +34,7 @@ export interface RunnerStatus {
   readonly id: string;
   readonly baseUrl: string;
   readonly state: RunnerState;
-  readonly totalSlots: number;
+  readonly totalSlots: number | null;
   readonly availableSlots: number | null;
   readonly healthy: boolean;
   readonly supportsVnc: boolean;
@@ -51,7 +51,7 @@ export const adaptRunnerStatus = (runner: RawRunnerStatus): RunnerStatus => ({
   id: runner.id,
   baseUrl: runner.base_url,
   state: runner.state,
-  totalSlots: runner.total_slots,
+  totalSlots: runner.total_slots ?? null,
   availableSlots: runner.available_slots ?? null,
   healthy: runner.healthy,
   supportsVnc: runner.supports_vnc,

--- a/packages/core/AGENT_NOTES.md
+++ b/packages/core/AGENT_NOTES.md
@@ -15,9 +15,10 @@
   получения последнего события при реконнекте клиента.
 
 ## Data & Models
-- `Runner`: идентификатор, `base_url`, состояние, слоты, флаг `healthy`, поддержка
-  VNC (`supports_vnc`), время последнего heartbeat, capability-флаги. Идентификаторы
-  триммируются и не допускают пустых значений.
+- `Runner`: идентификатор, `base_url`, состояние, слоты (включая `total_slots=null`
+  для «безлимитных» раннеров), флаг `healthy`, поддержка VNC (`supports_vnc`), время
+  последнего heartbeat, capability-флаги. Идентификаторы триммируются и не допускают
+  пустых значений.
 - `Session`: UUID, `runner_id`, статус (`INIT→DEAD`), `created_at`, `last_seen_at`
   (alias `updated_at`), опциональный `ended_at`, флаги `headless`, `idle_ttl_seconds`
   (30–3600), `browser`, `labels`, `start_url`, `start_url_wait`, `ws_endpoint`,
@@ -56,7 +57,7 @@
 - Все временные метки должны быть timezone-aware (`tzinfo` не `None`).
 - `Session.last_seen_at ≥ created_at`; если задано, `ended_at ≥ created_at`.
 - `idle_ttl_seconds` в диапазоне 30–3600 секунд.
-- `Runner.available_slots ≤ total_slots`; OFFLINE-раннер не может быть `healthy`.
+- `Runner.available_slots ≤ total_slots` при наличии лимита; OFFLINE-раннер не может быть `healthy`.
 - `SessionProxySettings` требует хотя бы одного URL, предотвращая пустые прокси.
 - `SessionVncDetails` требует хотя бы один из HTTP/WS URL и валидный TTL при наличии токена.
 - `Session.workstation` валидируется на совпадение с `workstation_id` и
@@ -93,4 +94,5 @@
   workstation-полями, обновлены тесты сериализации/валидации.
 - 2025-10-24 · gpt-5-codex — Добавлен стресс-тест моста на 5k событий и задокументированы латентности/пороговые значения.
 - 2025-10-30 · ChatGPT — Проверена установка зависимостей и прохождение линтера/тестов через Poetry (`ruff`, `pytest`).
+- 2025-10-28 · gpt-5-codex — Разрешены раннеры без лимита: `Runner.total_slots` стал optional, валидация `available_slots` учитывает `None`, добавлены покрывающие тесты.
 

--- a/packages/core/core/models.py
+++ b/packages/core/core/models.py
@@ -261,8 +261,10 @@ class Runner(BaseModel):
         id: Stable runner identifier (unique within the cluster).
         base_url: Base HTTP URL for runner control API.
         state: Operational state of the runner.
-        total_slots: Maximum concurrent sessions supported.
-        available_slots: Currently free slots; derived from total minus active sessions.
+        total_slots: Optional hard cap on concurrent sessions. ``None`` indicates
+            that the runner reports unbounded capacity.
+        available_slots: Currently free slots when ``total_slots`` is known.
+            ``None`` is used when the runner does not provide slot telemetry.
         healthy: Whether the runner passes health checks.
         supports_vnc: Whether the runner can expose VNC previews.
         vnc_http_url_template: Optional public HTTP viewer template exposed via
@@ -282,11 +284,14 @@ class Runner(BaseModel):
     id: str = Field(min_length=1, description="Runner identifier")
     base_url: AnyUrl = Field(description="Base URL for runner control plane")
     state: RunnerState = Field(default=RunnerState.STARTING, description="Operational state")
-    total_slots: PositiveInt = Field(description="Total concurrent sessions supported")
+    total_slots: PositiveInt | None = Field(
+        default=None,
+        description="Total concurrent sessions supported when bounded",
+    )
     available_slots: int | None = Field(
         default=None,
         ge=0,
-        description="Number of free session slots (<= total_slots)",
+        description="Number of free session slots when capacity is reported",
     )
     healthy: bool = Field(default=True, description="True if health checks pass")
     supports_vnc: bool = Field(default=False, description="Runner can allocate VNC sessions")
@@ -351,14 +356,19 @@ class Runner(BaseModel):
             Runner(id='runner-1', base_url=AnyUrl('http://runner:8080', ...), ...)
         """
 
-        object.__setattr__(
-            self,
-            "available_slots",
-            self.total_slots if self.available_slots is None else self.available_slots,
-        )
-        if self.available_slots < 0:
+        if self.available_slots is None:
+            object.__setattr__(
+                self,
+                "available_slots",
+                self.total_slots,
+            )
+        if self.available_slots is not None and self.available_slots < 0:
             raise ValueError("available_slots must be >= 0")
-        if self.available_slots > self.total_slots:
+        if (
+            self.available_slots is not None
+            and self.total_slots is not None
+            and self.available_slots > self.total_slots
+        ):
             raise ValueError("available_slots cannot exceed total_slots")
         if self.state == RunnerState.OFFLINE and self.healthy:
             raise ValueError("offline runners cannot be marked healthy")

--- a/packages/core/tests/test_models.py
+++ b/packages/core/tests/test_models.py
@@ -66,6 +66,13 @@ def test_runner_defaults_available_slots_to_total() -> None:
     assert runner.state == RunnerState.STARTING
 
 
+def test_runner_with_unbounded_capacity_preserves_null_slots() -> None:
+    """Runner reports ``None`` slots when capacity is intentionally unbounded."""
+
+    runner = Runner(id="runner-1", base_url="http://runner:8080", total_slots=None)
+    assert runner.available_slots is None
+
+
 def test_runner_id_rejects_whitespace_only_identifiers() -> None:
     """Runner identifiers consisting of whitespace should be rejected."""
 

--- a/packages/core/tests/test_models_validation.py
+++ b/packages/core/tests/test_models_validation.py
@@ -82,6 +82,9 @@ def test_runner_derives_available_slots_and_validates_constraints() -> None:
     assert runner.available_slots == 4
     assert runner.id == "runner-42"
 
+    unbounded = Runner(id="runner-unbounded", base_url="http://runner", total_slots=None)
+    assert unbounded.available_slots is None
+
     with pytest.raises(ValidationError):
         Runner(id="runner-1", base_url="http://runner", total_slots=1, available_slots=2)
 

--- a/services/gateway/AGENT_NOTES.md
+++ b/services/gateway/AGENT_NOTES.md
@@ -43,6 +43,8 @@
 - `Session` теперь хранит прямой `ws_endpoint` от runner'а и проксируемый `ws_public_endpoint`; Gateway больше не перезаписывает
   прямой URL в REST-ответах, чтобы внутренние клиенты могли подключаться без прокси.
 - `SessionRegistry`/`RunnerRegistry` — простые in-memory контейнеры с `asyncio.Lock` для потокобезопасности.
+- `Runner` допускает `total_slots = null`, что сигнализирует об отсутствии жёсткого лимита; `RunnerRegistry.record_health`
+  принимает `total_slots=None`, чтобы очистить сохранённую ёмкость и отражать «неограниченные» раннеры.
 - `WorkstationRegistry` — in-memory карта рабочих станций, сохраняет `WorkstationRecord` с последним событием.
 - `InMemorySessionEventBridge` (из core) хранит последнее событие и раздаёт подписчикам.
 - `WorkstationRecord`/`WorkstationUpsertPayload` — gateway-модели для REST, совместимы с `core.WorkstationMeta`/`WorkstationEvent` и сохраняют идентификаторы/состояние.
@@ -167,3 +169,4 @@
 - 2025-10-30 · gpt-5-codex · Ужесточена валидация TTL VNC-токенов (диапазон 1–300 сек) и добавлены unit-тесты на ошибочные значения.
 - 2025-10-30 · gpt-5-codex · Очистка сессий при пропаже раннера стала устойчивой к `KeyError` в реестре сессий; добавлен тест на конкурентное удаление.
 - 2025-10-31 · gpt-5-codex · Реестр сессий очищает VNC токены перед сохранением и добавлен тест, подтверждающий выдачу нового токена после TTL при `GET /sessions`.
+- 2025-10-28 · gpt-5-codex · Добавлена поддержка «безлимитных» раннеров: `RunnerRegistry` принимает `total_slots=None`, health-профайлер сохраняет `null` в `slots.total/available`, UI/REST схемы обновлены.

--- a/services/gateway/app/routers/runners.py
+++ b/services/gateway/app/routers/runners.py
@@ -25,8 +25,14 @@ class RunnerStatus(BaseModel):
     id: str = Field(description="Runner identifier")
     base_url: AnyUrl = Field(description="Runner control-plane base URL")
     state: RunnerState = Field(description="Operational state reported by discovery")
-    total_slots: int = Field(description="Maximum concurrent sessions")
-    available_slots: int = Field(description="Currently free slots")
+    total_slots: int | None = Field(
+        default=None,
+        description="Maximum concurrent sessions when bounded",
+    )
+    available_slots: int | None = Field(
+        default=None,
+        description="Currently free slots when the runner reports capacity",
+    )
     healthy: bool = Field(description="Latest health probe outcome")
     supports_vnc: bool = Field(description="Runner can serve VNC sessions")
     last_heartbeat_at: datetime | None = Field(

--- a/services/gateway/app/services/runner_registry.py
+++ b/services/gateway/app/services/runner_registry.py
@@ -11,6 +11,13 @@ from uuid import UUID
 from core import Runner, RunnerState
 
 
+class _Missing:
+    """Sentinel used to differentiate between absent and explicit ``None`` values."""
+
+
+_MISSING = _Missing()
+
+
 class RunnerRegistry:
     """Track runner information reported by the discovery layer.
 
@@ -325,7 +332,7 @@ class RunnerRegistry:
         *,
         healthy: bool,
         heartbeat_at: datetime | None,
-        total_slots: int | None = None,
+        total_slots: int | None | _Missing = _MISSING,
         available_slots: int | None = None,
         supports_vnc: bool | None = None,
     ) -> Runner | None:
@@ -336,7 +343,7 @@ class RunnerRegistry:
             healthy: Outcome of the health probe.
             heartbeat_at: Timestamp when the health response was observed.
             total_slots: Optional override for the slot capacity reported by
-                the runner.
+                the runner. Pass ``None`` to clear previously stored limits.
             available_slots: Optional override for the currently available
                 slots derived from the health payload.
             supports_vnc: Optional capability flag indicating whether the
@@ -352,20 +359,21 @@ class RunnerRegistry:
             if current is None:
                 return None
 
-            updates: dict[str, object] = {"healthy": healthy}
-            if heartbeat_at is not None:
-                updates["last_heartbeat_at"] = heartbeat_at
-            if total_slots is not None:
-                updates["total_slots"] = total_slots
-
-            if available_slots is not None:
-                capacity = (
-                    total_slots
-                    if total_slots is not None
-                    else current.total_slots
-                )
+        updates: dict[str, object] = {"healthy": healthy}
+        if heartbeat_at is not None:
+            updates["last_heartbeat_at"] = heartbeat_at
+        capacity: int | None
+        if total_slots is not _MISSING:
+            updates["total_slots"] = total_slots
+            capacity = total_slots
+        else:
+            capacity = current.total_slots
+        if available_slots is not None:
+            if capacity is None:
+                constrained = max(available_slots, 0)
+            else:
                 constrained = max(min(available_slots, capacity), 0)
-                updates["available_slots"] = constrained
+            updates["available_slots"] = constrained
 
             if supports_vnc is not None:
                 updates["supports_vnc"] = supports_vnc

--- a/services/gateway/tests/test_gateway.py
+++ b/services/gateway/tests/test_gateway.py
@@ -69,7 +69,7 @@ def gateway_app() -> FastAPI:
             Runner(
                 id="runner-1",
                 base_url="http://runner-1",
-                total_slots=1,
+                total_slots=None,
                 supports_vnc=True,
                 vnc_http_url_template="https://vnc.example/view/{id}",
                 vnc_ws_url_template="wss://vnc.example/ws/{id}",
@@ -314,7 +314,7 @@ async def test_lifespan_restores_sessions_from_healthy_runners() -> None:
             json={
                 "status": "ok",
                 "runner_id": "runner-1",
-                "slots": {"total": 1, "available": 0},
+                "slots": {"total": None, "available": None},
                 "vnc": {"enabled": True},
             },
         )
@@ -325,7 +325,7 @@ async def test_lifespan_restores_sessions_from_healthy_runners() -> None:
             Runner(
                 id="runner-1",
                 base_url="http://runner-1",
-                total_slots=1,
+                total_slots=None,
                 supports_vnc=True,
             )
         ],
@@ -512,7 +512,7 @@ def test_create_command_returns_503_when_no_vnc_runner_available(
             Runner(
                 id="runner-2",
                 base_url="http://runner-2",
-                total_slots=1,
+                total_slots=None,
                 supports_vnc=False,
             )
         )

--- a/services/gateway/tests/test_runner_client.py
+++ b/services/gateway/tests/test_runner_client.py
@@ -27,7 +27,7 @@ def sample_runner() -> Runner:
     return Runner(
         id="runner-1",
         base_url="http://runner.example",
-        total_slots=1,
+        total_slots=None,
         supports_vnc=True,
     )
 

--- a/services/gateway/tests/test_runner_health.py
+++ b/services/gateway/tests/test_runner_health.py
@@ -22,7 +22,7 @@ def anyio_backend() -> str:
 async def test_probe_updates_registry_on_success() -> None:
     """Successful probes should update health and slot information."""
 
-    runner = Runner(id="runner-1", base_url="http://runner-1", total_slots=1)
+    runner = Runner(id="runner-1", base_url="http://runner-1", total_slots=None)
     registry = RunnerRegistry([runner])
 
     def _handler(request: httpx.Request) -> httpx.Response:
@@ -32,7 +32,7 @@ async def test_probe_updates_registry_on_success() -> None:
             json={
                 "status": "ok",
                 "runner_id": "runner-1",
-                "slots": {"total": 4, "available": 2},
+                "slots": {"total": None, "available": None},
                 "vnc": {"enabled": True},
             },
         )
@@ -42,8 +42,8 @@ async def test_probe_updates_registry_on_success() -> None:
     updated = await client.probe(runner, registry)
     assert updated is not None
     assert updated.healthy is True
-    assert updated.available_slots == 2
-    assert updated.total_slots == 4
+    assert updated.available_slots is None
+    assert updated.total_slots is None
     assert updated.supports_vnc is True
     assert updated.last_heartbeat_at is not None
     assert updated.last_heartbeat_at.tzinfo is UTC

--- a/services/gateway/tests/test_runner_registry.py
+++ b/services/gateway/tests/test_runner_registry.py
@@ -147,6 +147,33 @@ async def test_record_health_updates_snapshot() -> None:
 
 
 @pytest.mark.anyio("asyncio")
+async def test_record_health_allows_clearing_capacity() -> None:
+    """Explicit ``None`` total slots should clear stored runner capacity."""
+
+    registry = RunnerRegistry(
+        [
+            Runner(
+                id="runner-flex",
+                base_url="http://runner-flex",
+                total_slots=2,
+            )
+        ]
+    )
+
+    updated = await registry.record_health(
+        "runner-flex",
+        healthy=True,
+        heartbeat_at=datetime.now(tz=UTC),
+        total_slots=None,
+        available_slots=None,
+    )
+
+    assert updated is not None
+    assert updated.total_slots is None
+    assert updated.available_slots is None
+
+
+@pytest.mark.anyio("asyncio")
 async def test_session_ws_binding_registration() -> None:
     """RunnerRegistry stores runner and public endpoints for sessions."""
 

--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -8,7 +8,8 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 ## Interfaces
 - **HTTP**
   - `GET /health` — возвращает `{status, runner_id, camoufox_path, slots, vnc, proxy, prewarm, ttl}`;
-    `slots.total` считывается из `RunnerSettings.slot_limit`, `slots.active` — количество
+    `slots.total` и `slots.available` равны `null`, сигнализируя об отсутствии
+    жёсткого ограничения на параллельные сессии; `slots.active` — количество
     не-`DEAD` сессий; `prewarm` включает счётчик и последнюю ошибку прогрева;
     `ttl` содержит ближайшее истечение (`next_expiry_at`) и счетчики работы
     фонового reaper-а (`total_runs`, `expired_sessions`, `last_run_at`).
@@ -71,7 +72,8 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - **Camoufox SDK dependency**: Runner зависит от официального `camoufox==0.4.11[geoip]`, а локальный shim (`packages/camoufox`) лишь делегирует вызовы к нему. Тесты используют автofixture, которая подсовывает изолированный каталог установки и подменяет сетевые вызовы.
 - **Process-backed VNC controller**: Non-headless sessions allocate Xvfb/x11vnc/websockify helpers via `ProcessVncController`. The controller maintains a bounded pool of displays and ports, composes public HTTP/WS URLs from `RunnerSettings`, and tears down helpers whenever sessions terminate or switch to headless mode.
 - **Gateway-signed VNC tokens**: Runner never persists VNC `token` or `token_ttl_seconds`; any user-supplied values are stripped and synthetic descriptors leave them `None` so that the gateway can issue signed credentials.
-- **Environment-driven settings**: `RunnerSettings.from_env` centralises configuration parsing without extra dependencies, easing future extension. Дополнительные параметры: `slot_limit`, базовые VNC URL, глобальный флаг прокси и ёмкость истории ошибок прогрева.
+- **Environment-driven settings**: `RunnerSettings.from_env` centralises configuration parsing without extra dependencies, easing future extension. Дополнительные параметры включают базовые VNC URL, глобальный флаг прокси и ёмкость истории ошибок прогрева.
+- **Unlimited runner capacity**: Конфигурация больше не ограничивает количество параллельных сессий; `/health` возвращает `slots.total = null` и `slots.available = null`, чтобы сигнализировать об отсутствии лимита, сохраняя обратную совместимость структуры ответа.
 - **Local compose warm pool park**: docker-compose mounts `services/runner/config/warm-pool.local.json` и `browser-prefs.local.json`, обеспечивая демонстрационный парк рабочих станций с фиксированными `fingerprint_id` и набором тумблеров, который разделяют прогретые и холодные сессии; режим по умолчанию `WARM_POOL_MODE=hybrid` даёт возможность создавать холодные браузеры, когда парк занят.
 - **Playwright CLI compatibility**: начиная с Playwright 1.55 runner вызывает `playwright launch-server --browser <name>` и транслирует публичное имя `camoufox` в `firefox`, параллельно прокидывая `CAMOUFOX_BINARY`, чтобы использовать Camoufox runtime вместо стандартного Firefox. Лаунчер понимает как JSON-ответы (`{"wsEndpoint": ...}`), так и текстовый вывод (`ws://...` / ANSI-раскрашенный), что устраняет возврат 429 при создании cold-сессий.
 - **Bounded prewarm history**: менеджер хранит ошибки прогрева в `deque` с ограничением размера, что позволяет health-эндпоинту
@@ -158,6 +160,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-12 · gpt-5-codex · Интегрирован процессный noVNC-контроллер, расширены настройки VNC и обновлены unit-тесты с заглушками.
 - 2025-10-13 · gpt-5-codex · Добавлены Prometheus-метрики, эндпоинт `/metrics` и тестовое покрытие на экспорт/счётчики.
 - 2025-10-14 · gpt-5-codex · Привели код и тесты к требованиям Ruff (импорт, длины строк, ошибки) и актуализировали конфигурацию линтера.
+- 2025-10-28 · gpt-5-codex · Убрали лимит сессий: `RunnerSettings` больше не содержит `slot_limit`, `/health` возвращает `null` в `slots.total/available`, обновлены core/gateway/UI модели и тесты.
 - 2025-10-15 · gpt-5-codex · Добавлены warm pool-конфиги (JSON), загрузка при старте, новые настройки и модульные тесты на валидацию/парсинг.
 - 2025-10-16 · gpt-5-codex · Реализован ``WarmPoolManager`` с управлением состояниями, recycle, преднавигацией и юнит-тестами на ключевые сценарии.
 - 2025-10-17 · gpt-5-codex · Интегрирован warm pool в `SessionManager`/API, добавлен отклик 429 при нехватке слотов и покрытие тестами.

--- a/services/runner/README-TASK.md
+++ b/services/runner/README-TASK.md
@@ -50,7 +50,7 @@
   "status": "ok",
   "runner_id": "runner-name",
   "camoufox_path": "/usr/bin/camoufox",
-  "slots": {"total": 3, "active": 1, "available": 2},
+  "slots": {"total": null, "active": 1, "available": null},
   "vnc": {
     "http_base_url": "http://localhost:9000/vnc",
     "ws_base_url": "ws://localhost:9000/vnc",

--- a/services/runner/app/config/settings.py
+++ b/services/runner/app/config/settings.py
@@ -40,7 +40,6 @@ class RunnerSettings(BaseModel):
         camoufox_path: Absolute path to the Camoufox binary.
         event_endpoint: Optional HTTP(S) endpoint used by the event publisher
             stub. When absent, events are kept in-memory.
-        slot_limit: Maximum number of concurrently active sessions.
         warm_pool_config_path: Optional path to a JSON file describing the warm
             workstation pool.
         warm_pool_mode: Strategy for sourcing browsers — exclusively warm pool,
@@ -82,7 +81,6 @@ class RunnerSettings(BaseModel):
     runner_id: str = Field(default="runner-local", min_length=1)
     camoufox_path: Path = Field(default=Path("/usr/bin/camoufox"))
     event_endpoint: AnyUrl | None = Field(default=None)
-    slot_limit: PositiveInt = Field(default=4, ge=1)
     warm_pool_config_path: Path | None = Field(
         default=None,
         description="Path to the warm pool configuration JSON file",
@@ -167,8 +165,6 @@ class RunnerSettings(BaseModel):
             source["camoufox_path"] = Path(env["CAMOUFOX_PATH"])
         if "EVENT_ENDPOINT" in env:
             source["event_endpoint"] = env["EVENT_ENDPOINT"]
-        if "SLOT_LIMIT" in env:
-            source["slot_limit"] = int(env["SLOT_LIMIT"])
         if "WARM_POOL_CONFIG_PATH" in env:
             raw = env["WARM_POOL_CONFIG_PATH"].strip()
             source["warm_pool_config_path"] = Path(raw) if raw else None

--- a/services/runner/app/main.py
+++ b/services/runner/app/main.py
@@ -92,8 +92,11 @@ async def health(
 
     metrics = await manager.get_metrics()
     active_slots = metrics.active_sessions
-    total_slots = settings.slot_limit
-    available_slots = max(total_slots - active_slots, 0)
+    slots_payload = {
+        "total": None,
+        "active": active_slots,
+        "available": None,
+    }
     warm_pool_stats = manager.get_warm_pool_statistics()
     warm_pool_payload = {
         "enabled": warm_pool_stats is not None and warm_pool_stats.total > 0,
@@ -107,11 +110,9 @@ async def health(
         "status": "ok",
         "runner_id": settings.runner_id,
         "camoufox_path": str(settings.camoufox_path),
-        "slots": {
-            "total": total_slots,
-            "active": active_slots,
-            "available": available_slots,
-        },
+        # ``None`` values communicate that the runner does not enforce a hard
+        # cap on concurrent sessions while preserving schema compatibility.
+        "slots": slots_payload,
         "warm_pool": warm_pool_payload,
         "vnc": {
             "http_base_url": str(settings.vnc_http_base_url),

--- a/services/runner/tests/test_main.py
+++ b/services/runner/tests/test_main.py
@@ -292,7 +292,6 @@ async def test_health_endpoint_reports_extended_metrics() -> None:
     settings = RunnerSettings(
         runner_id="runner-health",
         camoufox_path="/usr/bin/camoufox",
-        slot_limit=3,
         vnc_enabled=True,
         vnc_http_base_url="http://localhost:9000/vnc",
         vnc_ws_base_url="ws://localhost:9000/vnc",
@@ -332,7 +331,7 @@ async def test_health_endpoint_reports_extended_metrics() -> None:
     assert payload["status"] == "ok"
     assert payload["runner_id"] == "runner-health"
     assert payload["camoufox_path"].endswith("camoufox")
-    assert payload["slots"] == {"total": 3, "active": 2, "available": 1}
+    assert payload["slots"] == {"total": None, "active": 2, "available": None}
     assert payload["warm_pool"] == {
         "enabled": True,
         "total": 3,

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -806,7 +806,6 @@ async def test_metrics_track_active_sessions_and_prewarm_failures(
         RunnerSettings(
             runner_id="runner-metrics",
             camoufox_path="/usr/bin/camoufox",
-            slot_limit=3,
             prewarm_failure_history_size=2,
         ),
         publisher,


### PR DESCRIPTION
## Summary
- drop the `slot_limit` setting from the runner and return `null` slot totals/availability from the `/health` endpoint
- relax the shared `core.Runner` model and gateway registry logic to accept unlimited-capacity runners and propagate clears
- update UI runner schemas/tests plus project agent notes and docs to document the unbounded slot behaviour

## Testing
- ⚠️ `PYTHONPATH=../.. poetry run pytest -q tests/test_main.py tests/test_session_manager.py` *(fails: missing optional camoufox_sdk module in test fixture)*
- ⚠️ `pnpm -C apps/ui test -- --runTestsByPath src/__tests__/DashboardPage.test.tsx src/pages/DashboardPage.test.tsx` *(fails: workspace lacks installed Vite dependencies)*

## Security
- None


------
https://chatgpt.com/codex/tasks/task_e_68dff88ed894832a9c869af403622184