### PR TITLE
Fix runner stop teardown and offline camoufox stubs

### DIFF
--- a/services/runner/AGENT_NOTES.md
+++ b/services/runner/AGENT_NOTES.md
@@ -68,7 +68,7 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - **HTTP publisher toggle**: `get_event_publisher` читает `RunnerSettings.event_endpoint` и, если URL задан, использует `HttpSessionEventPublisher`, публикующий события в Gateway через `POST /events`.
 - **Workstation events**: `WarmPoolManager` публикует `workstation.state_changed|recycled|error` при любых переходах слота; маршруты `/workstations` только вызывают методы менеджера.
 - **SSE/WS обёртки**: `SseWorkstationEventPublisher` и `WebSocketWorkstationEventPublisher` форматируют события для стриминга в Gateway/UI.
-- **Camoufox SDK dependency**: Runner зависит от официального `camoufox==0.4.11[geoip]`, а локальный shim (`packages/camoufox`) лишь делегирует вызовы к нему. Тесты используют автofixture, которая подсовывает изолированный каталог установки и подменяет сетевые вызовы.
+- **Camoufox SDK dependency**: Runner зависит от официального `camoufox==0.4.11[geoip]`, а локальный shim (`packages/camoufox`) лишь делегирует вызовы к нему. Тесты используют автofixture, которая подсовывает изолированный каталог установки, подменяет сетевые вызовы и при отсутствии `camoufox_sdk` регистрирует заглушку `camoufox.pkgman`, чтобы сьют запускался офлайн.
 - **Process-backed VNC controller**: Non-headless sessions allocate Xvfb/x11vnc/websockify helpers via `ProcessVncController`. The controller maintains a bounded pool of displays and ports, composes public HTTP/WS URLs from `RunnerSettings`, and tears down helpers whenever sessions terminate or switch to headless mode.
 - **Gateway-signed VNC tokens**: Runner never persists VNC `token` or `token_ttl_seconds`; any user-supplied values are stripped and synthetic descriptors leave them `None` so that the gateway can issue signed credentials.
 - **Environment-driven settings**: `RunnerSettings.from_env` centralises configuration parsing without extra dependencies, easing future extension. Дополнительные параметры: `slot_limit`, базовые VNC URL, глобальный флаг прокси и ёмкость истории ошибок прогрева.
@@ -96,6 +96,9 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
   `reap_expired_sessions`, завершает истёкшие по `idle_ttl_seconds` сессии и публикует события
   `session.ended` с reason=`idle-timeout`. Запускается/останавливается через `start()`/`stop()` и
   lifecycle-хуки FastAPI.
+- **Graceful shutdown**: `SessionManager.stop` освобождает reaper task group, завершает холодные
+  браузеры, дожидается `WarmPoolManager.drain()` и закрывает VNC-пайплайны, чтобы повторный
+  `start()` перезапустил warm pool с нуля.
 - **Prometheus registry**: Runner экспортирует `/metrics`, используя
   `prometheus_client.CollectorRegistry`; значения обновляются в момент изменения состояния
   (`active_sessions`, VNC аллокации, пробеги reaper-а) вместо ленивой агрегации на запрос.
@@ -178,3 +181,5 @@ Warm workstation preloading is handled by ``app.warm_pool.WarmPoolManager`` whic
 - 2025-10-31 · gpt-5-codex · Сессии, созданные на warm-слотах, теперь запоминают workstation-метаданные и очищают их при релизе; добавлены проверки в unit-тестах.
 - 2025-10-31 · gpt-5-codex · Синхронизирован флаг `vnc_enabled` с реальными VNC-деталями и добавлены регрессионные тесты на headless и сбойную аллокацию.
 - 2025-10-31 · gpt-5-codex · Защищено `SessionManager.create_session` от сбоев публикации: откат аллокаций warm/VNC, обновлены метрики и добавлен регрессионный тест.
+- 2025-11-01 · gpt-5-codex · Переписан `SessionManager.stop`: холодные браузеры закрываются с `force=True`, warm pool drain вызывается на остановке, тесты покрывают рестарт.
+- 2025-11-02 · gpt-5-codex · Добавлено принудительное `cancel_scope.cancel()` перед остановкой reaper TaskGroup, обновлена авт.fixture для Camoufox (офлайн-заглушка `camoufox.pkgman`).

--- a/services/runner/app/session_manager.py
+++ b/services/runner/app/session_manager.py
@@ -585,8 +585,27 @@ class SessionManager:
         async with self._lock:
             task_group = self._reaper_task_group
             self._reaper_task_group = None
+            cold_session_ids = [
+                session_id
+                for session_id in self._browser_handles
+                if session_id not in self._warm_sessions
+            ]
+            warm_pool = self._warm_pool
+            self._warm_pool_started = False
         if task_group is not None:
+            # Cancel the reaper loop before exiting the task group context;
+            # otherwise the infinite sleep cycle would keep the awaitable
+            # pending indefinitely.
+            task_group.cancel_scope.cancel()
             await task_group.__aexit__(None, None, None)
