### PR TITLE
Handle dashboard session query errors

### DIFF
--- a/apps/ui/AGENT_NOTES.md
+++ b/apps/ui/AGENT_NOTES.md
@@ -83,3 +83,4 @@
 - 2025-10-24 · gpt-5-codex · Добавлен Nginx-конфиг, проксирующий `/api` на gateway, и обновлена Docker-сборка для совместимости с docker-compose стеком.
 - 2025-10-25 · gpt-5-codex · UI адаптеры теперь дописывают `token` в VNC URL, обновлён `SessionDetailsPanel` тест для верификации iframe.
 - 2025-02-14 · gpt-5-codex · Верифицированы рабочие команды `pnpm install`, `pnpm -C apps/ui lint`, `pnpm -C apps/ui test`, `pnpm -C apps/ui build`.
+- 2025-10-26 · gpt-5-codex · Добавлена обработка ошибки загрузки сессий в DashboardPage с баннером повторной попытки и покрывающим витестом.

--- a/apps/ui/src/__tests__/DashboardPage.test.tsx
+++ b/apps/ui/src/__tests__/DashboardPage.test.tsx
@@ -308,6 +308,32 @@ describe('DashboardPage', () => {
     expect(screen.getByText('Загружаем раннеров…')).toBeTruthy();
   });
 
+  it('shows an error banner when the sessions query fails', () => {
+    useQueryMock.mockImplementation(({ queryKey }: { queryKey: QueryKey }) => {
+      if (queryKey === queryKeys.sessions) {
+        return {
+          data: undefined,
+          isLoading: false,
+          isFetching: false,
+          error: new Error('Network down'),
+        };
+      }
+      if (queryKey === queryKeys.runners) {
+        return { data: [], isLoading: false, isFetching: false, error: null };
+      }
+      throw new Error('Unexpected query key');
+    });
+
+    render(<DashboardPage />);
+
+    const banner = screen.getByRole('alert');
+    expect(banner.textContent ?? '').toContain('Network down');
+
+    fireEvent.click(within(banner).getByRole('button', { name: 'Повторить' }));
+
+    expect(invalidateQueriesMock).toHaveBeenCalledWith({ queryKey: queryKeys.sessions });
+  });
+
   it('filters sessions based on active store filters', () => {
     const sessions = [
       createSession({ id: 'session-alpha', runnerId: 'runner-alpha', browser: 'Chrome', region: 'eu' }),

--- a/apps/ui/src/pages/DashboardPage.tsx
+++ b/apps/ui/src/pages/DashboardPage.tsx
@@ -63,13 +63,18 @@ export function DashboardPage(): JSX.Element {
   const connectionError = useSessionEventConnection((state) => state.error);
   const requestConnectionRetry = useSessionEventConnection((state) => state.requestRetry);
 
-  const { data, isLoading, isFetching } = useQuery({
+  const { data, isLoading, isFetching, error } = useQuery({
     queryKey: queryKeys.sessions,
     queryFn: () => fetchSessions({ token: token ?? undefined }),
     refetchInterval: 15_000,
   });
 
   const sessions = useMemo(() => data ?? [], [data]);
+  const sessionsErrorMessage = error
+    ? error instanceof Error
+      ? error.message
+      : 'Не удалось загрузить сессии.'
+    : null;
 
   const {
     data: runners,
@@ -134,6 +139,18 @@ export function DashboardPage(): JSX.Element {
           <SessionToolbar sessions={sessions} onCreate={() => setComposerOpen(true)} />
           {isLoading ? (
             <div className="loading">Загружаем сессии…</div>
+          ) : sessionsErrorMessage ? (
+            <div className="dashboard__banner dashboard__banner--error" role="alert">
+              <span>{sessionsErrorMessage}</span>
+              <button
+                type="button"
+                onClick={() => {
+                  void queryClient.invalidateQueries({ queryKey: queryKeys.sessions });
+                }}
+              >
+                Повторить
+              </button>
+            </div>
           ) : (
             <SessionList sessions={filteredSessions} selectedId={selectedId} onSelect={setSelectedId} />
           )}


### PR DESCRIPTION
Summary
- surface a dashboard banner when the sessions query errors and hook the retry button to invalidate the cache
- add a vitest assertion for the error path and document the change in the UI agent notes

Testing
- pnpm test -- DashboardPage.test.tsx

Security
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68dffa000784832aa46623c517fdcff1