+        for session_id in cold_session_ids:
+            await self._shutdown_browser(session_id, force=True)
+        async with self._lock:
+            self._browser_handles.clear()
+        if warm_pool is not None:
+            await warm_pool.drain()
+            async with self._lock:
+                self._warm_sessions.clear()
         await self._shutdown_all_vnc()
 
     async def _resolve_vnc(

--- a/services/runner/tests/conftest.py
+++ b/services/runner/tests/conftest.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import sys
 from importlib import import_module
 from pathlib import Path
+from types import ModuleType
 from typing import Iterator
 
 import pytest
@@ -43,32 +44,77 @@ def camoufox_installation(
         Path: The fake installation directory used during the test.
     """
 
-    pkgman = import_module("camoufox.pkgman")
-
     install_dir = tmp_path_factory.mktemp("camoufox-install")
-    binary_path = install_dir / pkgman.LAUNCH_FILE[pkgman.OS_NAME]
+    binary_name = "camoufox"
+
+    try:
+        pkgman = import_module("camoufox.pkgman")
+    except ModuleNotFoundError as exc:
+        if exc.name != "camoufox_sdk":  # pragma: no cover - unexpected SDK failure
+            raise
+        pkgman = ModuleType("camoufox.pkgman")
+        os_name = "linux"
+        pkgman.OS_NAME = os_name
+        pkgman.LAUNCH_FILE = {os_name: binary_name}
+
+        class _StubFetcher:
+            """Lightweight stand-in that avoids network-bound installation paths."""
+
+            def __init__(self, *_: object, **__: object) -> None:
+                """Accept arbitrary arguments mirroring the real constructor."""
+
+            def install(self) -> Path:
+                """Return the synthetic installation directory created for tests."""
+
+                return install_dir
+
+            def cleanup(self) -> bool:
+                """Signal that no teardown work is required for the stub."""
+
+                return True
+
+        pkgman.CamoufoxFetcher = _StubFetcher
+        pkgman.camoufox_path = lambda download_if_missing=True: install_dir
+        pkgman.launch_path = lambda: str(install_dir / binary_name)
+        pkgman.installed_verstr = lambda: "test-0.0.0"
+
+        # Ensure ``import camoufox.pkgman`` resolves to the stub module even when the
+        # parent package is absent.  Tests interact only with ``pkgman`` so the
+        # minimal namespace keeps dependencies hermetic offline.
+        parent = sys.modules.setdefault("camoufox", ModuleType("camoufox"))
+        parent.__path__ = []  # type: ignore[attr-defined]
+        parent.pkgman = pkgman
+        sys.modules["camoufox.pkgman"] = pkgman
+    else:
+        binary_name = pkgman.LAUNCH_FILE[pkgman.OS_NAME]
+        binary_path = install_dir / binary_name
+        monkeypatch.setattr(
+            pkgman,
+            "camoufox_path",
+            lambda download_if_missing=True: install_dir,
+            raising=False,
+        )
+        monkeypatch.setattr(
+            pkgman, "launch_path", lambda: str(binary_path), raising=False
+        )
+        monkeypatch.setattr(
+            pkgman, "installed_verstr", lambda: "test-0.0.0", raising=False
+        )
+
+        fetcher_cls = pkgman.CamoufoxFetcher
+
+        def _noop_install(self) -> Path:  # type: ignore[override]
+            return install_dir
+
+        monkeypatch.setattr(fetcher_cls, "install", _noop_install, raising=False)
+        monkeypatch.setattr(fetcher_cls, "cleanup", lambda self: True, raising=False)
+
+    binary_path = install_dir / binary_name
     binary_path.parent.mkdir(parents=True, exist_ok=True)
     binary_path.write_text("#!/bin/sh\nexit 0\n")
     binary_path.chmod(0o755)
 
     version_file = install_dir / "version.json"
     version_file.write_text("{\"version\": \"test\", \"release\": \"0.0.0\"}")
-
-    monkeypatch.setattr(
-        pkgman,
-        "camoufox_path",
-        lambda download_if_missing=True: install_dir,
-        raising=False,
-    )
-    monkeypatch.setattr(pkgman, "launch_path", lambda: str(binary_path), raising=False)
-    monkeypatch.setattr(pkgman, "installed_verstr", lambda: "test-0.0.0", raising=False)
-
-    fetcher_cls = pkgman.CamoufoxFetcher
-
-    def _noop_install(self) -> Path:  # type: ignore[override]
-        return install_dir
-
-    monkeypatch.setattr(fetcher_cls, "install", _noop_install, raising=False)
-    monkeypatch.setattr(fetcher_cls, "cleanup", lambda self: True, raising=False)
 
     yield install_dir

--- a/services/runner/tests/test_session_manager.py
+++ b/services/runner/tests/test_session_manager.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import types
 from datetime import UTC, datetime, timedelta
 from typing import Callable
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from app.config import RunnerSettings, WarmPoolMode
 from app.events import InMemorySessionEventPublisher
-from app.metrics import METRICS_REGISTRY
+from app.metrics import METRICS_REGISTRY, VNC_ALLOCATIONS_GAUGE
 from app.session_manager import (
     SessionCapacityError,
     SessionCreatePayload,
@@ -58,6 +58,9 @@ class _StubWarmPoolManager:
         self._slots: dict[str, dict[str, object]] = {}
         self._counter = 0
         self.started = False
+        self.start_calls = 0
+        self.drain_calls = 0
+        self.drained = False
         self.reservations: list[str] = []
         self.cancellations: list[str] = []
         self.busy: list[str] = []
@@ -73,6 +76,7 @@ class _StubWarmPoolManager:
     async def start(self) -> None:
         """Mark the stub as initialised."""
 
+        self.start_calls += 1
         self.started = True
 
     async def reserve_slot(self, workstation_id: str | None = None) -> WarmPoolReservation:
@@ -151,6 +155,25 @@ class _StubWarmPoolManager:
             proxy_url=slot["proxy"],
             state=WarmPoolState.IDLE,
         )
+
+    async def drain(self) -> list[WarmPoolSnapshot]:
+        """Record that all warm slots are being torn down."""
+
+        self.drain_calls += 1
+        self.started = False
+        self.drained = True
+        snapshots: list[WarmPoolSnapshot] = []
+        for workstation_id, slot in self._slots.items():
+            slot["state"] = WarmPoolState.DRAINING
+            snapshots.append(
+                WarmPoolSnapshot(
+                    workstation_id=workstation_id,
+                    fingerprint_id=slot["fingerprint"],
+                    proxy_url=slot["proxy"],
+                    state=WarmPoolState.DRAINING,
+                )
+            )
+        return snapshots
 
     def get_statistics(self) -> WarmPoolStatistics:
         """Return utilisation counters for compatibility with the real manager."""
@@ -1217,3 +1240,57 @@ async def test_create_session_rolls_back_on_mark_busy_failure() -> None:
     assert manager._browser_handles == {}
     assert warm_pool.busy == []
     assert await publisher.drain() == []
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stop_shuts_down_cold_handles_and_drains_warm_pool(
+    stub_vnc_controller: _StubVncController,
+) -> None:
+    """``stop`` must tear down cold handles, drain warm slots, and allow restart."""
+
+    publisher = InMemorySessionEventPublisher()
+    warm_pool = _StubWarmPoolManager(workstations=["ws-stop"])
+    manager, warm_pool = _build_manager(
+        RunnerSettings(runner_id="runner-stop", camoufox_path="/usr/bin/camoufox"),
+        publisher,
+        vnc_controller=stub_vnc_controller,
+        warm_pool=warm_pool,
+    )
+    assert warm_pool is not None
+
+    await manager.start()
+    assert warm_pool.start_calls == 1
+    assert manager._reaper_task_group is not None
+
+    cold_session_id = uuid4()
+    warm_session_id = uuid4()
+    cold_handle = _StubBrowserHandle(ws_endpoint="ws://cold/stop", pid=6100)
+    warm_handle = _StubBrowserHandle(ws_endpoint="ws://warm/stop", pid=6200)
+    vnc_handle = await stub_vnc_controller.allocate(str(cold_session_id))
+
+    async with manager._lock:
+        manager._browser_handles[cold_session_id] = cold_handle
+        manager._browser_handles[warm_session_id] = warm_handle
+        manager._warm_sessions[warm_session_id] = "ws-stop"
+        manager._vnc_handles[cold_session_id] = vnc_handle
+    VNC_ALLOCATIONS_GAUGE.set(len(manager._vnc_handles))
+
+    drain_calls_before = warm_pool.drain_calls
+    await manager.stop()
+
+    assert manager._reaper_task_group is None
+    assert cold_handle.shutdown_calls == [{"force": True, "timeout": 5.0}]
+    assert warm_handle.shutdown_calls == []
+    assert warm_pool.drain_calls == drain_calls_before + 1
+    assert manager._browser_handles == {}
+    assert manager._warm_sessions == {}
+    assert manager._warm_pool_started is False
+    assert vnc_handle.released is True
+    sample = METRICS_REGISTRY.get_sample_value("runner_vnc_allocations")
+    assert sample is None or sample == pytest.approx(0.0)
+
+    await manager.start()
+    assert warm_pool.start_calls == 2
+    assert manager._reaper_task_group is not None
+
+    await manager.stop()


### PR DESCRIPTION
## Summary
- cancel the reaper task group before awaiting shutdown so SessionManager.stop finishes while draining warm and cold handles
- add an offline camoufox.pkgman stub in the pytest fixture so the test suite passes without the official SDK
- document the offline Camoufox fallback in the runner agent notes

## Testing
- `PYTHONPATH=../..:../../packages/core poetry run pytest -q tests/test_session_manager.py`
- `poetry run ruff check app/session_manager.py tests/test_session_manager.py tests/conftest.py`

## Security
- no security-sensitive changes

------
https://chatgpt.com/codex/tasks/task_e_68dffc1c39a0832a9e0b0d056307ee85